### PR TITLE
fix: in use_exit_code mode, print reports to stdio

### DIFF
--- a/example/lint.sh
+++ b/example/lint.sh
@@ -16,7 +16,8 @@ buildevents=$(mktemp)
 filter='.namedSetOfFiles | values | .files[] | ((.pathPrefix | join("/")) + "/" + .name)'
 
 # Produce report files
-# You can add --aspects_parameters=fail_on_violation=true to make this command fail instead.
+# To make the command fail when there's a lint warning, you can add arguments:
+#  --aspects_parameters=fail_on_violation=true --keep_going
 # NB: perhaps --remote_download_toplevel is needed as well with remote execution?
 bazel build \
   --aspects $(echo //tools:lint.bzl%{buf,eslint,flake8,pmd,ruff,shellcheck} | tr ' ' ',') \

--- a/lint/buf.bzl
+++ b/lint/buf.bzl
@@ -57,6 +57,11 @@ def buf_lint_action(ctx, buf_toolchain, target, report, use_exit_code = False):
     args.add_joined(["--buf-plugin_out", "."], join_with = "=")
     args.add_all(sources)
 
+    if use_exit_code:
+        command = "{protoc} $@ && touch {report}"
+    else:
+        command = "{protoc} $@ 2>{report} || true"
+
     ctx.actions.run_shell(
         inputs = depset([
             ctx.file._config,
@@ -64,12 +69,9 @@ def buf_lint_action(ctx, buf_toolchain, target, report, use_exit_code = False):
             buf_toolchain.cli,
         ], transitive = [deps]),
         outputs = [report],
-        command = """\
-            {protoc} $@ 2>{report} {exit_zero}
-        """.format(
+        command = command.format(
             protoc = ctx.executable._protoc.path,
             report = report.path,
-            exit_zero = "" if use_exit_code else "|| true",
         ),
         arguments = [args],
         mnemonic = _MNEMONIC,

--- a/lint/flake8.bzl
+++ b/lint/flake8.bzl
@@ -36,18 +36,27 @@ def flake8_action(ctx, executable, srcs, config, report, use_exit_code = False):
     # https://flake8.pycqa.org/en/latest/user/options.html
     args = ctx.actions.args()
     args.add_all(srcs)
-    args.add(report, format = "--output-file=%s")
     args.add(config, format = "--config=%s")
-    if not use_exit_code:
+    if use_exit_code:
+        ctx.actions.run_shell(
+            inputs = inputs,
+            outputs = outputs,
+            tools = [executable],
+            command = executable.path + " $@ && touch " + report.path,
+            arguments = [args],
+            mnemonic = _MNEMONIC,
+        )
+    else:
+        args.add(report, format = "--output-file=%s")
         args.add("--exit-zero")
 
-    ctx.actions.run(
-        inputs = inputs,
-        outputs = outputs,
-        executable = executable,
-        arguments = [args],
-        mnemonic = _MNEMONIC,
-    )
+        ctx.actions.run(
+            inputs = inputs,
+            outputs = outputs,
+            executable = executable,
+            arguments = [args],
+            mnemonic = _MNEMONIC,
+        )
 
 # buildifier: disable=function-docstring
 def _flake8_aspect_impl(target, ctx):

--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -50,19 +50,28 @@ def ruff_action(ctx, executable, srcs, config, report, use_exit_code = False):
     # `ruff help check` to see available options
     args = ctx.actions.args()
     args.add("check")
-    args.add(report, format = "--output-file=%s")
-    if not use_exit_code:
-        args.add("--exit-zero")
-
     args.add_all(srcs)
 
-    ctx.actions.run(
-        inputs = inputs,
-        outputs = outputs,
-        executable = executable,
-        arguments = [args],
-        mnemonic = _MNEMONIC,
-    )
+    if use_exit_code:
+        ctx.actions.run_shell(
+            inputs = inputs,
+            outputs = outputs,
+            command = executable.path + " $@ && touch " + report.path,
+            arguments = [args],
+            mnemonic = _MNEMONIC,
+            tools = [executable],
+        )
+    else:
+        args.add(report, format = "--output-file=%s")
+        args.add("--exit-zero")
+
+        ctx.actions.run(
+            inputs = inputs,
+            outputs = outputs,
+            executable = executable,
+            arguments = [args],
+            mnemonic = _MNEMONIC,
+        )
 
 # buildifier: disable=function-docstring
 def _ruff_aspect_impl(target, ctx):

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -53,25 +53,27 @@ def shellcheck_action(ctx, executable, srcs, config, report, use_exit_code = Fal
         use_exit_code: whether to fail the build when a lint violation is reported
     """
     inputs = srcs + [config]
-    outputs = [report]
 
     # Wire command-line options, see
     # https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md#options
     args = ctx.actions.args()
     args.add_all(srcs)
 
+    if use_exit_code:
+        command = "{shellcheck} $@ && touch {report}"
+    else:
+        command = "{shellcheck} $@ >{report} || true"
+
     ctx.actions.run_shell(
-        inputs = inputs + [executable],
-        outputs = outputs,
-        command = """\
-            {shellcheck} $@ >{report} {exit_zero}
-        """.format(
+        inputs = inputs,
+        outputs = [report],
+        command = command.format(
             shellcheck = executable.path,
             report = report.path,
-            exit_zero = "" if use_exit_code else "|| true",
         ),
         arguments = [args],
         mnemonic = _MNEMONIC,
+        tools = [executable],
     )
 
 # buildifier: disable=function-docstring


### PR DESCRIPTION
Previously we always directed the tools output into a report file, but when you ask for the exit code to be used, this means the Bazel build fails without printing the result of the tool. Instead, all the logic related to directing output into the report file should only be used when exit code is ignored.
