### PR TITLE
chore: rename our output group to be more unique

### DIFF
--- a/example/lint.sh
+++ b/example/lint.sh
@@ -14,7 +14,7 @@ fi
 
 # Produce report files
 # You can add --aspects_parameters=fail_on_violation=true to make this command fail instead.
-bazel build --aspects //tools:lint.bzl%eslint,//tools:lint.bzl%buf,//tools:lint.bzl%flake8,//tools:lint.bzl%pmd --output_groups=report $@
+bazel build --aspects //tools:lint.bzl%eslint,//tools:lint.bzl%buf,//tools:lint.bzl%flake8,//tools:lint.bzl%pmd --output_groups=rules_lint_report $@
 
 # Show the results.
 # `-mtime -1`: only look at files modified in the last day, to mitigate showing stale results of old bazel runs.

--- a/lint/README.md
+++ b/lint/README.md
@@ -51,8 +51,8 @@ Add these three things:
 2. A `_my_linter_aspect_impl` function, following the https://bazel.build/extending/aspects#aspect_implementation API.
    This is responsible for selecting which rule types in the graph it "knows how to lint".
    It should call the `my_linter_action` function.
-   It must always return a `report` output group.
-   Currently we also rely on the report output file being named following the convention `*-report.txt`, though this is
+   It must always return a `rules_lint_report` output group.
+   The simple lint.sh also relies on the report output file being named following the convention `*-report.txt`, though this is
    a design smell.
 
 3. A `my_linter_aspect` factory function. This is a higher-order function that returns an aspect.

--- a/lint/buf.bzl
+++ b/lint/buf.bzl
@@ -80,7 +80,7 @@ def _buf_lint_aspect_impl(target, ctx):
         results = depset()
 
     return [
-        OutputGroupInfo(report = results),
+        OutputGroupInfo(rules_lint_report = results),
     ]
 
 def buf_lint_aspect(config, toolchain = "@rules_buf//tools/protoc-gen-buf-lint:toolchain_type"):

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -83,7 +83,7 @@ def _eslint_aspect_impl(target, ctx):
         results = depset()
 
     return [
-        OutputGroupInfo(report = results),
+        OutputGroupInfo(rules_lint_report = results),
     ]
 
 def eslint_aspect(binary, config):

--- a/lint/flake8.bzl
+++ b/lint/flake8.bzl
@@ -55,7 +55,7 @@ def _flake8_aspect_impl(target, ctx):
         results = depset()
 
     return [
-        OutputGroupInfo(report = results),
+        OutputGroupInfo(rules_lint_report = results),
     ]
 
 def flake8_aspect(binary, config):

--- a/lint/lint_test.bzl
+++ b/lint/lint_test.bzl
@@ -40,7 +40,7 @@ load("@aspect_bazel_lib//lib:paths.bzl", "to_rlocation_path")
 def _test_impl(ctx):
     reports = []
     for src in ctx.attr.srcs:
-        for report in src[OutputGroupInfo].report.to_list():
+        for report in src[OutputGroupInfo].rules_lint_report.to_list():
             reports.append(report)
 
     bin = ctx.actions.declare_file("lint_test.sh")

--- a/lint/pmd.bzl
+++ b/lint/pmd.bzl
@@ -60,7 +60,7 @@ def _pmd_aspect_impl(target, ctx):
         results = depset()
 
     return [
-        OutputGroupInfo(report = results),
+        OutputGroupInfo(rules_lint_report = results),
     ]
 
 def pmd_aspect(binary, rulesets):


### PR DESCRIPTION
Let's do this before the aspect-cli repo takes a dependency on the exact name.

---

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

**For changes visible to end-users**

- Relevant documentation has been updated

### Test plan

- Covered by existing test cases
