### PR TITLE
docs(golangci-lint): fix the target name

### DIFF
--- a/docs/golangci-lint.md
+++ b/docs/golangci-lint.md
@@ -6,7 +6,7 @@ API for declaring a golangci-lint lint aspect that visits go_library, go_test, a
 load("@aspect_rules_lint//lint:golangci-lint.bzl", "golangci_lint_aspect")
 
 golangci_lint = golangci_lint_aspect(
-    binary = "@@//tools:golangci-lint",
+    binary = "@@//tools:golangci_lint",
     config = "@@//:.golangci.yaml",
 )
 ```

--- a/lint/golangci-lint.bzl
+++ b/lint/golangci-lint.bzl
@@ -4,7 +4,7 @@
 load("@aspect_rules_lint//lint:golangci-lint.bzl", "golangci_lint_aspect")
 
 golangci_lint = golangci_lint_aspect(
-    binary = "@@//tools:golangci-lint",
+    binary = "@@//tools:golangci_lint",
     config = "@@//:.golangci.yaml",
 )
 ```


### PR DESCRIPTION
This is what the //example workspace uses, and it's what I had to use to get this to work in our VideoAmp repo.
https://github.com/aspect-build/rules_lint/blob/ebe8678587abb1f9104abbfc6ca2ee1a8579b4aa/example/tools/lint.bzl#L59-L62

---

### Type of change

- Documentation (updates to documentation or READMEs)

**For changes visible to end-users**

- Relevant documentation has been updated

### Test plan

- This documentation matches the working version in //example