### PR TITLE
fix(HCL): back out from formatting all HCL files

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -32,7 +32,6 @@ function ls-files {
       'C++') patterns=('*.cpp' '*.c++' '*.cc' '*.cp' '*.cppm' '*.cxx' '*.h' '*.h++' '*.hh' '*.hpp' '*.hxx' '*.inc' '*.inl' '*.ino' '*.ipp' '*.ixx' '*.re' '*.tcc' '*.tpp' '*.txx') ;;
       'CSS') patterns=('*.css') ;;
       'Go') patterns=('*.go') ;;
-      'HCL') patterns=('*.hcl' '*.nomad' '*.tf' '*.tfvars' '*.workflow') ;;
       'HTML') patterns=('*.html' '*.hta' '*.htm' '*.html.hl' '*.inc' '*.xht' '*.xhtml') ;;
       'JSON') patterns=('.all-contributorsrc' '.arcconfig' '.auto-changelog' '.c8rc' '.htmlhintrc' '.imgbotconfig' '.nycrc' '.tern-config' '.tern-project' '.watchmanconfig' 'Pipfile.lock' 'composer.lock' 'deno.lock' 'flake.lock' 'mcmod.info' '*.json' '*.4DForm' '*.4DProject' '*.avsc' '*.geojson' '*.gltf' '*.har' '*.ice' '*.JSON-tmLanguage' '*.jsonl' '*.mcmeta' '*.tfstate' '*.tfstate.backup' '*.topojson' '*.webapp' '*.webmanifest' '*.yy' '*.yyp') ;;
       'Java') patterns=('*.java' '*.jav' '*.jsh') ;;
@@ -49,6 +48,14 @@ function ls-files {
       'Swift') patterns=('*.swift') ;;
       'TSX') patterns=('*.tsx') ;;
       'TypeScript') patterns=('*.ts' '*.cts' '*.mts') ;;
+
+      # Note: terraform fmt cannot handle all HCL files such as .terraform.lock
+      # "Only .tf and .tfvars files can be processed with terraform fmt"
+      # so we define a custom language here instead of 'HCL' from github-linguist definition for the language.
+      # TODO: we should probably use https://terragrunt.gruntwork.io/docs/reference/cli-options/#hclfmt instead
+      # which does support the entire HCL language FWICT
+      'Terraform') patterns=('*.tf' '*.tfvars') ;;
+
       *)
         echo >&2 "Internal error: unknown language $language"
         exit 1
@@ -196,10 +203,10 @@ if [ -n "$files" ] && [ -n "$bin" ]; then
   echo "$files" | tr \\n \\0 | xargs -0 $bin $ruffmode
 fi
 
-files=$(ls-files HCL $@)
+files=$(ls-files Terraform $@)
 bin=$(rlocation {{terraform-fmt}})
 if [ -n "$files" ] && [ -n "$bin" ]; then
-  echo "Formatting Hashicorp Config Language with terraform fmt..."
+  echo "Formatting Terraform files with terraform fmt..."
   echo "$files" | tr \\n \\0 | xargs -0 $bin fmt $tfmode
 fi
 

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -69,7 +69,7 @@ bats_load_library "bats-assert"
     run bazel run //format/test:format_hcl
     assert_success
 
-    assert_output --partial "Formatting Hashicorp Config Language with terraform fmt..."
+    assert_output --partial "Formatting Terraform files with terraform fmt..."
     assert_output --partial "+ terraform-fmt fmt example/src/hello.tf"
 }
 


### PR DESCRIPTION
The tool we are using (terraform fmt) doesn't support all HCL file extensions. We should probably switch tools. I don't have time today so reducing scope from an 'HCL' language to a (locally-invented) 'Terraform' language with fewer file types

Fixes #141

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:
`bazel run format --override_repository=aspect_rules_lint=$HOME/Projects/rules_lint` in aspect silo