### PR TITLE
fix filename pattern matching

### DIFF
--- a/format/private/filter.jq
+++ b/format/private/filter.jq
@@ -24,12 +24,12 @@ with_entries(select(.key | IN(
 
 # Convert values to filenames and extensions with star prefix
 | with_entries(.value = (
-    .value.filenames + (.value.extensions | map("*" + .))
+    .value.filenames + ( .value.filenames | [.[]? | "*/" + .] ) + (.value.extensions | map("*" + .))
 ))
 
 # Render each language as a line in a Bash case statement, e.g.
 # 'Jsonnet') patterns=('*.jsonnet' '*.libsonnet') ;;
-| to_entries | map(    
+| to_entries | map(
   "'" + .key + "') patterns=(" + (.value | map("'" + . + "'") | join(" ")) + ") ;;"
 )
 

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -34,18 +34,18 @@ function ls-files {
       'Go') patterns=('*.go') ;;
       'HCL') patterns=('*.hcl' '*.nomad' '*.tf' '*.tfvars' '*.workflow') ;;
       'HTML') patterns=('*.html' '*.hta' '*.htm' '*.html.hl' '*.inc' '*.xht' '*.xhtml') ;;
-      'JSON') patterns=('.all-contributorsrc' '.arcconfig' '.auto-changelog' '.c8rc' '.htmlhintrc' '.imgbotconfig' '.nycrc' '.tern-config' '.tern-project' '.watchmanconfig' 'Pipfile.lock' 'composer.lock' 'deno.lock' 'flake.lock' 'mcmod.info' '*.json' '*.4DForm' '*.4DProject' '*.avsc' '*.geojson' '*.gltf' '*.har' '*.ice' '*.JSON-tmLanguage' '*.jsonl' '*.mcmeta' '*.tfstate' '*.tfstate.backup' '*.topojson' '*.webapp' '*.webmanifest' '*.yy' '*.yyp') ;;
+      'JSON') patterns=('.all-contributorsrc' '.arcconfig' '.auto-changelog' '.c8rc' '.htmlhintrc' '.imgbotconfig' '.nycrc' '.tern-config' '.tern-project' '.watchmanconfig' 'Pipfile.lock' 'composer.lock' 'deno.lock' 'flake.lock' 'mcmod.info' '*/.all-contributorsrc' '*/.arcconfig' '*/.auto-changelog' '*/.c8rc' '*/.htmlhintrc' '*/.imgbotconfig' '*/.nycrc' '*/.tern-config' '*/.tern-project' '*/.watchmanconfig' '*/Pipfile.lock' '*/composer.lock' '*/deno.lock' '*/flake.lock' '*/mcmod.info' '*.json' '*.4DForm' '*.4DProject' '*.avsc' '*.geojson' '*.gltf' '*.har' '*.ice' '*.JSON-tmLanguage' '*.jsonl' '*.mcmeta' '*.tfstate' '*.tfstate.backup' '*.topojson' '*.webapp' '*.webmanifest' '*.yy' '*.yyp') ;;
       'Java') patterns=('*.java' '*.jav' '*.jsh') ;;
-      'JavaScript') patterns=('Jakefile' '*.js' '*._js' '*.bones' '*.cjs' '*.es' '*.es6' '*.frag' '*.gs' '*.jake' '*.javascript' '*.jsb' '*.jscad' '*.jsfl' '*.jslib' '*.jsm' '*.jspre' '*.jss' '*.jsx' '*.mjs' '*.njs' '*.pac' '*.sjs' '*.ssjs' '*.xsjs' '*.xsjslib') ;;
+      'JavaScript') patterns=('Jakefile' '*/Jakefile' '*.js' '*._js' '*.bones' '*.cjs' '*.es' '*.es6' '*.frag' '*.gs' '*.jake' '*.javascript' '*.jsb' '*.jscad' '*.jsfl' '*.jslib' '*.jsm' '*.jspre' '*.jss' '*.jsx' '*.mjs' '*.njs' '*.pac' '*.sjs' '*.ssjs' '*.xsjs' '*.xsjslib') ;;
       'Jsonnet') patterns=('*.jsonnet' '*.libsonnet') ;;
       'Kotlin') patterns=('*.kt' '*.ktm' '*.kts') ;;
-      'Markdown') patterns=('contents.lr' '*.md' '*.livemd' '*.markdown' '*.mdown' '*.mdwn' '*.mkd' '*.mkdn' '*.mkdown' '*.ronn' '*.scd' '*.workbook') ;;
+      'Markdown') patterns=('contents.lr' '*/contents.lr' '*.md' '*.livemd' '*.markdown' '*.mdown' '*.mdwn' '*.mkd' '*.mkdn' '*.mkdown' '*.ronn' '*.scd' '*.workbook') ;;
       'Protocol Buffer') patterns=('*.proto') ;;
-      'Python') patterns=('.gclient' 'DEPS' 'SConscript' 'SConstruct' 'wscript' '*.py' '*.cgi' '*.fcgi' '*.gyp' '*.gypi' '*.lmi' '*.py3' '*.pyde' '*.pyi' '*.pyp' '*.pyt' '*.pyw' '*.rpy' '*.spec' '*.tac' '*.wsgi' '*.xpy') ;;
+      'Python') patterns=('.gclient' 'DEPS' 'SConscript' 'SConstruct' 'wscript' '*/.gclient' '*/DEPS' '*/SConscript' '*/SConstruct' '*/wscript' '*.py' '*.cgi' '*.fcgi' '*.gyp' '*.gypi' '*.lmi' '*.py3' '*.pyde' '*.pyi' '*.pyp' '*.pyt' '*.pyw' '*.rpy' '*.spec' '*.tac' '*.wsgi' '*.xpy') ;;
       'SQL') patterns=('*.sql' '*.cql' '*.ddl' '*.inc' '*.mysql' '*.prc' '*.tab' '*.udf' '*.viw') ;;
       'Scala') patterns=('*.scala' '*.kojo' '*.sbt' '*.sc') ;;
