### PR TITLE
Add golangci-lint as an aspect

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,6 +24,6 @@ bazel_dep(name = "rules_buf", version = "0.1.1")
 # Needed due to rules_proto leaking the dependency
 bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
 
-bazel_dep(name = "rules_go", version = "0.39.1", dev_dependency = True)
+bazel_dep(name = "rules_go", version = "0.39.1", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "gazelle", version = "0.31.0", dev_dependency = True)
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ We treat type-checkers as a build tool, not as a linter. This is for a few reaso
 | SQL                       | [prettier-plugin-sql] |                  |
 | Starlark (Bazel)          | [Buildifier]          |                  |
 | Swift                     | [SwiftFormat] (1)     |                  |
-| Go                        | [gofmt]               |                  |
+| Go                        | [gofmt]               | [golangci-lint]  |
 | Protocol Buffers          | [buf]                 | [buf lint]       |
 | Terraform                 | [terraform] fmt       |                  |
 | Jsonnet                   | [jsonnetfmt]          |                  |
@@ -93,6 +93,7 @@ We treat type-checkers as a build tool, not as a linter. This is for a few reaso
 [ruff]: https://docs.astral.sh/ruff/
 [shellcheck]: https://www.shellcheck.net/
 [shfmt]: https://github.com/mvdan/sh
+[golangci-lint]: https://github.com/golangci/golangci-lint
 
 1. Non-hermetic: requires that a swift toolchain is installed on the machine.
    See https://github.com/bazelbuild/rules_swift#1-install-swift

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -38,6 +38,11 @@ stardoc_with_diff_test(
 )
 
 stardoc_with_diff_test(
+    name = "golangci-lint",
+    bzl_library_target = "//lint:golangci-lint",
+)
+
+stardoc_with_diff_test(
     name = "shellcheck",
     bzl_library_target = "//lint:shellcheck",
 )

--- a/docs/golangci-lint.md
+++ b/docs/golangci-lint.md
@@ -1,0 +1,93 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+API for declaring a golangci-lint lint aspect that visits go_library, go_test, and go_binary rules.
+
+```
+load("@aspect_rules_lint//lint:golangci-lint.bzl", "golangci_lint_aspect")
+
+golangci_lint = golangci_lint_aspect(
+    binary = "@@//tools:golangci-lint",
+    config = "@@//:.golangci.yaml",
+)
+```
+
+
+<a id="fetch_golangci_lint"></a>
+
+## fetch_golangci_lint
+
+<pre>
+fetch_golangci_lint()
+</pre>
+
+
+
+
+
+<a id="golangci_lint_action"></a>
+
+## golangci_lint_action
+
+<pre>
+golangci_lint_action(<a href="#golangci_lint_action-ctx">ctx</a>, <a href="#golangci_lint_action-executable">executable</a>, <a href="#golangci_lint_action-srcs">srcs</a>, <a href="#golangci_lint_action-config">config</a>, <a href="#golangci_lint_action-report">report</a>, <a href="#golangci_lint_action-use_exit_code">use_exit_code</a>)
+</pre>
+
+Run golangci-lint as an action under Bazel.
+
+Based on https://github.com/golangci/golangci-lint
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="golangci_lint_action-ctx"></a>ctx |  Bazel Rule or Aspect evaluation context   |  none |
+| <a id="golangci_lint_action-executable"></a>executable |  label of the the golangci-lint program   |  none |
+| <a id="golangci_lint_action-srcs"></a>srcs |  golang files to be linted   |  none |
+| <a id="golangci_lint_action-config"></a>config |  label of the .golangci.yaml file   |  none |
+| <a id="golangci_lint_action-report"></a>report |  output file to generate   |  none |
+| <a id="golangci_lint_action-use_exit_code"></a>use_exit_code |  whether to fail the build when a lint violation is reported   |  <code>False</code> |
+
+
+<a id="golangci_lint_aspect"></a>
+
+## golangci_lint_aspect
+
+<pre>
+golangci_lint_aspect(<a href="#golangci_lint_aspect-binary">binary</a>, <a href="#golangci_lint_aspect-config">config</a>)
+</pre>
+
+A factory function to create a linter aspect.
+
+Attrs:
+    binary: a golangci-lint executable.
+    config: the .golangci.yaml file
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="golangci_lint_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
+| <a id="golangci_lint_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
+
+
+<a id="golangci_lint_binary"></a>
+
+## golangci_lint_binary
+
+<pre>
+golangci_lint_binary(<a href="#golangci_lint_binary-name">name</a>)
+</pre>
+
+Wrapper around native_binary to select the correct golangci-lint executable for the execution platform.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="golangci_lint_binary-name"></a>name |  <p align="center"> - </p>   |  none |
+
+

--- a/docs/golangci-lint.md
+++ b/docs/golangci-lint.md
@@ -73,21 +73,3 @@ Attrs:
 | <a id="golangci_lint_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
 
 
