### PR TITLE
fix: Respect exclude when formatting with ruff

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -62,7 +62,7 @@ case "$mode" in
  fix)
    swiftmode=""
    prettiermode="--write"
-   ruffmode="format"
+   ruffmode="format --force-exclude"
    shfmtmode="-w"
    javamode="--replace"
    ktmode=""

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -62,6 +62,9 @@ case "$mode" in
  fix)
    swiftmode=""
    prettiermode="--write"
+   # Force exclusions in the configuration file to be honored even when file paths are supplied
+   # as command-line arguments; see
+   # https://github.com/astral-sh/ruff/discussions/5857#discussioncomment-6583943
    ruffmode="format --force-exclude"
    shfmtmode="-w"
    javamode="--replace"


### PR DESCRIPTION
As per discussion here: https://github.com/astral-sh/ruff/discussions/5857#discussioncomment-6583943 pass `--force-exclude` when invoking `ruff format`

---

<!-- Delete this comment! Follow our PR template instructions: https://github.com/aspect-build/.github/blob/main/pull_requests.md -->

### Type of change

- Bug fix (change which fixes an issue)

**For changes visible to end-users**

- Suggested release notes are provided below:
ruff format now respects exclude and extend-exclude directives in ruff.toml configuration files.

### Test plan

- Manual testing; please provide instructions so we can reproduce:
Add a directory path to an extend-exclude directive in ruff.toml and observe that the files in that directory are not formatted.
