### PR TITLE
feat: check srcs of *_binary targets in lint aspect walks

### DIFF
--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -79,7 +79,7 @@ def eslint_action(ctx, executable, srcs, report, use_exit_code = False):
 
 # buildifier: disable=function-docstring
 def _eslint_aspect_impl(target, ctx):
-    if ctx.rule.kind not in ["ts_project", "ts_project_rule"]:
+    if ctx.rule.kind not in ["js_binary", "js_library", "ts_project", "ts_project_rule"]:
         return []
 
     report, info = report_file(_MNEMONIC, target, ctx)

--- a/lint/flake8.bzl
+++ b/lint/flake8.bzl
@@ -51,7 +51,7 @@ def flake8_action(ctx, executable, srcs, config, report, use_exit_code = False):
 
 # buildifier: disable=function-docstring
 def _flake8_aspect_impl(target, ctx):
-    if ctx.rule.kind not in ["py_library"]:
+    if ctx.rule.kind not in ["py_binary", "py_library"]:
         return []
 
     report, info = report_file(_MNEMONIC, target, ctx)

--- a/lint/pmd.bzl
+++ b/lint/pmd.bzl
@@ -55,7 +55,7 @@ def pmd_action(ctx, executable, srcs, rulesets, report, use_exit_code = False):
 
 # buildifier: disable=function-docstring
 def _pmd_aspect_impl(target, ctx):
-    if ctx.rule.kind not in ["java_library"]:
+    if ctx.rule.kind not in ["java_binary", "java_library"]:
         return []
 
     report, info = report_file(_MNEMONIC, target, ctx)

--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -53,7 +53,7 @@ def ruff_action(ctx, executable, srcs, config, report, use_exit_code = False):
 
 # buildifier: disable=function-docstring
 def _ruff_aspect_impl(target, ctx):
-    if ctx.rule.kind not in ["py_library"]:
+    if ctx.rule.kind not in ["py_binary", "py_library"]:
         return []
 
     report, info = report_file(_MNEMONIC, target, ctx)


### PR DESCRIPTION
These commonly contain an entry point or "main" which should be linted, but not contained in any *_library target srcs.

Fixes #40