-      'Shell') patterns=('.bash_aliases' '.bash_functions' '.bash_history' '.bash_logout' '.bash_profile' '.bashrc' '.cshrc' '.flaskenv' '.kshrc' '.login' '.profile' '.zlogin' '.zlogout' '.zprofile' '.zshenv' '.zshrc' '9fs' 'PKGBUILD' 'bash_aliases' 'bash_logout' 'bash_profile' 'bashrc' 'cshrc' 'gradlew' 'kshrc' 'login' 'man' 'profile' 'zlogin' 'zlogout' 'zprofile' 'zshenv' 'zshrc' '*.sh' '*.bash' '*.bats' '*.cgi' '*.command' '*.fcgi' '*.ksh' '*.sh.in' '*.tmux' '*.tool' '*.trigger' '*.zsh' '*.zsh-theme') ;;
-      'Starlark') patterns=('BUCK' 'BUILD' 'BUILD.bazel' 'MODULE.bazel' 'Tiltfile' 'WORKSPACE' 'WORKSPACE.bazel' '*.bzl' '*.star') ;;
+      'Shell') patterns=('.bash_aliases' '.bash_functions' '.bash_history' '.bash_logout' '.bash_profile' '.bashrc' '.cshrc' '.flaskenv' '.kshrc' '.login' '.profile' '.zlogin' '.zlogout' '.zprofile' '.zshenv' '.zshrc' '9fs' 'PKGBUILD' 'bash_aliases' 'bash_logout' 'bash_profile' 'bashrc' 'cshrc' 'gradlew' 'kshrc' 'login' 'man' 'profile' 'zlogin' 'zlogout' 'zprofile' 'zshenv' 'zshrc' '*/.bash_aliases' '*/.bash_functions' '*/.bash_history' '*/.bash_logout' '*/.bash_profile' '*/.bashrc' '*/.cshrc' '*/.flaskenv' '*/.kshrc' '*/.login' '*/.profile' '*/.zlogin' '*/.zlogout' '*/.zprofile' '*/.zshenv' '*/.zshrc' '*/9fs' '*/PKGBUILD' '*/bash_aliases' '*/bash_logout' '*/bash_profile' '*/bashrc' '*/cshrc' '*/gradlew' '*/kshrc' '*/login' '*/man' '*/profile' '*/zlogin' '*/zlogout' '*/zprofile' '*/zshenv' '*/zshrc' '*.sh' '*.bash' '*.bats' '*.cgi' '*.command' '*.fcgi' '*.ksh' '*.sh.in' '*.tmux' '*.tool' '*.trigger' '*.zsh' '*.zsh-theme') ;;
+      'Starlark') patterns=('BUCK' 'BUILD' 'BUILD.bazel' 'MODULE.bazel' 'Tiltfile' 'WORKSPACE' 'WORKSPACE.bazel' '*/BUCK' '*/BUILD' '*/BUILD.bazel' '*/MODULE.bazel' '*/Tiltfile' '*/WORKSPACE' '*/WORKSPACE.bazel' '*.bzl' '*.star') ;;
       'Swift') patterns=('*.swift') ;;
       'TSX') patterns=('*.tsx') ;;
       'TypeScript') patterns=('*.ts' '*.cts' '*.mts') ;;
@@ -54,7 +54,7 @@ function ls-files {
         exit 1
         ;;
     esac
-    
+
     if [ "$#" -eq 0 ]; then
         # When the formatter is run with no arguments, we run over "all files in the repo".
         # However, we want to ignore anything that is in .gitignore, is marked for delete, etc.
@@ -62,7 +62,7 @@ function ls-files {
 
         # TODO: determine which staged changes we should format; avoid formatting unstaged changes
         # TODO: try to format only modified regions of the file (where supported)
-        git ls-files --cached --modified --other --exclude-standard ${patterns[@]} | {
+        git ls-files --cached --modified --other --exclude-standard "${patterns[@]}" | {
           grep -vE "^$(git ls-files --deleted)$" || true;
         }
     else

--- a/format/private/mirror_linguist_languages.sh
+++ b/format/private/mirror_linguist_languages.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Generate a snippet of bash code to help us detect languages based on filenames
-raw=$(mktemp --suffix=.yml)
-json=$(mktemp --suffix=.json)
+raw=$(mktemp)
 wget -O "$raw" https://raw.githubusercontent.com/github-linguist/linguist/master/lib/linguist/languages.yml
 # We could do this entirely in yq, but the author happens to already know JQ :shrug:
-yq -o=json '.' "$raw" | jq --from-file=filter.jq --raw-output
+yq '.' "$raw" | jq --from-file filter.jq --raw-output


### PR DESCRIPTION
git ls-files seems to match against filename strings exactly, and doesn't use the same logic as e.g. gitignore. this means that to match files by exact filename below the root, we need a */ at the start of the pattern to match more than files strictly at the root of the tree. these prefixed patterns however miss the root, so we need to include both forms.

additionally, the pattern array needs to be quoted to prevent the shell from doing glob expansion against any files in the current directory.

Fixes #117 and #122.

---

### Type of change

- Bug fix (change which fixes an issue)