### PR TITLE
fix(eslint): switch to compact report

### DIFF
--- a/example/test/lint_test.bats
+++ b/example/test/lint_test.bats
@@ -23,7 +23,7 @@ EOF
 	assert_output --partial 'src/Foo.java:9:	FinalizeOverloaded:	Finalize methods should not be overloaded'
 
 	# ESLint
-	assert_output --partial 'src/file.ts:2:7: Type string trivially inferred from a string literal, remove type annotation  [error from @typescript-eslint/no-inferrable-types]'
+	assert_output --partial 'src/file.ts: line 2, col 7, Error - Type string trivially inferred from a string literal, remove type annotation. (@typescript-eslint/no-inferrable-types)'
 
 	# Buf
 	assert_output --partial 'src/file.proto:1:1:Import "src/unused.proto" is unused.'

--- a/lint/eslint.bazel-formatter.js
+++ b/lint/eslint.bazel-formatter.js
@@ -1,78 +1,45 @@
-// Fork of 'stylish' plugin that prints relative paths.
+// Fork of 'compact' plugin that prints relative paths.
 // This allows an editor to navigate to the location of the lint warning even though we present
 // eslint with paths underneath a bazel sandbox folder.
-// from https://github.com/eslint/eslint/blob/331cf62024b6c7ad4067c14c593f116576c3c861/lib/cli-engine/formatters/stylish.js
+// from https://github.com/eslint/eslint/blob/331cf62024b6c7ad4067c14c593f116576c3c861/lib/cli-engine/formatters/compact.js
 const path = require("node:path");
 
 /**
- * Given a word and a count, append an s if count is not one.
- * @param {string} word A word in its singular form.
- * @param {int} count A number controlling whether word should be pluralized.
- * @returns {string} The original word with an s on the end if count is not one.
+ * Returns the severity of warning or error
+ * @param {Object} message message object to examine
+ * @returns {string} severity level
+ * @private
  */
-function pluralize(word, count) {
-  return count === 1 ? word : `${word}s`;
+function getMessageType(message) {
+  if (message.fatal || message.severity === 2) {
+    return "Error";
+  }
+  return "Warning";
 }
 
 module.exports = function (results, context) {
   let output = "",
-    errorCount = 0,
-    warningCount = 0,
-    fixableErrorCount = 0,
-    fixableWarningCount = 0;
+    total = 0;
 
   results.forEach((result) => {
     const messages = result.messages;
 
-    if (messages.length === 0) {
-      return;
-    }
-
-    errorCount += result.errorCount;
-    warningCount += result.warningCount;
-    fixableErrorCount += result.fixableErrorCount;
-    fixableWarningCount += result.fixableWarningCount;
-
-    const relpath = path.relative(context.cwd, result.filePath);
+    total += messages.length;
 
     messages.forEach((message) => {
-      const msgtext = message.message.replace(/([^ ])\.$/u, "$1");
-      const severity =
-        message.fatal || message.severity === 2 ? "error" : "warning";
-      const location = [relpath, message.line, message.column].join(":");
-      output += `${location}: ${msgtext}  [${severity} from ${
-        message.ruleId || ""
-      }]\n`;
+      output += `${path.relative(context.cwd, result.filePath)}: `;
+      output += `line ${message.line || 0}`;
+      output += `, col ${message.column || 0}`;
+      output += `, ${getMessageType(message)}`;
+      output += ` - ${message.message}`;
+      output += message.ruleId ? ` (${message.ruleId})` : "";
+      output += "\n";
     });
   });
 
-  const total = errorCount + warningCount;
   if (total > 0) {
-    output += [
-      "\n",
-      "\u2716 ",
-      total,
-      pluralize(" problem", total),
-      " (",
-      errorCount,
-      pluralize(" error", errorCount),
-      ", ",
-      warningCount,
-      pluralize(" warning", warningCount),
-      ")\n",
-    ].join("");
-
-    if (fixableErrorCount > 0 || fixableWarningCount > 0) {
-      output += [
-        "  ",
-        fixableErrorCount,
-        pluralize(" error", fixableErrorCount),
-        " and ",
-        fixableWarningCount,
-        pluralize(" warning", fixableWarningCount),
-        " potentially fixable with the `--fix` option.\n",
-      ].join("");
-    }
+    output += `\n${total} problem${total !== 1 ? "s" : ""}`;
   }
+
   return output;
 };


### PR DESCRIPTION
The 'stylish' report is kinda hard to maintain a fork of it. I broke the errorformat parser by making our fork of stylish not quite the same.

In https://github.com/aspect-build/silo/pull/4540 I'm working on parsing the outputs of the linters, so we need to exactly match the known format. In theory the stylish report is better, but it has dependencies on chalk and strip-ansi that I'd rather not have to worry about here.

---

### Type of change

- Style (white-space, formatting, etc...)

### Test plan

- Covered by existing test cases
