### PR TITLE
Add rustfmt support

### DIFF
--- a/example/MODULE.bazel
+++ b/example/MODULE.bazel
@@ -12,6 +12,7 @@ bazel_dep(name = "rules_jvm_external", version = "4.5")
 bazel_dep(name = "rules_go", version = "0.42.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
 bazel_dep(name = "rules_python", version = "0.26.0")
+bazel_dep(name = "rules_rust", version = "0.38.0")
 bazel_dep(name = "buildifier_prebuilt", version = "6.3.3")
 bazel_dep(name = "platforms", version = "0.0.7")
 
@@ -85,6 +86,42 @@ use_repo(
     "maven",
     "unpinned_maven",
 )
+
+#### Rust ####
+
+RUST_VERSION = "1.75.0"
+
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+rust.toolchain(
+    edition = "2021",
+    versions = [RUST_VERSION],
+)
+
+# # We need to express that building Rust on darwin/aarch64 should use the toolchain
+# # for darwin/amd64. The bzlmod integration for rules_rust does not currently expose
+# # that functionality, so we have a small module extension to do this.
+# # This should be removed once the bzlmod integration in rules_rust matures sufficiently.
+# rust_repository_sets = use_extension("//build/bzlmod:rust.bzl", "rust_repository_sets")
+# rust_repository_sets.repo_set(
+#     name = "macos_x86_64",
+#     exec_triple = "aarch64-apple-darwin",
+#     extra_target_triples = ["x86_64-apple-darwin"],
+#     versions = [RUST_VERSION],
+# )
+# rust_repository_sets.repo_set(
+#     name = "linux_aarch64",
+#     exec_triple = "x86_64-unknown-linux-gnu",
+#     extra_target_triples = ["aarch64-unknown-linux-gnu"],
+#     versions = [RUST_VERSION],
+# )
+# use_repo(
+#     rust_repository_sets,
+#     "extra_rust_toolchains",
+# )
+
+# register_toolchains(
+#     "@extra_rust_toolchains//:all",
+# )
 
 buf = use_extension("@rules_buf//buf:extensions.bzl", "buf")
 use_repo(buf, "rules_buf_toolchains")

--- a/example/WORKSPACE.bazel
+++ b/example/WORKSPACE.bazel
@@ -196,6 +196,20 @@ load("@maven//:defs.bzl", "pinned_maven_install")
 
 pinned_maven_install()
 
+# To find additional information on this release or newer ones visit:
+# https://github.com/bazelbuild/rules_rust/releases
+http_archive(
+    name = "rules_rust",
+    sha256 = "36ab8f9facae745c9c9c1b33d225623d976e78f2cc3f729b7973d8c20934ab95",
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.31.0/rules_rust-v0.31.0.tar.gz"],
+)
+
+load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
+
+rules_rust_dependencies()
+
+rust_register_toolchains()
+
 #---SNIP--- Below here is re-used in the workspace snippet published on releases
 
 # Use whichever formatter binaries you need:

--- a/example/src/BUILD.bazel
+++ b/example/src/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -42,4 +43,9 @@ go_binary(
 cc_binary(
     name = "hello_cc",
     srcs = ["hello.cpp"],
+)
+
+rust_binary(
+    name = "hello_rust",
+    srcs = ["hello.rs"],
 )

--- a/example/src/hello.rs
+++ b/example/src/hello.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello World!");
+}

--- a/example/tools/BUILD
+++ b/example/tools/BUILD
@@ -11,6 +11,8 @@ load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")
 load("@npm//:prettier/package_json.bzl", prettier = "bin")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
+load("@rules_rust//rust:toolchain.bzl", "current_rustfmt_toolchain")
+load(":rustfmt.bzl", "rustfmt_binary")
 
 package(default_visibility = ["//:__subpackages__"])
 
@@ -92,6 +94,7 @@ alias(
         "@io_bazel_rules_go//go/platform:linux_arm64": "@com_github_mvdan_gofumpt_linux_arm64//file",
     }),
 )