-<a id="golangci_lint_binary"></a>
-
-## golangci_lint_binary
-
-<pre>
-golangci_lint_binary(<a href="#golangci_lint_binary-name">name</a>)
-</pre>
-
-Wrapper around native_binary to select the correct golangci-lint executable for the execution platform.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="golangci_lint_binary-name"></a>name |  <p align="center"> - </p>   |  none |
-
-

--- a/docs/golangci-lint.md
+++ b/docs/golangci-lint.md
@@ -17,11 +17,17 @@ golangci_lint = golangci_lint_aspect(
 ## fetch_golangci_lint
 
 <pre>
-fetch_golangci_lint()
+fetch_golangci_lint(<a href="#fetch_golangci_lint-version">version</a>)
 </pre>
 
+Naive macro that fetches a specific version of the golangci-lint from GitHub releases, for commonly-used platforms
+
+**PARAMETERS**
 
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="fetch_golangci_lint-version"></a>version |  must be the default value. In the future this could be honored when we support multiple versions.   |  <code>"1.55.2"</code> |
 
 
 <a id="golangci_lint_action"></a>

--- a/example/.golangci.yaml
+++ b/example/.golangci.yaml
@@ -3,6 +3,12 @@
 
 run:
   timeout: 5m
+
+  # Prevent non-hermetic behavior. Per the documentation:
+  # > If invoked with -mod=readonly, the go command is disallowed from the implicit
+  # > automatic updating of go.mod described above. Instead, it fails when any changes
+  # > to go.mod are needed. This setting is most useful to check that go.mod does
+  # > not need updates, such as in a continuous integration and testing system.
   modules-download-mode: readonly
 
 linters:

--- a/example/.golangci.yaml
+++ b/example/.golangci.yaml
@@ -1,0 +1,17 @@
+# Refer to golangci-lint's example config file for more options and information:
+# https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+
+linters:
+  enable:
+  # Default
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - typecheck
+    - unused

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -18,6 +18,7 @@ exports_files(
         ".ruff.toml",
         ".shellcheckrc",
         ".scalafmt.conf",
+        ".golangci.yaml",
     ],
     visibility = ["//visibility:public"],
 )

--- a/example/MODULE.bazel
+++ b/example/MODULE.bazel
@@ -8,7 +8,7 @@ bazel_dep(name = "rules_buf", version = "0.2.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "rules_java", version = "5.5.0")
 bazel_dep(name = "rules_jvm_external", version = "4.5")
-bazel_dep(name = "rules_go", version = "0.42.0")
+bazel_dep(name = "rules_go", version = "0.42.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
 bazel_dep(name = "rules_python", version = "0.26.0")
 bazel_dep(name = "buildifier_prebuilt", version = "6.3.3")
@@ -50,7 +50,7 @@ pip.parse(
 )
 use_repo(pip, "pip")
 
-go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     name = "go_sdk",
     version = "1.20.3",

--- a/example/MODULE.bazel.lock
+++ b/example/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "a750d778e6bcd950b4ccec400e9eff2ee566e18fa1004ee3a71f0a8d9297dd8a",
+  "moduleFileHash": "9d432ff89f0562c91ec0cd8fd7d084ca1108cf557bde2d8bae21cdba1195db60",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -14,7 +14,7 @@
   },
   "localOverrideHashes": {
     "bazel_tools": "922ea6752dc9105de5af957f7a99a6933c0a6a712d23df6aad16a9c399f7e787",
-    "aspect_rules_lint": "4b4eff7dcf87f2347d9061e30af0e88d6979dc5127110e7d8a8ae279864f8b59"
+    "aspect_rules_lint": "2ad9a7d855e528dc93d1f99890e60afa5d7a12925b5899719fa9cd02d7671a3a"
   },
   "moduleDepGraph": {
     "<root>": {
@@ -154,7 +154,7 @@
           "hasNonDevUseExtension": true
         },
         {
-          "extensionBzlFile": "@rules_go//go:extensions.bzl",
+          "extensionBzlFile": "@io_bazel_rules_go//go:extensions.bzl",
           "extensionName": "go_sdk",
           "usingModule": "<root>",
           "location": {
@@ -249,7 +249,7 @@
         "bazel_skylib": "bazel_skylib@1.5.0",
         "rules_java": "rules_java@7.1.0",
         "rules_jvm_external": "rules_jvm_external@4.5",
-        "rules_go": "rules_go@0.42.0",
+        "io_bazel_rules_go": "rules_go@0.42.0",
         "rules_proto": "rules_proto@5.3.0-21.7",
         "rules_python": "rules_python@0.26.0",
         "buildifier_prebuilt": "buildifier_prebuilt@6.3.3",
@@ -274,6 +274,7 @@
         "rules_proto": "rules_proto@5.3.0-21.7",
         "rules_buf": "rules_buf@0.2.0",
         "com_google_protobuf": "protobuf@21.7",
+        "io_bazel_rules_go": "rules_go@0.42.0",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       }
@@ -16761,85 +16762,225 @@
             }
           }
         }
