### PR TITLE
chore: workaround eslint bug

### DIFF
--- a/example/test/BUILD.bazel
+++ b/example/test/BUILD.bazel
@@ -1,6 +1,6 @@
 "Demonstrates how to enforce zero-lint-tolerance policy with tests"
 
-load("//tools:lint.bzl", "flake8_test", "pmd_test")
+load("//tools:lint.bzl", "eslint_test", "flake8_test", "pmd_test")
 
 flake8_test(
     name = "flake8",
@@ -13,6 +13,14 @@ flake8_test(
 pmd_test(
     name = "pmd",
     srcs = ["//src:foo"],
+    # Expected to fail based on current content of the file.
+    # Normally you'd fix the file instead of tagging this test.
+    tags = ["manual"],
+)
+
+eslint_test(
+    name = "eslint",
+    srcs = ["//src:ts"],
     # Expected to fail based on current content of the file.
     # Normally you'd fix the file instead of tagging this test.
     tags = ["manual"],

--- a/example/tools/lint.bzl
+++ b/example/tools/lint.bzl
@@ -15,6 +15,8 @@ eslint = eslint_aspect(
     config = "@@//:eslintrc",
 )
 
+eslint_test = make_lint_test(aspect = eslint)
+
 flake8 = flake8_aspect(
     binary = "@@//:flake8",
     config = "@@//:.flake8",

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -56,7 +56,7 @@ def eslint_action(ctx, executable, srcs, report, use_exit_code = False):
     outputs = [report]
 
     if not use_exit_code:
-        exit_code_out = ctx.actions.declare_file("exit_code_out")
+        exit_code_out = ctx.actions.declare_file("_{}.exit_code_out".format(ctx.label.name))
         outputs.append(exit_code_out)
         env["JS_BINARY__EXIT_CODE_OUTPUT_FILE"] = exit_code_out.path
 

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -60,10 +60,15 @@ def eslint_action(ctx, executable, srcs, report, use_exit_code = False):
         outputs.append(exit_code_out)
         env["JS_BINARY__EXIT_CODE_OUTPUT_FILE"] = exit_code_out.path
 
-    ctx.actions.run(
-        inputs = inputs,
+    ctx.actions.run_shell(
+        inputs = inputs + [executable._eslint],
         outputs = outputs,
-        executable = executable._eslint,
+        # Workaround https://github.com/eslint/eslint/issues/17660
+        # If the output wasn't created, then put empty file there.
+        command = "./{eslint} $@; [ -f {output} ] || touch {output}".format(
+            eslint = executable._eslint.path,
+            output = report.path,
+        ),
         arguments = [args],
         env = env,
         mnemonic = "ESLint",
@@ -71,7 +76,7 @@ def eslint_action(ctx, executable, srcs, report, use_exit_code = False):
 
 # buildifier: disable=function-docstring
 def _eslint_aspect_impl(target, ctx):
-    if ctx.rule.kind in ["ts_project_rule"]:
+    if ctx.rule.kind in ["ts_project", "ts_project_rule"]:
         report = ctx.actions.declare_file(target.label.name + ".eslint-report.txt")
         eslint_action(ctx, ctx.executable, ctx.rule.files.srcs, report, ctx.attr.fail_on_violation)
         results = depset([report])


### PR DESCRIPTION
It doesn't create the report when there are no warnings. Also account for the rule kind of ts_project in earlier releases of rules_ts