+
 alias(
     name = "swiftformat",
     actual = select({
@@ -135,6 +138,17 @@ native_binary(
     out = "golangci-lint",
 )
 
+current_rustfmt_toolchain(
+    name = "rustfmt_current_toolchain",
+)
+
+rustfmt_binary(
+    name = "rustfmt",
+    toolchains = [
+        ":rustfmt_current_toolchain",
+    ],
+)
+
 # bazel run :shellcheck -- --help
 shellcheck_binary(name = "shellcheck")
 
@@ -150,6 +164,7 @@ multi_formatter_binary(
     markdown = ":prettier",
     protobuf = ":buf",
     python = ":ruff",
+    rust = ":rustfmt",
     scala = ":scalafmt",
     sh = ":shfmt",
     sql = ":prettier",

--- a/example/tools/rustfmt.bzl
+++ b/example/tools/rustfmt.bzl
@@ -1,0 +1,30 @@
+def rustfmt_binary_impl(ctx):
+    """Creates an executable target from the current rust toolchain."""
+    toolchain = ctx.toolchains[str(Label("@rules_rust//rust/rustfmt:toolchain_type"))]
+
+    out_file = ctx.actions.declare_file("{name}.rustfmt".format(name = ctx.attr.name))
+
+    script = """#!/usr/bin/env bash
+    {rustfmt} $@
+    """.format(rustfmt = toolchain.rustfmt.path)
+
+    ctx.actions.write(
+        output = out_file,
+        content = script,
+        is_executable = True,
+    )
+
+    return [
+        DefaultInfo(
+            executable = out_file,
+            runfiles = ctx.runfiles(transitive_files = toolchain.all_files),
+        ),
+    ]
+
+rustfmt_binary = rule(
+    implementation = rustfmt_binary_impl,
+    executable = True,
+    toolchains = [
+        str(Label("@rules_rust//rust/rustfmt:toolchain_type")),
+    ],
+)

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -265,7 +265,7 @@ files=$(ls-files Rust $@)
 bin=$(rlocation {{rustfmt}})
 if [ -n "$files" ] && [ -n "$bin" ]; then
   echo "Formatting Rust with rustfmt..."
-  echo "$files" | tr \\n \\0 | xargs -0 $bin
+  echo "$files" | tr \\n \\0 | xargs -0 $bin $rustfmtmode
 fi
 
 files=$(ls-files Shell $@)

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -42,6 +42,7 @@ function ls-files {
       'Markdown') patterns=('contents.lr' '*.md' '*.livemd' '*.markdown' '*.mdown' '*.mdwn' '*.mkd' '*.mkdn' '*.mkdown' '*.ronn' '*.scd' '*.workbook') ;;
       'Protocol Buffer') patterns=('*.proto') ;;
       'Python') patterns=('.gclient' 'DEPS' 'SConscript' 'SConstruct' 'wscript' '*.py' '*.cgi' '*.fcgi' '*.gyp' '*.gypi' '*.lmi' '*.py3' '*.pyde' '*.pyi' '*.pyp' '*.pyt' '*.pyw' '*.rpy' '*.spec' '*.tac' '*.wsgi' '*.xpy') ;;
+      'Rust') patterns=('*.rs') ;;
       'SQL') patterns=('*.sql' '*.cql' '*.ddl' '*.inc' '*.mysql' '*.prc' '*.tab' '*.udf' '*.viw') ;;
       'Scala') patterns=('*.scala' '*.kojo' '*.sbt' '*.sc') ;;
       'Shell') patterns=('.bash_aliases' '.bash_functions' '.bash_history' '.bash_logout' '.bash_profile' '.bashrc' '.cshrc' '.flaskenv' '.kshrc' '.login' '.profile' '.zlogin' '.zlogout' '.zprofile' '.zshenv' '.zshrc' '9fs' 'PKGBUILD' 'bash_aliases' 'bash_logout' 'bash_profile' 'bashrc' 'cshrc' 'gradlew' 'kshrc' 'login' 'man' 'profile' 'zlogin' 'zlogout' 'zprofile' 'zshenv' 'zshrc' '*.sh' '*.bash' '*.bats' '*.cgi' '*.command' '*.fcgi' '*.ksh' '*.sh.in' '*.tmux' '*.tool' '*.trigger' '*.zsh' '*.zsh-theme') ;;
