### PR TITLE
chore: demonstrate golangci-lint not working with deps

### DIFF
--- a/example/.aspect/cli/config.yaml
+++ b/example/.aspect/cli/config.yaml
@@ -3,6 +3,7 @@ lint:
     - //tools/lint:linters.bzl%eslint
     - //tools/lint:linters.bzl%buf
     - //tools/lint:linters.bzl%flake8
+    - //tools/lint:linters.bzl%golangci_lint
     - //tools/lint:linters.bzl%pmd
     - //tools/lint:linters.bzl%ruff
     - //tools/lint:linters.bzl%vale

--- a/example/src/BUILD.bazel
+++ b/example/src/BUILD.bazel
@@ -46,6 +46,7 @@ sh_library(
 go_binary(
     name = "hello_go",
     srcs = ["hello.go"],
+    deps = ["//src/gopher"],
 )
 
 cc_binary(

--- a/example/src/gopher/BUILD.bazel
+++ b/example/src/gopher/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "gopher",
+    srcs = ["gopher.go"],
+    importpath = "gopher",
+    visibility = ["//visibility:public"],
+)

--- a/example/src/gopher/gopher.go
+++ b/example/src/gopher/gopher.go
@@ -1,0 +1,5 @@
+package gopher
+
+func Name() string {
+	return "Gopher!"
+}

--- a/example/src/hello.go
+++ b/example/src/hello.go
@@ -2,13 +2,22 @@ package main
 
 import (
 	"fmt"
+	"gopher"
+	"log"
 )
 
-const (
-	w = "world"
-)
+// staticcheck won't like this
+var notUsed string
 
 func main() {
-	hello := fmt.Sprintf("Hello %s\n", w)
+	s := []string{"a"}
+	// staticcheck also won't like this
+	if s != nil {
+		for _, v := range s {
+			log.Println(v)
+		}
+	}
+	hello := fmt.Sprintf("Hello %s\n", gopher.Name())
 	fmt.Printf(hello)
+	_ = s
 }


### PR DESCRIPTION
Steps to reproduce:

1. Check out this repo/branch
2. `cd example`
3. `bazel lint src:hello_go`

Expected result would be successful linting. Actual is below. This seems to come about because the go_binary depends on a go_library

this is a demo of https://github.com/aspect-build/rules_lint/issues/129

INFO: Analyzed target //src:hello_go (0 packages loaded, 0 targets configured).
INFO: From golangcilint src/golangcilint.hello_go.aspect_rules_lint.report:
level=warning msg="[runner] Can't run linter goanalysis_metalinter: buildir: failed to load package : could not load export data: no export data for \"gopher\""
level=error msg="Running error: 1 error occurred:\n\t* can't run linter goanalysis_metalinter: buildir: failed to load package : could not load export data: no export data for \"gopher\"\n\n"
