### PR TITLE
chore: change maintainer to individual rather than team.

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -2,9 +2,9 @@
   "homepage": "https://github.com/aspect-build/rules_lint",
   "maintainers": [
     {
-      "email": "hello@aspect.dev",
-      "github": "aspect-build",
-      "name": "Aspect team"
+      "email": "alex@aspect.dev",
+      "github": "alexeagle",
+      "name": "Alex Eagle"
     }
   ],
   "repository": ["github:aspect-build/rules_lint"],


### PR DESCRIPTION
I saw us making this change in other repos so it should be consistent. Maybe it also explains why I didn't get an email about rules_lint 0.6.1 not publishing a PR to BCR
