### PR TITLE
golangci-lint: Handle empty srcs list

### DIFF
--- a/lint/golangci-lint.bzl
+++ b/lint/golangci-lint.bzl
@@ -69,7 +69,12 @@ def _golangci_lint_aspect_impl(target, ctx):
         return []
 
     report, info = report_file(_MNEMONIC, target, ctx)
-    golangci_lint_action(ctx, ctx.executable._golangci_lint, filter_srcs(ctx.rule), ctx.file._config_file, report, ctx.attr.fail_on_violation)
+
+    srcs = filter_srcs(ctx.rule)
+    if not srcs:
+        return []
+
+    golangci_lint_action(ctx, ctx.executable._golangci_lint, srcs, ctx.file._config_file, report, ctx.attr.fail_on_violation)
     return [info]
 
 def golangci_lint_aspect(binary, config):


### PR DESCRIPTION
A common pattern with go and blaze is to have go_library() targets that contain the source files and then trivial go_binary() targets that just wrap the matching library, without any other direct sources.

"golangci-lint run" fails on these binaries because it doesn't like an empty list of sources. It also generally seems pointless to run if we're not passing any files.