### PR TITLE
feat: allow multiple ruff config files

### DIFF
--- a/docs/ruff.md
+++ b/docs/ruff.md
@@ -9,7 +9,7 @@ load("@aspect_rules_lint//lint:ruff.bzl", "ruff_aspect")
 
 ruff = ruff_aspect(
     binary = "@@//:ruff",
-    config = "@@//:.ruff.toml",
+    configs = "@@//:.ruff.toml",
 )
 ```
 
@@ -42,6 +42,20 @@ ruff_action(<a href="#ruff_action-ctx">ctx</a>, <a href="#ruff_action-executable
 
 Run ruff as an action under Bazel.
 
+Ruff will select the configuration file to use for each source file, as documented here:
+https://docs.astral.sh/ruff/configuration/#config-file-discovery
+
+Note: all config files are passed to the action.
+This means that a change to any config file invalidates the action cache entries for ALL
+ruff actions.
+
+However this is needed because:
+
+1. ruff has an `extend` field, so it may need to read more than one config file
+2. ruff's logic for selecting the appropriate config needs to read the file content to detect
+  a `[tool.ruff]` section.
+
+
 **PARAMETERS**
 
 
@@ -50,7 +64,7 @@ Run ruff as an action under Bazel.
 | <a id="ruff_action-ctx"></a>ctx |  Bazel Rule or Aspect evaluation context   |  none |
 | <a id="ruff_action-executable"></a>executable |  label of the the ruff program   |  none |
 | <a id="ruff_action-srcs"></a>srcs |  python files to be linted   |  none |
-| <a id="ruff_action-config"></a>config |  label of the ruff config file (pyproject.toml, ruff.toml, or .ruff.toml)   |  none |
+| <a id="ruff_action-config"></a>config |  labels of ruff config files (pyproject.toml, ruff.toml, or .ruff.toml)   |  none |
 | <a id="ruff_action-report"></a>report |  output file to generate   |  none |
 | <a id="ruff_action-use_exit_code"></a>use_exit_code |  whether to fail the build when a lint violation is reported   |  <code>False</code> |
 
@@ -60,7 +74,7 @@ Run ruff as an action under Bazel.
 ## ruff_aspect
 
 <pre>
-ruff_aspect(<a href="#ruff_aspect-binary">binary</a>, <a href="#ruff_aspect-config">config</a>)
+ruff_aspect(<a href="#ruff_aspect-binary">binary</a>, <a href="#ruff_aspect-configs">configs</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -79,7 +93,7 @@ Attrs:
             build_file_content = """exports_files(["ruff"])""",
         )
 
-    config: the ruff config file (`pyproject.toml`, `ruff.toml`, or `.ruff.toml`)
+    configs: ruff config file(s) (`pyproject.toml`, `ruff.toml`, or `.ruff.toml`)
 
 **PARAMETERS**
 
@@ -87,6 +101,6 @@ Attrs:
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="ruff_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
-| <a id="ruff_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
+| <a id="ruff_aspect-configs"></a>configs |  <p align="center"> - </p>   |  none |
 
 

--- a/example/src/hello copy.tf
+++ b/example/src/hello copy.tf
@@ -1,8 +1,0 @@
-resource "aws_subnet" "private_subnet_us_east_2a" {
-  cidr_block        = "10.0.128.0/20"
-  vpc_id            = aws_vpc.aspect_ci_vpc.id
-  availability_zone = "us-east-2a"
-  tags = {
-    Name = "aspect-ci-subnet-private1-us-east-2a"
-  }
-}

--- a/example/src/subdir/BUILD.bazel
+++ b/example/src/subdir/BUILD.bazel
@@ -1,0 +1,6 @@
+exports_files(["ruff.toml"])
+
+py_library(
+    name = "unused_import",
+    srcs = ["unused_import.py"],
+)

--- a/example/src/subdir/ruff.toml
+++ b/example/src/subdir/ruff.toml
@@ -1,3 +1,3 @@
-# This file should be used by Ruff when linting the py_library targets beneath this folder.
+# This file should be used by Ruff when linting files beneath this folder.
 [lint]
 ignore = ["F401"]

--- a/example/src/subdir/ruff.toml
+++ b/example/src/subdir/ruff.toml
@@ -1,0 +1,3 @@
+# This file should be used by Ruff when linting the py_library targets beneath this folder.
+[lint]
+ignore = ["F401"]

--- a/example/src/subdir/unused_import.py
+++ b/example/src/subdir/unused_import.py
@@ -1,0 +1,2 @@
+# Because the ruff.toml in this folder ignores unused import (F401) we expect no lints here.
+import os

--- a/example/tools/lint.bzl
+++ b/example/tools/lint.bzl
@@ -35,7 +35,10 @@ pmd_test = make_lint_test(aspect = pmd)
 
 ruff = ruff_aspect(
     binary = "@@//tools:ruff",
-    config = "@@//:.ruff.toml",
+    configs = [
+        "@@//:.ruff.toml",
+        "@@//src/subdir:ruff.toml",
+    ],
 )
 
 shellcheck = shellcheck_aspect(


### PR DESCRIPTION
Allows the common monorepo scenario where one application has to have a different configuration for whatever reason.

As documented at https://docs.astral.sh/ruff/configuration/#config-file-discovery the tool already knows how to select the right file for a given python source file.
