### PR TITLE
Better workaround for eslint bug

### DIFF
--- a/example/test/BUILD.bazel
+++ b/example/test/BUILD.bazel
@@ -1,6 +1,18 @@
 "Demonstrates how to enforce zero-lint-tolerance policy with tests"
 
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("//tools:lint.bzl", "eslint_test", "flake8_test", "pmd_test")
+
+ts_project(
+    name = "no_violations",
+    srcs = ["no_violations.ts"],
+    tsconfig = {},
+)
+
+eslint_test(
+    name = "eslint_empty_report",
+    srcs = [":no_violations"],
+)
 
 flake8_test(
     name = "flake8",

--- a/example/test/no_violations.ts
+++ b/example/test/no_violations.ts
@@ -1,0 +1,1 @@
+export const a = "this is fine";

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -1,6 +1,13 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(glob(["*.bzl"]) + ["lint_test.sh"])
+
+js_library(
+    name = "eslint.workaround_17660",
+    srcs = ["eslint.workaround_17660.js"],
+    visibility = ["//visibility:public"],
+)
 
 bzl_library(
     name = "buf",

--- a/lint/eslint.workaround_17660.js
+++ b/lint/eslint.workaround_17660.js
@@ -1,0 +1,9 @@
+// Workaround for https://github.com/eslint/eslint/issues/17660
+// Use as a --require script so that this script is evaluated before the eslint entry point.
+// Creates an empty report file just in case eslint doesn't try to write one.
+const fs = require("fs");
+for (let i = 0; i < process.argv.length; i++) {
+  if (process.argv[i] == "--output-file") {
+    fs.closeSync(fs.openSync(process.argv[i + 1], "w"));
+  }
+}


### PR DESCRIPTION
Changing to ctx.actions.run_shell caused the RUNFILES lookup logic to fail with bzlmod disabled.
(and we're missing test coverage)

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- New test cases added
added a "happy path" eslint_test target.