### PR TITLE
chore: fix bcr publishing

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -2,10 +2,6 @@
 
 set -o errexit -o nounset -o pipefail
 
-# Don't include our example in the distribution artifact, to reduce size.
-# See https://git-scm.com/docs/git-archive#ATTRIBUTES
-echo >>.git/info/attributes "example export-ignore"
-
 # Set by GH actions, see
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 TAG=${GITHUB_REF_NAME}


### PR DESCRIPTION
We can't exclude examples because that's the bcr test module.
Oops!