-      },
-      "os:osx,arch:aarch64": {
-        "bzlTransitiveDigest": "G2qnTlBBa9eTHC7TZFVz1vGqrdiGJyHKWVLwacYRx+w=",
+      }
+    },
+    "@@rules_go~0.42.0//go/private:extensions.bzl%non_module_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "Fdqr2x/FZ6V3rmXwFF8d+gY+R1fLY6ITqVvt3kl6xfE=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "go_default_sdk": {
-            "bzlFile": "@@rules_go~0.42.0//go/private:sdk.bzl",
-            "ruleClassName": "go_download_sdk_rule",
+          "org_golang_x_tools_go_vcs": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_go~0.42.0~go_sdk~go_default_sdk",
-              "goos": "",
-              "goarch": "",
-              "sdks": {},
-              "experiments": [],
-              "patches": [],
-              "patch_strip": 0,
+              "name": "rules_go~0.42.0~non_module_dependencies~org_golang_x_tools_go_vcs",
               "urls": [
-                "https://dl.google.com/go/{}"
+                "https://mirror.bazel.build/github.com/golang/tools/archive/refs/tags/go/vcs/v0.1.0-deprecated.zip",
+                "https://github.com/golang/tools/archive/refs/tags/go/vcs/v0.1.0-deprecated.zip"
               ],
-              "version": "1.21.1",
-              "strip_prefix": "go"
-            }
-          },
-          "go_host_compatible_sdk_label": {
-            "bzlFile": "@@rules_go~0.42.0//go/private:extensions.bzl",
-            "ruleClassName": "host_compatible_toolchain",
-            "attributes": {
-              "name": "rules_go~0.42.0~go_sdk~go_host_compatible_sdk_label",
-              "toolchain": "@go_sdk//:ROOT"
-            }
-          },
-          "go_toolchains": {
-            "bzlFile": "@@rules_go~0.42.0//go/private:sdk.bzl",
-            "ruleClassName": "go_multiple_toolchains",
-            "attributes": {
-              "name": "rules_go~0.42.0~go_sdk~go_toolchains",
-              "prefixes": [
-                "_0000_go_sdk_",
-                "_0001_go_default_sdk_"
+              "sha256": "1b389268d126467105305ae4482df0189cc80a13aaab28d0946192b4ad0737a8",
+              "strip_prefix": "tools-go-vcs-v0.1.0-deprecated/go/vcs",
+              "patches": [
+                "@@rules_go~0.42.0//third_party:org_golang_x_tools_go_vcs-gazelle.patch"
               ],
-              "geese": [
-                "",
-                ""
-              ],
-              "goarchs": [
-                "",
-                ""
-              ],
-              "sdk_repos": [
-                "go_sdk",
-                "go_default_sdk"
-              ],
-              "sdk_types": [
-                "remote",
-                "remote"
-              ],
-              "sdk_versions": [
-                "1.20.3",
-                "1.21.1"
+              "patch_args": [
+                "-p1"
               ]
             }
           },
-          "go_sdk": {
-            "bzlFile": "@@rules_go~0.42.0//go/private:sdk.bzl",
-            "ruleClassName": "go_download_sdk_rule",
+          "org_golang_x_xerrors": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_go~0.42.0~go_sdk~go_sdk",
-              "goos": "",
-              "goarch": "",
-              "sdks": {},
-              "experiments": [],
-              "patches": [],
-              "patch_strip": 0,
+              "name": "rules_go~0.42.0~non_module_dependencies~org_golang_x_xerrors",
               "urls": [
-                "https://dl.google.com/go/{}"
+                "https://mirror.bazel.build/github.com/golang/xerrors/archive/04be3eba64a22a838cdb17b8dca15a52871c08b4.zip",
+                "https://github.com/golang/xerrors/archive/04be3eba64a22a838cdb17b8dca15a52871c08b4.zip"
               ],
-              "version": "1.20.3",
-              "strip_prefix": "go"
+              "sha256": "ffad2b06ef2e09d040da2ff08077865e99ab95d4d0451737fc8e33706bb01634",
+              "strip_prefix": "xerrors-04be3eba64a22a838cdb17b8dca15a52871c08b4",
+              "patches": [
+                "@@rules_go~0.42.0//third_party:org_golang_x_xerrors-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "gogo_special_proto": {
+            "bzlFile": "@@rules_go~0.42.0//proto:gogo.bzl",
+            "ruleClassName": "gogo_special_proto",
+            "attributes": {
+              "name": "rules_go~0.42.0~non_module_dependencies~gogo_special_proto"
+            }
+          },
+          "org_golang_google_protobuf": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_go~0.42.0~non_module_dependencies~org_golang_google_protobuf",
+              "sha256": "f5d1f6d0e9b836aceb715f1df2dc065083a55b07ecec3b01b5e89d039b14da02",
+              "urls": [
+                "https://mirror.bazel.build/github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.31.0.zip",
+                "https://github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.31.0.zip"
+              ],
+              "strip_prefix": "protobuf-go-1.31.0",
+              "patches": [
+                "@@rules_go~0.42.0//third_party:org_golang_google_protobuf-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "com_github_mwitkow_go_proto_validators": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_go~0.42.0~non_module_dependencies~com_github_mwitkow_go_proto_validators",
+              "urls": [
+                "https://mirror.bazel.build/github.com/mwitkow/go-proto-validators/archive/refs/tags/v0.3.2.zip",
+                "https://github.com/mwitkow/go-proto-validators/archive/refs/tags/v0.3.2.zip"
+              ],
+              "sha256": "d8697f05a2f0eaeb65261b480e1e6035301892d9fc07ed945622f41b12a68142",
+              "strip_prefix": "go-proto-validators-0.3.2"
+            }
+          },
+          "org_golang_x_tools": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_go~0.42.0~non_module_dependencies~org_golang_x_tools",
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/tools/archive/refs/tags/v0.7.0.zip",
+                "https://github.com/golang/tools/archive/refs/tags/v0.7.0.zip"
+              ],
+              "sha256": "9f20a20f29f4008d797a8be882ef82b69cf8f7f2b96dbdfe3814c57d8280fa4b",
+              "strip_prefix": "tools-0.7.0",
+              "patches": [
+                "@@rules_go~0.42.0//third_party:org_golang_x_tools-deletegopls.patch",
+                "@@rules_go~0.42.0//third_party:org_golang_x_tools-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "org_golang_google_genproto": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_go~0.42.0~non_module_dependencies~org_golang_google_genproto",
+              "urls": [
+                "https://mirror.bazel.build/github.com/googleapis/go-genproto/archive/007df8e322eb3e384d36c0821e2337825c203ca6.zip",
+                "https://github.com/googleapis/go-genproto/archive/007df8e322eb3e384d36c0821e2337825c203ca6.zip"
+              ],
+              "sha256": "e7d0f3faed86258ed4e8e5527a8e98ff00fbd5b1a9b379a99a4aa2f76ce8bbcc",
+              "strip_prefix": "go-genproto-007df8e322eb3e384d36c0821e2337825c203ca6",
+              "patches": [
+                "@@rules_go~0.42.0//third_party:org_golang_google_genproto-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "bazel_skylib": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_go~0.42.0~non_module_dependencies~bazel_skylib",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz"
+              ],
+              "sha256": "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
+              "strip_prefix": ""
+            }
+          },
+          "com_github_gogo_protobuf": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_go~0.42.0~non_module_dependencies~com_github_gogo_protobuf",
+              "urls": [
+                "https://mirror.bazel.build/github.com/gogo/protobuf/archive/refs/tags/v1.3.2.zip",
+                "https://github.com/gogo/protobuf/archive/refs/tags/v1.3.2.zip"
+              ],
+              "sha256": "f89f8241af909ce3226562d135c25b28e656ae173337b3e58ede917aa26e1e3c",
+              "strip_prefix": "protobuf-1.3.2",
+              "patches": [
+                "@@rules_go~0.42.0//third_party:com_github_gogo_protobuf-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "com_github_golang_protobuf": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_go~0.42.0~non_module_dependencies~com_github_golang_protobuf",
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/protobuf/archive/refs/tags/v1.5.3.zip",
+                "https://github.com/golang/protobuf/archive/refs/tags/v1.5.3.zip"
+              ],
+              "sha256": "2dced4544ae5372281e20f1e48ca76368355a01b31353724718c4d6e3dcbb430",
+              "strip_prefix": "protobuf-1.5.3",
+              "patches": [
+                "@@rules_go~0.42.0//third_party:com_github_golang_protobuf-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "io_bazel_rules_nogo": {
+            "bzlFile": "@@rules_go~0.42.0//go/private:nogo.bzl",
+            "ruleClassName": "go_register_nogo",
+            "attributes": {
+              "name": "rules_go~0.42.0~non_module_dependencies~io_bazel_rules_nogo",
+              "nogo": "@io_bazel_rules_go//:default_nogo"
+            }
+          },
+          "com_github_golang_mock": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_go~0.42.0~non_module_dependencies~com_github_golang_mock",
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/mock/archive/refs/tags/v1.7.0-rc.1.zip",
+                "https://github.com/golang/mock/archive/refs/tags/v1.7.0-rc.1.zip"
+              ],
+              "patches": [
+                "@@rules_go~0.42.0//third_party:com_github_golang_mock-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ],
+              "sha256": "5359c78b0c1649cf7beb3b48ff8b1d1aaf0243b22ea4789aba94805280075d8e",
+              "strip_prefix": "mock-1.7.0-rc.1"
+            }
+          },
+          "org_golang_x_sys": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_go~0.42.0~non_module_dependencies~org_golang_x_sys",
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/sys/archive/refs/tags/v0.12.0.zip",
+                "https://github.com/golang/sys/archive/refs/tags/v0.12.0.zip"
+              ],
+              "sha256": "229b079d23d18f5b1a0c46335020cddc6e5d543da2dae6e45b59d84b5d074e3a",
+              "strip_prefix": "sys-0.12.0",
+              "patches": [
+                "@@rules_go~0.42.0//third_party:org_golang_x_sys-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
             }
           }
         }

