### PR TITLE
fix undocumented dependency on aspect_bazel_lib for WORKSPACE users

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -38,16 +38,16 @@ http_archive(
     url = "https://github.com/aspect-build/rules_lint/releases/download/${TAG}/${ARCHIVE}",
 )
 
-# aspect_rule_lint depends on aspect_bazel_lib
+# aspect_rules_lint depends on aspect_bazel_lib. Either 1.x or 2.x works.
 http_archive(
     name = "aspect_bazel_lib",
     sha256 = "979667bb7276ee8fcf2c114c9be9932b9a3052a64a647e0dcaacfb9c0016f0a3",
     strip_prefix = "bazel-lib-2.4.1",
     url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.4.1/bazel-lib-v2.4.1.tar.gz",
 )
-load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "aspect_bazel_lib_register_toolchains")
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
 
-# Required bazel-lib dependencies
+# aspect_bazel_lib depends on bazel_skylib
 aspect_bazel_lib_dependencies()
 EOF
 

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -37,6 +37,18 @@ http_archive(
     strip_prefix = "${PREFIX}",
     url = "https://github.com/aspect-build/rules_lint/releases/download/${TAG}/${ARCHIVE}",
 )
+
+# aspect_rule_lint depends on aspect_bazel_lib
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "979667bb7276ee8fcf2c114c9be9932b9a3052a64a647e0dcaacfb9c0016f0a3",
+    strip_prefix = "bazel-lib-2.4.1",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.4.1/bazel-lib-v2.4.1.tar.gz",
+)
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "aspect_bazel_lib_register_toolchains")
+
+# Required bazel-lib dependencies
+aspect_bazel_lib_dependencies()
 EOF
 
 awk 'f;/--SNIP--/{f=1}' example/WORKSPACE.bazel


### PR DESCRIPTION
I noticed that the instructions in each release for using aspect-build/rules_lint with WORKSPACE don't include the dependency that it has on aspect-build/bazel-lib, and so if you follow the setup instructions literally you'll end up with errors when `bazel run`-ing your formatter target:

```
$ bazel run //tools:format
ERROR: Skipping '//tools:format': error loading package 'tools': at /private/var/tmp/_bazel_mattbrown/d7cfcf96ac70d7089c913ecc8b613cd1/external/aspect_rules_lint/format/defs.bzl:33:6: at /private/var/tmp/_bazel_mattbrown/d7cfcf96ac70d7089c913ecc8b613cd1/external/aspect_rules_lint/format/private/formatter_binary.bzl:3:6: Unable to find package for @@aspect_bazel_lib//lib:paths.bzl: The repository '@@aspect_bazel_lib' could not be resolved: Repository '@@aspect_bazel_lib' is not defined.
```

I suppose ideally this library would export a deps.bzl file following the usual convention, so that setting up rules_lint in a project requires less to copy and paste; happy to change this PR to do that if desired.
