### PR TITLE
fix early glob expansion, starlark patterns

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -62,7 +62,7 @@ function ls-files {
 
         # TODO: determine which staged changes we should format; avoid formatting unstaged changes
         # TODO: try to format only modified regions of the file (where supported)
-        git ls-files --cached --modified --other --exclude-standard ${patterns[@]} | {
+        git ls-files --cached --modified --other --exclude-standard "${patterns[@]}" | {
           grep -vE "^$(git ls-files --deleted)$" || true;
         }
     else

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -45,7 +45,7 @@ function ls-files {
       'SQL') patterns=('*.sql' '*.cql' '*.ddl' '*.inc' '*.mysql' '*.prc' '*.tab' '*.udf' '*.viw') ;;
       'Scala') patterns=('*.scala' '*.kojo' '*.sbt' '*.sc') ;;
       'Shell') patterns=('.bash_aliases' '.bash_functions' '.bash_history' '.bash_logout' '.bash_profile' '.bashrc' '.cshrc' '.flaskenv' '.kshrc' '.login' '.profile' '.zlogin' '.zlogout' '.zprofile' '.zshenv' '.zshrc' '9fs' 'PKGBUILD' 'bash_aliases' 'bash_logout' 'bash_profile' 'bashrc' 'cshrc' 'gradlew' 'kshrc' 'login' 'man' 'profile' 'zlogin' 'zlogout' 'zprofile' 'zshenv' 'zshrc' '*.sh' '*.bash' '*.bats' '*.cgi' '*.command' '*.fcgi' '*.ksh' '*.sh.in' '*.tmux' '*.tool' '*.trigger' '*.zsh' '*.zsh-theme') ;;
-      'Starlark') patterns=('BUCK' 'BUILD' 'BUILD.bazel' 'MODULE.bazel' 'Tiltfile' 'WORKSPACE' 'WORKSPACE.bazel' '*.bzl' '*.star') ;;
+      'Starlark') patterns=('BUCK' '**/BUCK' 'BUILD' '**/BUILD' 'BUILD.bazel' '**/BUILD.bazel' 'MODULE.bazel' 'Tiltfile' '**/Tiltfile' 'WORKSPACE' 'WORKSPACE.bazel' '*.bzl' '*.star') ;;
       'Swift') patterns=('*.swift') ;;
       'TSX') patterns=('*.tsx') ;;
       'TypeScript') patterns=('*.ts' '*.cts' '*.mts') ;;


### PR DESCRIPTION
tl;dr this is a partial correction of #117 

Looks like the patterns in the reworked format.sh are not catching everything anymore, partially because of an unquoted bash array expansion, and partially because the patterns are incomplete as written here.

This is an incomplete fix, so don't expect this to be merged exactly (don't have more time today), but at least wanted to get this reported and put up this fix for at least the part i'm concerned about

More work is probably needed for other languages, as the patterns look to be probably deficient in the same way the starlark patterns are
---

### Type of change

- Bug fix