### PR TITLE
refactor: remove Vale workaround for StylesPath

### DIFF
--- a/docs/vale.md
+++ b/docs/vale.md
@@ -42,22 +42,9 @@ copy_to_directory(
 )
 ```
 
-Now the `.vale.ini` file will have a `StylesPath` entry that points to this folder, for example,
-
-```ini
-StylesPath = tools/vale_styles
-```
-
-Finally, it's necessary for the `.vale.ini` file to be copied to the bazel-bin folder so that it
-is relative to the generated `vale_styles` folder.
-Use [`copy_to_bin`](https://docs.aspect.build/rulesets/aspect_bazel_lib/docs/copy_to_bin/) for this:
-
-```starlark
-copy_to_bin(
-    name = ".vale_ini",
-    srcs = [".vale.ini"],
-)
-```
+Note that the `.vale.ini` file may have a `StylesPath` entry.
+Under Bazel, we set `VALE_STYLES_PATH` in the environment, so the `StylesPath` is used
+only when running Vale outside Bazel, such as in an editor extension.
 
 See the example in rules_lint for a fully-working vale setup.
 
@@ -92,7 +79,7 @@ A repository macro used from WORKSPACE to fetch vale binaries
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="fetch_vale-tag"></a>tag |  a tag of vale that we have mirrored, e.g. <code>v3.0.5</code>   |  <code>"v3.0.7"</code> |
+| <a id="fetch_vale-tag"></a>tag |  a tag of vale that we have mirrored, e.g. <code>v3.0.5</code>   |  <code>"v3.1.0"</code> |
 
 
 <a id="vale_action"></a>

--- a/example/.vale.ini
+++ b/example/.vale.ini
@@ -1,9 +1,3 @@
-# NB: this path doesn't exist in the source tree, it's created by the copy_to_directory rule
-# in tools/BUILD.bazel.
-# If you want vale to run outside Bazel, such as with an editor extension,
-# you could also use `write_source_files` to have the tools/vale_styles folder written into the source tree as well.
-StylesPath = tools/vale_styles
-
 MinAlertLevel = warning
 Packages = Google,write-good
 

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
@@ -20,6 +19,7 @@ exports_files(
         ".shellcheckrc",
         ".scalafmt.conf",
         ".golangci.yaml",
+        ".vale.ini",
     ],
     visibility = ["//visibility:public"],
 )
@@ -47,10 +47,4 @@ js_library(
 alias(
     name = "format",
     actual = "//tools:format",
-)
-
-copy_to_bin(
-    name = ".vale_ini",
-    srcs = [".vale.ini"],
-    visibility = ["//src:__subpackages__"],
 )

--- a/example/tools/lint.bzl
+++ b/example/tools/lint.bzl
@@ -66,6 +66,6 @@ golangci_lint_test = make_lint_test(aspect = golangci_lint)
 
 vale = vale_aspect(
     binary = "@@//tools:vale",
-    config = "@@//:.vale_ini",
+    config = "@@//:.vale.ini",
     styles = "@@//tools:vale_styles",
 )

--- a/lint/mirror_vale.sh
+++ b/lint/mirror_vale.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -o errexit -o nounset -o pipefail
+
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 RELEASES=$(mktemp)
 RAW=$(mktemp)

--- a/lint/vale_versions.bzl
+++ b/lint/vale_versions.bzl
@@ -1,5 +1,15 @@
 "This file is automatically updated by mirror_vale.sh"
 VALE_VERSIONS = {
+    "v3.1.0": {
+        "Linux_386": "81564dde82bf90b3552f0f181fe56803a8ab727c65c350c82290120a9ca47fa3",
+        "Linux_64-bit": "7c62da29c53dc58f836327bda3a763b7862633d7f957c1abf12e661c2d65a3e0",
+        "Linux_arm64": "8f83cf1345685f3da9c2a69a7952beab3d38f961b13d7a339156e1187d11f8f5",
+        "macOS_64-bit": "d00806911d713ee5325cf6aa377a0d48dd44d418c35f66e7527abf113b89cd48",
+        "macOS_arm64": "78baa52b88fff4bbebd88e0dcc8504932bb750b787a8fb3d2d4966e8e38dac60",
+        "Windows_386": "bf87bf2718cb425bce7fd201a635b4be3ec6efa4e361aaf64c62b3a90587c33d",
+        "Windows_64-bit": "8e0bff5ab631bcb2d05dfb01599ff9256a9d46b7163f0dcb75b99321d54fd992",
+        "Windows_arm64": "ac3111fa52c322cb5aaf3c321dbe170fb1f16977847a2a2329272606f45a806c",
+    },
     "v3.0.7": {
         "Linux_386": "86128821d5220cca019b05b2fd2470202ed9f6ed7c26baa45efb9f905c94281d",
         "Linux_64-bit": "103a070f45b36d6c206d1ec0668bd1e1ce63e721022693ed37933b673fdaa45d",


### PR DESCRIPTION
Thanks @jdkato for the fix in https://github.com/errata-ai/vale/commit/2139c4176a4d2e62d7dfb95dca24b96b9e8b7251 so we no longer need to tell users about copying their configuration file to be relative to the styles folder.

Note, to be less breaking I didn't remove the older Vale versions. Users who pinned to those and set their `StylesPath` should still work, as this newly added environment variable won't be referenced.

---

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

**For changes visible to end-users**

- Relevant documentation has been updated

### Test plan

- Covered by existing test cases