--- a/example/WORKSPACE.bazel
+++ b/example/WORKSPACE.bazel
@@ -206,6 +206,10 @@ load("@aspect_rules_lint//lint:ruff.bzl", "fetch_ruff")
 
 fetch_ruff()
 
+load("@aspect_rules_lint//lint:golangci-lint.bzl", "fetch_golangci_lint")
+
+fetch_golangci_lint()
+
 load("@aspect_rules_lint//lint:shellcheck.bzl", "fetch_shellcheck")
 
 fetch_shellcheck()

--- a/example/WORKSPACE.bzlmod
+++ b/example/WORKSPACE.bzlmod
@@ -31,6 +31,10 @@ fetch_swiftformat()
 
 fetch_ruff()
 
+load("@aspect_rules_lint//lint:golangci-lint.bzl", "fetch_golangci_lint")
+
+fetch_golangci_lint()
+
 load("@aspect_rules_lint//lint:shellcheck.bzl", "fetch_shellcheck")
 
 fetch_shellcheck()

--- a/example/lint.sh
+++ b/example/lint.sh
@@ -21,7 +21,7 @@ filter='.namedSetOfFiles | values | .files[] | ((.pathPrefix | join("/")) + "/" 
 
 # NB: perhaps --remote_download_toplevel is needed as well with remote execution?
 args=(
-	"--aspects=$(echo //tools:lint.bzl%{buf,eslint,flake8,pmd,ruff,shellcheck} | tr ' ' ',')"
+	"--aspects=$(echo //tools:lint.bzl%{buf,eslint,flake8,pmd,ruff,shellcheck,golangci_lint} | tr ' ' ',')"
 	"--build_event_json_file=$buildevents"
 )
 report_args=(
@@ -50,7 +50,7 @@ fi
 if [ $1 == "--dry-run" ]; then
 	fix="print"
 	shift
-fi 
+fi
 
 # Produce report files
 bazel build ${args[@]} ${report_args[@]} $@

--- a/example/src/BUILD.bazel
+++ b/example/src/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -31,4 +32,9 @@ java_library(
 sh_library(
     name = "hello_shell",
     srcs = ["hello.sh"],
+)
+
+go_binary(
+    name = "hello_go",
+    srcs = ["hello.go"],
 )

--- a/example/src/hello.go
+++ b/example/src/hello.go
@@ -9,5 +9,6 @@ const (
 )
 
 func main() {
-	fmt.Printf("Hello %s\n", w)
+	hello := fmt.Sprintf("Hello %s\n", w)
+	fmt.Printf(hello)
 }

--- a/example/src/hello.go
+++ b/example/src/hello.go
@@ -1,6 +1,8 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+)
 
 const (
 	w = "world"

--- a/example/test/lint_test.bats
+++ b/example/test/lint_test.bats
@@ -27,6 +27,9 @@ EOF
 
     # Buf
     assert_output --partial 'src/file.proto:1:1:Import "src/unused.proto" is unused.'
+
+    # Golangci-lint
+    assert_output --partial 'src/hello.go:13:2: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)'
 }
 
 @test "should produce reports" {

--- a/example/tools/BUILD
+++ b/example/tools/BUILD
@@ -5,8 +5,8 @@ we don't want to trigger eager fetches of these for builds that don't want to ru
 """
 
 load("@aspect_rules_lint//format:defs.bzl", "multi_formatter_binary")
-load("@aspect_rules_lint//lint:golangci-lint.bzl", "golangci_lint_binary")
 load("@aspect_rules_lint//lint:shellcheck.bzl", "shellcheck_binary")
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")
 load("@npm//:prettier/package_json.bzl", prettier = "bin")
 load("@rules_java//java:defs.bzl", "java_binary")
@@ -113,7 +113,18 @@ java_binary(
     runtime_deps = ["@net_sourceforge_pmd"],
 )
 
-golangci_lint_binary(name = "golangci_lint")
+native_binary(
+    name = "golangci_lint",
+    src = select(
+        {
+            "@bazel_tools//src/conditions:linux_x86_64": "@golangci_lint_linux_x86_64//:golangci-lint",
+            "@bazel_tools//src/conditions:linux_aarch64": "@golangci_lint_linux_aarch64//:golangci-lint",
+            "@bazel_tools//src/conditions:darwin_x86_64": "@golangci_lint_macos_x86_64//:golangci-lint",
+            "@bazel_tools//src/conditions:darwin_arm64": "@golangci_lint_macos_aarch64//:golangci-lint",
+        },
+    ),
+    out = "golangci-lint",
+)
 
 # bazel run :shellcheck -- --help
 shellcheck_binary(name = "shellcheck")
@@ -132,6 +143,6 @@ multi_formatter_binary(
     sh = ":shfmt",
     sql = ":prettier",
     starlark = "@buildifier_prebuilt//:buildifier",
-    swift = ":swiftformat",
+    #swift = ":swiftformat",
     terraform = ":terraform",
 )

--- a/example/tools/BUILD
+++ b/example/tools/BUILD
@@ -143,6 +143,6 @@ multi_formatter_binary(
     sh = ":shfmt",
     sql = ":prettier",
     starlark = "@buildifier_prebuilt//:buildifier",
-    #swift = ":swiftformat",
+    swift = ":swiftformat",
     terraform = ":terraform",
 )

--- a/example/tools/BUILD
+++ b/example/tools/BUILD
@@ -5,6 +5,7 @@ we don't want to trigger eager fetches of these for builds that don't want to ru
 """
 
 load("@aspect_rules_lint//format:defs.bzl", "multi_formatter_binary")
+load("@aspect_rules_lint//lint:golangci-lint.bzl", "golangci_lint_binary")
 load("@aspect_rules_lint//lint:shellcheck.bzl", "shellcheck_binary")
 load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")
 load("@npm//:prettier/package_json.bzl", prettier = "bin")
@@ -111,6 +112,8 @@ java_binary(
     main_class = "net.sourceforge.pmd.PMD",
     runtime_deps = ["@net_sourceforge_pmd"],
 )
+
+golangci_lint_binary(name = "golangci_lint")
 
 # bazel run :shellcheck -- --help
 shellcheck_binary(name = "shellcheck")

--- a/example/tools/lint.bzl
+++ b/example/tools/lint.bzl
@@ -3,6 +3,7 @@
 load("@aspect_rules_lint//lint:buf.bzl", "buf_lint_aspect")
 load("@aspect_rules_lint//lint:eslint.bzl", "eslint_aspect")
 load("@aspect_rules_lint//lint:flake8.bzl", "flake8_aspect")
+load("@aspect_rules_lint//lint:golangci-lint.bzl", "golangci_lint_aspect")
 load("@aspect_rules_lint//lint:lint_test.bzl", "make_lint_test")
 load("@aspect_rules_lint//lint:pmd.bzl", "pmd_aspect")
 load("@aspect_rules_lint//lint:ruff.bzl", "ruff_aspect")
@@ -52,3 +53,10 @@ shellcheck = shellcheck_aspect(
 )
 
 shellcheck_test = make_lint_test(aspect = shellcheck)
+
+golangci_lint = golangci_lint_aspect(
+    binary = "@@//tools:golangci_lint",
+    config = "@@//:.golangci.yaml",
+)
+
+golangci_lint_test = make_lint_test(aspect = golangci_lint)

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -101,6 +101,19 @@ bzl_library(
 )
 
 bzl_library(
+    name = "golangci-lint",
+    srcs = ["golangci-lint.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lint/private:lint_aspect",
+        "@bazel_skylib//rules:native_binary",
+        "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "@bazel_tools//tools/build_defs/repo:utils.bzl",
+        "@io_bazel_rules_go//go:def",
+    ],
+)
+
+bzl_library(
     name = "shellcheck",
     srcs = ["shellcheck.bzl"],
     visibility = ["//visibility:public"],

--- a/lint/golangci-lint.bzl
+++ b/lint/golangci-lint.bzl
@@ -10,7 +10,6 @@ golangci_lint = golangci_lint_aspect(
 ```
 """
 
-load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_bazel_rules_go//go:def.bzl", "go_context")
 load("//lint/private:lint_aspect.bzl", "report_file")
@@ -95,23 +94,6 @@ def golangci_lint_aspect(binary, config):
             ),
         },
         toolchains = ["@io_bazel_rules_go//go:toolchain"],
-    )
-
-def golangci_lint_binary(name):
-    """Wrapper around native_binary to select the correct golangci-lint executable for the execution platform."""
-    native_binary(
-        name = name,
-        src = select(
-            {
-                "@bazel_tools//src/conditions:linux_x86_64": "@golangci_lint_linux_x86_64//:golangci-lint",
-                "@bazel_tools//src/conditions:linux_aarch64": "@golangci_lint_linux_aarch64//:golangci-lint",
-                "@bazel_tools//src/conditions:darwin_x86_64": "@golangci_lint_macos_x86_64//:golangci-lint",
-                "@bazel_tools//src/conditions:darwin_arm64": "@golangci_lint_macos_aarch64//:golangci-lint",
-            },
-            no_match_error = "golangci-lint hasn't been fetched for your platform",
-        ),
-        out = "golangci-lint",
-        visibility = ["//visibility:public"],
     )
 
 # buildifier: disable=function-docstring

--- a/lint/golangci-lint.bzl
+++ b/lint/golangci-lint.bzl
@@ -96,33 +96,39 @@ def golangci_lint_aspect(binary, config):
         toolchains = ["@io_bazel_rules_go//go:toolchain"],
     )
 
-# buildifier: disable=function-docstring
-def fetch_golangci_lint():
+def fetch_golangci_lint(version = "1.55.2"):
+    """Naive macro that fetches a specific version of the golangci-lint from GitHub releases, for commonly-used platforms
+
+    Args:
+        version: must be the default value. In the future this could be honored when we support multiple versions.
+    """
+    if version != "1.55.2":
+        fail("Only a single version of golangci-lint is currently mirrored. Please file an issue if you need a different version.")
     http_archive(
         name = "golangci_lint_linux_x86_64",
         build_file_content = "exports_files([\"golangci-lint\"])",
-        strip_prefix = "golangci-lint-1.55.2-linux-amd64",
+        strip_prefix = "golangci-lint-{}-linux-amd64".format(version),
         sha256 = "ca21c961a33be3bc15e4292dc40c98c8dcc5463a7b6768a3afc123761630c09c",
-        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-linux-amd64.tar.gz"],
+        urls = ["https://github.com/golangci/golangci-lint/releases/download/v{0}/golangci-lint-{0}-linux-amd64.tar.gz".format(version)],
     )
     http_archive(
         name = "golangci_lint_linux_aarch64",
         build_file_content = "exports_files([\"golangci-lint\"])",
-        strip_prefix = "golangci-lint-1.55.2-linux-arm64",
+        strip_prefix = "golangci-lint-{}-linux-arm64".format(version),
         sha256 = "8eb0cee9b1dbf0eaa49871798c7f8a5b35f2960c52d776a5f31eb7d886b92746",
-        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-linux-arm64.tar.gz"],
+        urls = ["https://github.com/golangci/golangci-lint/releases/download/v{0}/golangci-lint-{0}-linux-arm64.tar.gz".format(version)],
     )
     http_archive(
         name = "golangci_lint_macos_x86_64",
         build_file_content = "exports_files([\"golangci-lint\"])",
-        strip_prefix = "golangci-lint-1.55.2-darwin-amd64",
+        strip_prefix = "golangci-lint-{}-darwin-amd64".format(version),
         sha256 = "632e96e6d5294fbbe7b2c410a49c8fa01c60712a0af85a567de85bcc1623ea21",
-        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-darwin-amd64.tar.gz"],
+        urls = ["https://github.com/golangci/golangci-lint/releases/download/v{0}/golangci-lint-{0}-darwin-amd64.tar.gz".format(version)],
     )
     http_archive(
         name = "golangci_lint_macos_aarch64",
         build_file_content = "exports_files([\"golangci-lint\"])",
-        strip_prefix = "golangci-lint-1.55.2-darwin-arm64",
+        strip_prefix = "golangci-lint-{}-darwin-arm64".format(version),
         sha256 = "234463f059249f82045824afdcdd5db5682d0593052f58f6a3039a0a1c3899f6",
-        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-darwin-arm64.tar.gz"],
+        urls = ["https://github.com/golangci/golangci-lint/releases/download/v{0}/golangci-lint-{0}-darwin-arm64.tar.gz".format(version)],
     )

--- a/lint/golangci-lint.bzl
+++ b/lint/golangci-lint.bzl
@@ -1,0 +1,146 @@
+"""API for declaring a golangci-lint lint aspect that visits go_library, go_test, and go_binary rules.
+
+```
+load("@aspect_rules_lint//lint:golangci-lint.bzl", "golangci_lint_aspect")
+
+golangci_lint = golangci_lint_aspect(
+    binary = "@@//tools:golangci-lint",
+    config = "@@//:.golangci.yaml",
+)
+```
+"""
+
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@io_bazel_rules_go//go:def.bzl", "go_context")
+load("//lint/private:lint_aspect.bzl", "report_file")
+
+_MNEMONIC = "golangcilint"
+
+def golangci_lint_action(ctx, executable, srcs, config, report, use_exit_code = False):
+    """Run golangci-lint as an action under Bazel.
+
+    Based on https://github.com/golangci/golangci-lint
+
+    Args:
+        ctx: Bazel Rule or Aspect evaluation context
+        executable: label of the the golangci-lint program
+        srcs: golang files to be linted
+        config: label of the .golangci.yaml file
+        report: output file to generate
+        use_exit_code: whether to fail the build when a lint violation is reported
+    """
+
+    # golangci-lint calls out to Go, so we need the go context
+    go = go_context(ctx)
+    inputs = srcs + [config] + go.sdk_files
+    args = ctx.actions.args()
+    args.add_all(srcs)
+
+    command = """#!/usr/bin/env bash
+        export GOROOT=$(cd "$(dirname {go_tool})/.."; pwd)
+        export GOPATH=$GOROOT
+        export GOCACHE="$(mktemp -d)"
+        export PATH="$GOPATH/bin:$PATH"
+        GOLANGCI_LINT_CACHE=$(pwd)/.cache {golangci_lint} run --config={config} $@"""
+
+    if use_exit_code:
+        command += " && touch {report}"
+    else:
+        command += " 2>{report} || true"
+
+    ctx.actions.run_shell(
+        inputs = inputs,
+        outputs = [report],
+        command = command.format(
+            golangci_lint = executable.path,
+            report = report.path,
+            config = config.path,
+            go_tool = ctx.toolchains["@io_bazel_rules_go//go:toolchain"].sdk.go.path,
+        ),
+        env = go.env,
+        arguments = [args],
+        mnemonic = _MNEMONIC,
+        tools = [executable],
+    )
+
+# buildifier: disable=function-docstring
+def _golangci_lint_aspect_impl(target, ctx):
+    if ctx.rule.kind not in ["go_binary", "go_library", "go_test"]:
+        return []
+
+    report, info = report_file(_MNEMONIC, target, ctx)
+    golangci_lint_action(ctx, ctx.executable._golangci_lint, ctx.rule.files.srcs, ctx.file._config_file, report, ctx.attr.fail_on_violation)
+    return [info]
+
+def golangci_lint_aspect(binary, config):
+    """A factory function to create a linter aspect.
+
+    Attrs:
+        binary: a golangci-lint executable.
+        config: the .golangci.yaml file
+    """
+    return aspect(
+        implementation = _golangci_lint_aspect_impl,
+        attrs = {
+            "fail_on_violation": attr.bool(),
+            "_golangci_lint": attr.label(
+                default = binary,
+                executable = True,
+                cfg = "exec",
+            ),
+            "_config_file": attr.label(
+                default = config,
+                allow_single_file = True,
+            ),
+        },
+        toolchains = ["@io_bazel_rules_go//go:toolchain"],
+    )
+
+def golangci_lint_binary(name):
+    """Wrapper around native_binary to select the correct golangci-lint executable for the execution platform."""
+    native_binary(
+        name = name,
+        src = select(
+            {
+                "@bazel_tools//src/conditions:linux_x86_64": "@golangci_lint_linux_x86_64//:golangci-lint",
+                "@bazel_tools//src/conditions:linux_aarch64": "@golangci_lint_linux_aarch64//:golangci-lint",
+                "@bazel_tools//src/conditions:darwin_x86_64": "@golangci_lint_macos_x86_64//:golangci-lint",
+                "@bazel_tools//src/conditions:darwin_arm64": "@golangci_lint_macos_aarch64//:golangci-lint",
+            },
+            no_match_error = "golangci-lint hasn't been fetched for your platform",
+        ),
+        out = "golangci-lint",
+        visibility = ["//visibility:public"],
+    )
+
+# buildifier: disable=function-docstring
+def fetch_golangci_lint():
+    http_archive(
+        name = "golangci_lint_linux_x86_64",
+        build_file_content = "exports_files([\"golangci-lint\"])",
+        strip_prefix = "golangci-lint-1.55.2-linux-amd64",
+        sha256 = "ca21c961a33be3bc15e4292dc40c98c8dcc5463a7b6768a3afc123761630c09c",
+        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-linux-amd64.tar.gz"],
+    )
+    http_archive(
+        name = "golangci_lint_linux_aarch64",
+        build_file_content = "exports_files([\"golangci-lint\"])",
+        strip_prefix = "golangci-lint-1.55.2-linux-arm64",
+        sha256 = "8eb0cee9b1dbf0eaa49871798c7f8a5b35f2960c52d776a5f31eb7d886b92746",
+        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-linux-arm64.tar.gz"],
+    )
+    http_archive(
+        name = "golangci_lint_macos_x86_64",
+        build_file_content = "exports_files([\"golangci-lint\"])",
+        strip_prefix = "golangci-lint-1.55.2-darwin-amd64",
+        sha256 = "632e96e6d5294fbbe7b2c410a49c8fa01c60712a0af85a567de85bcc1623ea21",
+        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-darwin-amd64.tar.gz"],
+    )
+    http_archive(
+        name = "golangci_lint_macos_aarch64",
+        build_file_content = "exports_files([\"golangci-lint\"])",
+        strip_prefix = "golangci-lint-1.55.2-darwin-arm64",
+        sha256 = "234463f059249f82045824afdcdd5db5682d0593052f58f6a3039a0a1c3899f6",
+        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-darwin-arm64.tar.gz"],
+    )


### PR DESCRIPTION
### Type of change
- New feature or functionality (change which adds functionality)

Fixes #82 

### Test plan

- New test cases added
- Manual testing; please provide instructions so we can reproduce: `(cd example && ./lint.sh //...)`


### Notes
Golang-ci lint relies on the go binary being in the PATH. I had to add rules_go as a dependency in the main repo for passing the toolchain type. I am not sure we can do this without that dependency.