### PR TITLE
fix: make lint tools visible to all subpackages of example repo

### DIFF
--- a/example/tools/BUILD
+++ b/example/tools/BUILD
@@ -7,7 +7,7 @@ we don't want to trigger eager fetches of these for builds that don't want to ru
 load("@aspect_rules_lint//format:defs.bzl", "multi_formatter_binary")
 load("@npm//:prettier/package_json.bzl", prettier = "bin")
 
-package(default_visibility = ["//:__pkg__"])
+package(default_visibility = ["//:__subpackages__"])
 
 alias(
     name = "jsonnetfmt",


### PR DESCRIPTION
If the linter binaries aren't visible to targets under `src/`, linting fails with

```
❯ bazel lint -- --java_runtime_version=remotejdk_11  src:all
ERROR: /home/plobsing/src/rules_lint/example/src/BUILD.bazel:21:11: in //tools:lint.bzl%ruff[fail_on_violation="false"] aspect on py_library rule //src:unused_import: alias '//tools:ruff' referring to target '@ruff_x86_64-unknown-linux-gnu//:ruff' is not visible from target '//src:unused_import'. Check the visibility declaration of the former target if you think the dependency is legitimate. To set the visibility of that source file target, use the exports_files() function
ERROR: Analysis of aspects '[//tools:lint.bzl%eslint, //tools:lint.bzl%buf, //tools:lint.bzl%flake8, //tools:lint.bzl%pmd, //tools:lint.bzl%ruff] with parameters {} on //src:unused_import' failed; build aborted: Analysis of target '//src:unused_import' failed
```