### PR TITLE
format: fix exit code of check when using clang-format

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -101,7 +101,7 @@ case "$mode" in
    tfmode="-check -diff"
    jsonnetmode="--test"
    scalamode="--test"
-   clangformatmode="--style=file --fallback-style=none --dry-run"
+   clangformatmode="--style=file --fallback-style=none --dry-run -Werror"
    ;;
  fix)
    swiftmode=""


### PR DESCRIPTION
### Type of change

- Bug fix

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config): No
- Relevant documentation has been updated: no relevant documentation
- Suggested release notes are provided below:

fixed the exit code of `multi_formatter_binary(...)` when `--mode check` is used with clang-format.

### Test plan

Manual testing:

- Modified example/hello.cpp to introduce a formatting error (e.g. remove a space after the left brace).
- Ran `bazel run //tools:format -- --mode check` and check the exit code is 1.
- Fixed the formatting error via `bazel run //tools:format`
- Ran `bazel run //tools:format -- --mode check` and checked the exit code is 0.
