### PR TITLE
refactor: rename our report outputs to be consistent

### DIFF
--- a/example/lint.sh
+++ b/example/lint.sh
@@ -19,7 +19,7 @@ bazel build --aspects //tools:lint.bzl%eslint,//tools:lint.bzl%buf,//tools:lint.
 # Show the results.
 # `-mtime -1`: only look at files modified in the last day, to mitigate showing stale results of old bazel runs.
 # `-size +1c`: don't show files containing zero bytes
-for report in $(find $(bazel info bazel-bin) -mtime -1 -size +1c -type f -name "*-report.txt"); do
+for report in $(find $(bazel info bazel-bin) -mtime -1 -size +1c -type f -name "*.aspect_rules_lint.report"); do
   echo "From ${report}:"
   cat "${report}"
   echo

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -13,7 +13,10 @@ bzl_library(
     name = "buf",
     srcs = ["buf.bzl"],
     visibility = ["//visibility:public"],
-    deps = ["@rules_proto//proto:defs"],
+    deps = [
+        "//lint/private:lint_aspect",
+        "@rules_proto//proto:defs",
+    ],
 )
 
 bzl_library(
@@ -21,6 +24,7 @@ bzl_library(
     srcs = ["eslint.bzl"],
     visibility = ["//visibility:public"],
     deps = [
+        "//lint/private:lint_aspect",
         "@aspect_bazel_lib//lib:copy_to_bin",
         "@aspect_rules_js//js:libs",
     ],
@@ -28,7 +32,6 @@ bzl_library(
 
 bzl_library(
     name = "lint_test",
-    srcs = ["lint_test.bzl"],
     visibility = ["//visibility:public"],
     deps = ["@aspect_bazel_lib//lib:paths"],
 )
@@ -37,10 +40,12 @@ bzl_library(
     name = "flake8",
     srcs = ["flake8.bzl"],
     visibility = ["//visibility:public"],
+    deps = ["//lint/private:lint_aspect"],
 )
 
 bzl_library(
     name = "pmd",
     srcs = ["pmd.bzl"],
     visibility = ["//visibility:public"],
+    deps = ["//lint/private:lint_aspect"],
 )

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -32,6 +32,7 @@ bzl_library(
 
 bzl_library(
     name = "lint_test",
+    srcs = ["lint_test.bzl"],  # keep
     visibility = ["//visibility:public"],
     deps = ["@aspect_bazel_lib//lib:paths"],
 )

--- a/lint/README.md
+++ b/lint/README.md
@@ -51,8 +51,9 @@ Add these three things:
 2. A `_my_linter_aspect_impl` function, following the https://bazel.build/extending/aspects#aspect_implementation API.
    This is responsible for selecting which rule types in the graph it "knows how to lint".
    It should call the `my_linter_action` function.
-   It must always return a `rules_lint_report` output group.
-   The simple lint.sh also relies on the report output file being named following the convention `*-report.txt`, though this is
+   It must always return a `rules_lint_report` output group, which is easiest by using the
+   `report_file` helper in `//lint/private:lint_aspect.bzl`.
+   The simple lint.sh also relies on the report output file being named following the convention `*.aspect_rules_lint.report`, though this is
    a design smell.
 
 3. A `my_linter_aspect` factory function. This is a higher-order function that returns an aspect.

--- a/lint/buf.bzl
+++ b/lint/buf.bzl
@@ -12,6 +12,7 @@ buf = buf_lint_aspect(
 """
 
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
+load("//lint/private:lint_aspect.bzl", "report_file")
 
 def _short_path(file, _):
     return file.path
@@ -72,16 +73,12 @@ def buf_lint_action(ctx, buf_toolchain, target, report, use_exit_code = False):
     )
 
 def _buf_lint_aspect_impl(target, ctx):
-    if ctx.rule.kind in ["proto_library"]:
-        report = ctx.actions.declare_file(target.label.name + ".buf-report.txt")
-        buf_lint_action(ctx, ctx.toolchains[ctx.attr._buf_toolchain], target, report, ctx.attr.fail_on_violation)
-        results = depset([report])
-    else:
-        results = depset()
+    if ctx.rule.kind not in ["proto_library"]:
+        return []
 
-    return [
-        OutputGroupInfo(rules_lint_report = results),
-    ]
+    report, info = report_file(target, ctx)
+    buf_lint_action(ctx, ctx.toolchains[ctx.attr._buf_toolchain], target, report, ctx.attr.fail_on_violation)
+    return [info]
 
 def buf_lint_aspect(config, toolchain = "@rules_buf//tools/protoc-gen-buf-lint:toolchain_type"):
     """A factory function to create a linter aspect.

--- a/lint/flake8.bzl
+++ b/lint/flake8.bzl
@@ -12,6 +12,8 @@ flake8 = flake8_aspect(
 ```
 """
 
+load("//lint/private:lint_aspect.bzl", "report_file")
+
 def flake8_action(ctx, executable, srcs, config, report, use_exit_code = False):
     """Run flake8 as an action under Bazel.
 
@@ -47,16 +49,12 @@ def flake8_action(ctx, executable, srcs, config, report, use_exit_code = False):
 
 # buildifier: disable=function-docstring
 def _flake8_aspect_impl(target, ctx):
-    if ctx.rule.kind in ["py_library"]:
-        report = ctx.actions.declare_file(target.label.name + ".flake8-report.txt")
-        flake8_action(ctx, ctx.executable._flake8, ctx.rule.files.srcs, ctx.file._config_file, report, ctx.attr.fail_on_violation)
-        results = depset([report])
-    else:
-        results = depset()
+    if ctx.rule.kind not in ["py_library"]:
+        return []
 
-    return [
-        OutputGroupInfo(rules_lint_report = results),
-    ]
+    report, info = report_file(target, ctx)
+    flake8_action(ctx, ctx.executable._flake8, ctx.rule.files.srcs, ctx.file._config_file, report, ctx.attr.fail_on_violation)
+    return [info]
 
 def flake8_aspect(binary, config):
     """A factory function to create a linter aspect.

--- a/lint/pmd.bzl
+++ b/lint/pmd.bzl
@@ -12,6 +12,8 @@ pmd = pmd_aspect(
 ```
 """
 
+load("//lint/private:lint_aspect.bzl", "report_file")
+
 def pmd_action(ctx, executable, srcs, rulesets, report, use_exit_code = False):
     """Run PMD as an action under Bazel.
 
@@ -26,7 +28,6 @@ def pmd_action(ctx, executable, srcs, rulesets, report, use_exit_code = False):
         use_exit_code: whether to fail the build when a lint violation is reported
     """
     inputs = srcs + rulesets
-    outputs = [report]
 
     # Wire command-line options, see
     # https://docs.pmd-code.org/latest/pmd_userdocs_cli_reference.html
@@ -44,7 +45,7 @@ def pmd_action(ctx, executable, srcs, rulesets, report, use_exit_code = False):
 
     ctx.actions.run(
         inputs = inputs,
-        outputs = outputs,
+        outputs = [report],
         executable = executable,
         arguments = [args, "--file-list", src_args],
         mnemonic = "PMD",
@@ -52,16 +53,12 @@ def pmd_action(ctx, executable, srcs, rulesets, report, use_exit_code = False):
 
 # buildifier: disable=function-docstring
 def _pmd_aspect_impl(target, ctx):
-    if ctx.rule.kind in ["java_library"]:
-        report = ctx.actions.declare_file(target.label.name + ".PMD-report.txt")
-        pmd_action(ctx, ctx.executable._pmd, ctx.rule.files.srcs, ctx.files._rulesets, report, ctx.attr.fail_on_violation)
-        results = depset([report])
-    else:
-        results = depset()
+    if ctx.rule.kind not in ["java_library"]:
+        return []
 
-    return [
-        OutputGroupInfo(rules_lint_report = results),
-    ]
+    report, info = report_file(target, ctx)
+    pmd_action(ctx, ctx.executable._pmd, ctx.rule.files.srcs, ctx.files._rulesets, report, ctx.attr.fail_on_violation)
+    return [info]
 
 def pmd_aspect(binary, rulesets):
     """A factory function to create a linter aspect.

--- a/lint/private/BUILD.bazel
+++ b/lint/private/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "lint_aspect",
+    srcs = ["lint_aspect.bzl"],
+    visibility = ["//lint:__subpackages__"],
+)

--- a/lint/private/lint_aspect.bzl
+++ b/lint/private/lint_aspect.bzl
@@ -1,0 +1,6 @@
+"Helpers to reduce boilerplate for writing linter aspects"
+
+def report_file(target, ctx):
+    report = ctx.actions.declare_file(target.label.name + ".aspect_rules_lint.report")
+    info = OutputGroupInfo(rules_lint_report = depset([report]))
+    return report, info


### PR DESCRIPTION
Makes it less likely the lint.sh shows wrong things.
