### PR TITLE
chore: reference latest aspect CLI version from .bazeliskrc

### DIFF
--- a/example/.bazeliskrc
+++ b/example/.bazeliskrc
@@ -1,2 +1,2 @@
 BAZELISK_BASE_URL=https://github.com/aspect-build/aspect-cli/releases/download
-USE_BAZEL_VERSION=aspect/5.7.2
+USE_BAZEL_VERSION=aspect/5.8.5


### PR DESCRIPTION
`aspect/5.7.2` doesn't seem to include the `lint` command and `bazel lint src:all` fails with

```
Error: unknown command "lint" for "aspect"
```

This error is resolved by using version 5.8.5.