### PR TITLE
chore: fix eslint absolute paths

### DIFF
--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -9,6 +9,12 @@ js_library(
     visibility = ["//visibility:public"],
 )
 
+js_library(
+    name = "eslint.bazel-formatter",
+    srcs = ["eslint.bazel-formatter.js"],
+    visibility = ["//visibility:public"],
+)
+
 bzl_library(
     name = "buf",
     srcs = ["buf.bzl"],

--- a/lint/eslint.bazel-formatter.js
+++ b/lint/eslint.bazel-formatter.js
@@ -1,0 +1,41 @@
+// Fork of 'stylish' plugin that prints relative paths.
+// This allows an editor to navigate to the location of the lint warning even though we present
+// eslint with paths underneath a bazel sandbox folder.
+// from https://github.com/eslint/eslint/blob/331cf62024b6c7ad4067c14c593f116576c3c861/lib/cli-engine/formatters/stylish.js
+const path = require("node:path");
+
+/**
+ * Given a word and a count, append an s if count is not one.
+ * @param {string} word A word in its singular form.
+ * @param {int} count A number controlling whether word should be pluralized.
+ * @returns {string} The original word with an s on the end if count is not one.
+ */
+function pluralize(word, count) {
+  return count === 1 ? word : `${word}s`;
+}
+
+module.exports = function (results, context) {
+  let output = "";
+
+  results.forEach((result) => {
+    const messages = result.messages;
+
+    if (messages.length === 0) {
+      return;
+    }
+
+    const relpath = path.relative(context.cwd, result.filePath);
+
+    messages.forEach((message) => {
+      const msgtext = message.message.replace(/([^ ])\.$/u, "$1");
+      const severity =
+        message.fatal || message.severity === 2 ? "error" : "warning";
+      const location = [relpath, message.line, message.column].join(":");
+      output += `${location}: ${msgtext}  [${severity} from ${
+        message.ruleId || ""
+      }]\n`;
+    });
+  });
+
+  return output;
+};

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -43,6 +43,7 @@ def eslint_action(ctx, executable, srcs, report, use_exit_code = False):
     # args.add("--debug")
 
     args.add_all(["--config", ctx.file._config_file.short_path])
+    args.add_all(["--format", "../../../" + ctx.file._formatter.path])
     args.add_all(["--output-file", report.short_path])
     args.add_all([s.short_path for s in srcs])
 
@@ -52,7 +53,7 @@ def eslint_action(ctx, executable, srcs, report, use_exit_code = False):
 
     # Add the config file along with any deps it has on npm packages
     inputs.extend(js_lib_helpers.gather_files_from_js_providers(
-        [ctx.attr._config_file, ctx.attr._workaround_17660],
+        [ctx.attr._config_file, ctx.attr._workaround_17660, ctx.attr._formatter],
         include_transitive_sources = True,
         include_declarations = False,
         include_npm_linked_packages = True,
@@ -110,6 +111,11 @@ def eslint_aspect(binary, config):
             ),
             "_workaround_17660": attr.label(
                 default = "@aspect_rules_lint//lint:eslint.workaround_17660",
+                allow_single_file = True,
+                cfg = "exec",
+            ),
+            "_formatter": attr.label(
+                default = "@aspect_rules_lint//lint:eslint.bazel-formatter",
                 allow_single_file = True,
                 cfg = "exec",
             ),


### PR DESCRIPTION
Demo:

```
example$ ./lint.sh src:all
INFO: Elapsed time: 0.954s, Critical Path: 0.88s
From /shared/cache/bazel/user_base/b6913b1339fd4037a680edabc6135c1d/execroot/__main__/bazel-out/k8-fastbuild/bin/src/unused_import.aspect_rules_lint.report:
src/unused_import.py:6:1: F401 'os' imported but unused

From /shared/cache/bazel/user_base/b6913b1339fd4037a680edabc6135c1d/execroot/__main__/bazel-out/k8-fastbuild/bin/src/foo.aspect_rules_lint.report:
src/Foo.java:9: FinalizeOverloaded:     Finalize methods should not be overloaded

From /shared/cache/bazel/user_base/b6913b1339fd4037a680edabc6135c1d/execroot/__main__/bazel-out/k8-fastbuild/bin/src/ts.aspect_rules_lint.report:
src/file.ts:2:7: Type string trivially inferred from a string literal, remove type annotation  [error from @typescript-eslint/no-inferrable-types]
```