### PR TITLE
golangci-lint: Capture results from stdout rather than stderr

### DIFF
--- a/lint/golangci-lint.bzl
+++ b/lint/golangci-lint.bzl
@@ -46,7 +46,7 @@ def golangci_lint_action(ctx, executable, srcs, config, report, use_exit_code = 
     if use_exit_code:
         command += " && touch {report}"
     else:
-        command += " 2>{report} || true"
+        command += " >{report} || true"
 
     ctx.actions.run_shell(
         inputs = inputs,


### PR DESCRIPTION
Without this, errors don't end up in the report file and are thus only displayed on the first run.

Suggested release note: golangci-lint: Fix capturing of output to report file from stdout rather than stderr

You can verify that this works better by repeatedly running "./lint.sh src:hello_go" in the example directory. Without this fix, only the first run yields the lint output and subsequent ones give empty output:

```console

dev-vm-db6l1 ~/src/rules_lint/example% ./lint.sh src:hello_go
INFO: Analyzed target //src:hello_go (242 packages loaded, 16606 targets configured).
INFO: From golangcilint src/golangcilint.hello_go.aspect_rules_lint.report:
../../bazel-source-roots/0/src/hello.go:13:2: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
	fmt.Printf(hello)
	^
INFO: Found 1 target...
Aspect //tools:lint.bzl%golangci_lint of //src:hello_go up-to-date:
  bazel-bin/src/golangcilint.hello_go.aspect_rules_lint.report
INFO: Elapsed time: 4.967s, Critical Path: 4.27s
INFO: 3 processes: 2 internal, 1 linux-sandbox.
INFO: Build completed successfully, 3 total actions
INFO: Build Event Protocol files produced successfully.
dev-vm-db6l1 ~/src/rules_lint/example% ./lint.sh src:hello_go
INFO: Analyzed target //src:hello_go (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Aspect //tools:lint.bzl%golangci_lint of //src:hello_go up-to-date:
  bazel-bin/src/golangcilint.hello_go.aspect_rules_lint.report
INFO: Elapsed time: 0.129s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build Event Protocol files produced successfully.
```

