### PR TITLE
fix: template the fix target string in failure error message

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -13,7 +13,7 @@ function on_exit {
   code=$?
   if [[ $code != 0 ]]; then
     echo >&2 "FAILED: A formatter tool exited with code $code"
-    echo >&2 "Try running 'bazel run //:format' to fix this."
+    echo >&2 "Try running 'bazel run {{fix_target}}' to fix this."
   fi
 }
 

--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -19,7 +19,9 @@ _attrs = {
 
 def _formatter_binary_impl(ctx):
     # We need to fill in the rlocation paths in the shell script
-    substitutions = {}
+    substitutions = {
+        "{{fix_target}}": str(ctx.label)
+    }
     tools = {
         "ruff": ctx.attr.python,
         "buildifier": ctx.attr.starlark,


### PR DESCRIPTION
There's a number of assumptions that the fix target is `//tools:format` when this might not be the case.
Adds a template string to the fix target in the failure error message on formatting.

---

### Type of change

- Bug fix (change which fixes an issue)

**For changes visible to end-users**

- Suggested release notes are provided below:

Ensure formatting error fix target correctly reflects the name of the formatter binary target.

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Run the formatter locally with a different target name.
