### PR TITLE
Enable shellcheck aspect for sh_binary

### DIFF
--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -78,7 +78,7 @@ def shellcheck_action(ctx, executable, srcs, config, report, use_exit_code = Fal
 
 # buildifier: disable=function-docstring
 def _shellcheck_aspect_impl(target, ctx):
-    if ctx.rule.kind not in ["sh_library"]:
+    if ctx.rule.kind not in ["sh_binary", "sh_library"]:
         return []
 
     report, info = report_file(_MNEMONIC, target, ctx)

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -78,7 +78,7 @@ def shellcheck_action(ctx, executable, srcs, config, report, use_exit_code = Fal
 
 # buildifier: disable=function-docstring
 def _shellcheck_aspect_impl(target, ctx):
-    if ctx.rule.kind not in ["sh_binary", "sh_library", "sh_test"]:
+    if ctx.rule.kind not in ["sh_binary", "sh_library"]:
         return []
 
     report, info = report_file(_MNEMONIC, target, ctx)

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -78,7 +78,7 @@ def shellcheck_action(ctx, executable, srcs, config, report, use_exit_code = Fal
 
 # buildifier: disable=function-docstring
 def _shellcheck_aspect_impl(target, ctx):
-    if ctx.rule.kind not in ["sh_binary", "sh_library"]:
+    if ctx.rule.kind not in ["sh_binary", "sh_library", "sh_test"]:
         return []
 
     report, info = report_file(_MNEMONIC, target, ctx)


### PR DESCRIPTION
### Type of change
- New feature or functionality (change which adds functionality)

**For changes visible to end-users**
If the user has srcs in an sh_binary with shellcheck violations then it will a breaking change for them.
I don't think it deserves a major version bump tho.

### Test plan

- Manual testing; please provide instructions so we can reproduce: Add an sh_binary and see that their srcs are linted.