@@ -54,7 +55,7 @@ function ls-files {
         exit 1
         ;;
     esac
-    
+
     if [ "$#" -eq 0 ]; then
         # When the formatter is run with no arguments, we run over "all files in the repo".
         # However, we want to ignore anything that is in .gitignore, is marked for delete, etc.
@@ -100,6 +101,7 @@ case "$mode" in
    bufmode="format -d --exit-code"
    tfmode="-check -diff"
    jsonnetmode="--test"
+   rustfmtmode="--write-mode=diff"
    scalamode="--test"
    clangformatmode="--style=file --fallback-style=none --dry-run"
    ;;
@@ -117,6 +119,7 @@ case "$mode" in
    bufmode="format -w"
    tfmode=""
    jsonnetmode="--in-place"
+   rustfmtmode="--write-mode=overwrite"
    scalamode=""
    clangformatmode="-style=file --fallback-style=none -i"
    ;;
@@ -256,6 +259,13 @@ bin=$(rlocation {{clang-format}})
 if [ -n "$files" ] && [ -n "$bin" ]; then
   echo "Formatting C/C++ with clang-format..."
   echo "$files" | tr \\n \\0 | xargs -0 $bin $clangformatmode
+fi
+
+files=$(ls-files Rust $@)
+bin=$(rlocation {{rustfmt}})
+if [ -n "$files" ] && [ -n "$bin" ]; then
+  echo "Formatting Rust with rustfmt..."
+  echo "$files" | tr \\n \\0 | xargs -0 $bin
 fi
 
 files=$(ls-files Shell $@)

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -42,7 +42,7 @@ function ls-files {
       'Markdown') patterns=('contents.lr' '*.md' '*.livemd' '*.markdown' '*.mdown' '*.mdwn' '*.mkd' '*.mkdn' '*.mkdown' '*.ronn' '*.scd' '*.workbook') ;;
       'Protocol Buffer') patterns=('*.proto') ;;
       'Python') patterns=('.gclient' 'DEPS' 'SConscript' 'SConstruct' 'wscript' '*.py' '*.cgi' '*.fcgi' '*.gyp' '*.gypi' '*.lmi' '*.py3' '*.pyde' '*.pyi' '*.pyp' '*.pyt' '*.pyw' '*.rpy' '*.spec' '*.tac' '*.wsgi' '*.xpy') ;;
-      'Rust') patterns=('*.rs') ;;
+      'Rust') patterns=('*.rs' '*.rs.in') ;;
       'SQL') patterns=('*.sql' '*.cql' '*.ddl' '*.inc' '*.mysql' '*.prc' '*.tab' '*.udf' '*.viw') ;;
       'Scala') patterns=('*.scala' '*.kojo' '*.sbt' '*.sc') ;;
       'Shell') patterns=('.bash_aliases' '.bash_functions' '.bash_history' '.bash_logout' '.bash_profile' '.bashrc' '.cshrc' '.flaskenv' '.kshrc' '.login' '.profile' '.zlogin' '.zlogout' '.zprofile' '.zshenv' '.zshrc' '9fs' 'PKGBUILD' 'bash_aliases' 'bash_logout' 'bash_profile' 'bashrc' 'cshrc' 'gradlew' 'kshrc' 'login' 'man' 'profile' 'zlogin' 'zlogout' 'zprofile' 'zshenv' 'zshrc' '*.sh' '*.bash' '*.bats' '*.cgi' '*.command' '*.fcgi' '*.ksh' '*.sh.in' '*.tmux' '*.tool' '*.trigger' '*.zsh' '*.zsh-theme') ;;

--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -15,6 +15,7 @@ TOOLS = {
     "scala": "scalafmt",
     "swift": "swiftformat",
     "go": "gofmt",
+    "rust": "rustfmt",
     "sql": "prettier-sql",
     "sh": "shfmt",
     "protobuf": "buf",


### PR DESCRIPTION
### Type of change
- New feature or functionality (change which adds functionality)

**For changes visible to end-users**
- Relevant documentation has been updated

### Test plan

- Manual testing; please provide instructions so we can reproduce: cd example && bazel run format


Trying to add rustfmt as a formatter. rules_rust already has a toolchain for rustfmt, so I am using that in the example.
However, the runfiles cannot be located since we change directory to the root of the repo before running the formatters. Is there a workaround for this?

Initializing rules_rust in the example folder can be improved, but I want to make it work first.

```
$ bazel run format
Formatting Rust with rustfmt...
/home/paulsmsm/.cache/bazel/_bazel_paulsmsm/573d3651f449593b84c17a4875272cea/execroot/_main/bazel-out/k8-opt-exec-ST-13d3ddad9198/bin/tools/rustfmt.rustfmt: line 2: external/rules_rust~0.38.0~rust~rustfmt_nightly-2023-12-28__x86_64-unknown-linux-gnu_tools/bin/rustfmt: No such file or directory
FAILED: A formatter tool exited with code 123
Try running 'bazel run @@//tools:format' to fix this.
Error: bazel exited with exit code: 123
```

When calling `bazel run //tools:rustfmt -- $(pwd)/src/hello.rs` works as expected.