### PR TITLE
docs: recommend check-mode for fallback pre-commit hook

### DIFF
--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -58,7 +58,7 @@ If you don't use pre-commit, you can just wire directly into the git hook, howev
 this option will always run the formatter over all files, not just changed files.
 
 ```bash
-$ echo "bazel run //tools:format" >> .git/hooks/pre-commit
+$ echo "bazel run //tools:format -- --mode check" >> .git/hooks/pre-commit
 $ chmod u+x .git/hooks/pre-commit
 ```
 


### PR DESCRIPTION
As fix-mode does not return a non-zero status, it will not block submission when it detects formatting issues. Instead, it will reformat files but not stage them within `git`. The result is that users are not barred from submitting malformatted code; when they do, they'll have the fixes as unstaged changes in the files they just submitted.

Check-mode's behaviour will block submission, which is more similar to what `pre-commit.com` does and is probably what most users will expect.