### PR TITLE
fix: allow ruff binary to be a source file

### DIFF
--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -88,6 +88,7 @@ def ruff_aspect(binary, config):
             "fail_on_violation": attr.bool(),
             "_ruff": attr.label(
                 default = binary,
+                allow_single_file = True,
                 executable = True,
                 cfg = "exec",
             ),


### PR DESCRIPTION
The `example/`  repo fails to lint because the `ruff` binary it provides is a source file.

```
❮ bazel lint -- --java_runtime_version=remotejdk_11  src:all
ERROR: /home/plobsing/src/rules_lint/example/src/BUILD.bazel:31:11: in (an implicit dependency) attribute of //tools:lint.bzl%ruff[fail_on_violation="false"] aspect on sh_library rule //src:hello_shell: alias '//tools:ruff' referring to source file '@ruff_x86_64-unknown-linux-gnu//:ruff' is misplaced here (expected no files)
```