### PR TITLE
Disabled globbing in format.sh

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -22,6 +22,10 @@ function on_exit {
 
 trap on_exit EXIT
 
+# Disable globbing, disabling globbing will allow formatting even if there is a match at the top level
+# See https://github.com/aspect-build/rules_lint/issues/122
+set -o noglob
+
 # ls-files <language> [<file>...]
 function ls-files {
     language="$1" && shift;


### PR DESCRIPTION
By disabling bash globbing patterns like *.md are passed directly to git commands. Without disabling globbing *.md would be expanded to README.md before being passed to git. This fixes an issue where having a README.md in the top level would prevent recursive formatting.

See issue https://github.com/aspect-build/rules_lint/issues/122

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:
Tested in a repo that mirrors the repo described in https://github.com/aspect-build/rules_lint/issues/122 and was able to recursively find *.md files.
