### PR TITLE
Lint prefix

### DIFF
--- a/docs/buf.md
+++ b/docs/buf.md
@@ -35,12 +35,12 @@ Runs the buf lint tool as a Bazel action.
 | <a id="buf_lint_action-use_exit_code"></a>use_exit_code |  whether the protoc process exiting non-zero will be a build failure   |  <code>False</code> |
 
 
-<a id="buf_lint_aspect"></a>
+<a id="lint_buf_aspect"></a>
 
-## buf_lint_aspect
+## lint_buf_aspect
 
 <pre>
-buf_lint_aspect(<a href="#buf_lint_aspect-config">config</a>, <a href="#buf_lint_aspect-toolchain">toolchain</a>)
+lint_buf_aspect(<a href="#lint_buf_aspect-config">config</a>, <a href="#lint_buf_aspect-toolchain">toolchain</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -50,7 +50,7 @@ A factory function to create a linter aspect.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="buf_lint_aspect-config"></a>config |  label of the the buf.yaml file   |  none |
-| <a id="buf_lint_aspect-toolchain"></a>toolchain |  override the default toolchain of the protoc-gen-buf-lint tool   |  <code>"@rules_buf//tools/protoc-gen-buf-lint:toolchain_type"</code> |
+| <a id="lint_buf_aspect-config"></a>config |  label of the the buf.yaml file   |  none |
+| <a id="lint_buf_aspect-toolchain"></a>toolchain |  override the default toolchain of the protoc-gen-buf-lint tool   |  <code>"@rules_buf//tools/protoc-gen-buf-lint:toolchain_type"</code> |
 
 

--- a/docs/eslint.md
+++ b/docs/eslint.md
@@ -65,25 +65,6 @@ https://eslint.org/docs/latest/use/command-line-interface
 | <a id="eslint_action-use_exit_code"></a>use_exit_code |  whether an eslint process exiting non-zero will be a build failure   |  <code>False</code> |
 
 
-<a id="eslint_aspect"></a>
-
-## eslint_aspect
-
-<pre>
-eslint_aspect(<a href="#eslint_aspect-binary">binary</a>, <a href="#eslint_aspect-configs">configs</a>)
-</pre>
-
-A factory function to create a linter aspect.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="eslint_aspect-binary"></a>binary |  the eslint binary, typically a rule like<br><br><pre><code> load("@npm//:eslint/package_json.bzl", eslint_bin = "bin") eslint_bin.eslint_binary(name = "eslint") </code></pre>   |  none |
-| <a id="eslint_aspect-configs"></a>configs |  label(s) of the eslint config file(s)   |  none |
-
-
 <a id="eslint_fix"></a>
 
 ## eslint_fix
@@ -103,5 +84,24 @@ Create a Bazel Action that spawns eslint with --fix.
 | <a id="eslint_fix-executable"></a>executable |  struct with an eslint field   |  none |
 | <a id="eslint_fix-srcs"></a>srcs |  list of file objects to lint   |  none |
 | <a id="eslint_fix-patch"></a>patch |  output file containing the applied fixes that can be applied with the patch(1) command.   |  none |
+
+
+<a id="lint_eslint_aspect"></a>
+
+## lint_eslint_aspect
+
+<pre>
+lint_eslint_aspect(<a href="#lint_eslint_aspect-binary">binary</a>, <a href="#lint_eslint_aspect-configs">configs</a>)
+</pre>
+
+A factory function to create a linter aspect.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="lint_eslint_aspect-binary"></a>binary |  the eslint binary, typically a rule like<br><br><pre><code> load("@npm//:eslint/package_json.bzl", eslint_bin = "bin") eslint_bin.eslint_binary(name = "eslint") </code></pre>   |  none |
+| <a id="lint_eslint_aspect-configs"></a>configs |  label(s) of the eslint config file(s)   |  none |
 
 

--- a/docs/flake8.md
+++ b/docs/flake8.md
@@ -40,12 +40,12 @@ Based on https://flake8.pycqa.org/en/latest/user/invocation.html
 | <a id="flake8_action-use_exit_code"></a>use_exit_code |  whether to fail the build when a lint violation is reported   |  <code>False</code> |
 
 
-<a id="flake8_aspect"></a>
+<a id="lint_flake8_aspect"></a>
 
-## flake8_aspect
+## lint_flake8_aspect
 
 <pre>
-flake8_aspect(<a href="#flake8_aspect-binary">binary</a>, <a href="#flake8_aspect-config">config</a>)
+lint_flake8_aspect(<a href="#lint_flake8_aspect-binary">binary</a>, <a href="#lint_flake8_aspect-config">config</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -67,7 +67,7 @@ Attrs:
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="flake8_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
-| <a id="flake8_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
+| <a id="lint_flake8_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
+| <a id="lint_flake8_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
 
 

--- a/docs/golangci-lint.md
+++ b/docs/golangci-lint.md
@@ -56,12 +56,12 @@ Based on https://github.com/golangci/golangci-lint
 | <a id="golangci_lint_action-use_exit_code"></a>use_exit_code |  whether to fail the build when a lint violation is reported   |  <code>False</code> |
 
 
-<a id="golangci_lint_aspect"></a>
+<a id="lint_golangci_aspect"></a>
 
-## golangci_lint_aspect
+## lint_golangci_aspect
 
 <pre>
-golangci_lint_aspect(<a href="#golangci_lint_aspect-binary">binary</a>, <a href="#golangci_lint_aspect-config">config</a>)
+lint_golangci_aspect(<a href="#lint_golangci_aspect-binary">binary</a>, <a href="#lint_golangci_aspect-config">config</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -75,7 +75,7 @@ Attrs:
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="golangci_lint_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
-| <a id="golangci_lint_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
+| <a id="lint_golangci_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
+| <a id="lint_golangci_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
 
 

--- a/docs/lint_test.md
+++ b/docs/lint_test.md
@@ -9,7 +9,7 @@ To use this, in your `linters.bzl` where you define the aspect, just create a te
 For example, with `flake8`:
 
 ```starlark
-load("@aspect_rules_lint//lint:lint_test.bzl", "make_lint_test")
+load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
 load("@aspect_rules_lint//lint:flake8.bzl", "flake8_aspect")
 
 flake8 = flake8_aspect(
@@ -17,7 +17,7 @@ flake8 = flake8_aspect(
     config = "@@//:.flake8",
 )
 
-flake8_test = make_lint_test(aspect = flake8)
+flake8_test = lint_test(aspect = flake8)
 ```
 
 Now in your BUILD files you can add a test:
@@ -37,12 +37,12 @@ flake8_test(
 ```
 
 
-<a id="make_lint_test"></a>
+<a id="lint_test"></a>
 
-## make_lint_test
+## lint_test
 
 <pre>
-make_lint_test(<a href="#make_lint_test-aspect">aspect</a>)
+lint_test(<a href="#lint_test-aspect">aspect</a>)
 </pre>
 
 
@@ -52,6 +52,6 @@ make_lint_test(<a href="#make_lint_test-aspect">aspect</a>)
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="make_lint_test-aspect"></a>aspect |  <p align="center"> - </p>   |  none |
+| <a id="lint_test-aspect"></a>aspect |  <p align="center"> - </p>   |  none |
 
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -66,7 +66,7 @@ This makes the build fail when any lint violations are present.
 
 ### 5. Failures during `bazel test`
 
-Add a [make_lint_test](./lint_test.md) call to the `linters.bzl` file, then use the resulting rule in your BUILD files or in a wrapper macro.
+Add a [lint_test](./lint_test.md) call to the `linters.bzl` file, then use the resulting rule in your BUILD files or in a wrapper macro.
 
 See the `example/test/BUILD.bazel` file in this repo for some examples.
 

--- a/docs/pmd.md
+++ b/docs/pmd.md
@@ -14,6 +14,39 @@ pmd = pmd_aspect(
 ```
 
 
+<a id="lint_pmd_aspect"></a>
+
+## lint_pmd_aspect
+
+<pre>
+lint_pmd_aspect(<a href="#lint_pmd_aspect-binary">binary</a>, <a href="#lint_pmd_aspect-rulesets">rulesets</a>)
+</pre>
+
+A factory function to create a linter aspect.
+
+Attrs:
+    binary: a PMD executable. Can be obtained from rules_java like so:
+
+        ```
+        java_binary(
+            name = "pmd",
+            main_class = "net.sourceforge.pmd.PMD",
+            # Point to wherever you have the java_import rule defined, see our example
+            runtime_deps = ["@net_sourceforge_pmd"],
+        )
+        ```
+
+    rulesets: the PMD ruleset XML files
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="lint_pmd_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
+| <a id="lint_pmd_aspect-rulesets"></a>rulesets |  <p align="center"> - </p>   |  none |
+
+
 <a id="pmd_action"></a>
 
 ## pmd_action
@@ -38,38 +71,5 @@ Based on https://docs.pmd-code.org/latest/pmd_userdocs_installation.html#running
 | <a id="pmd_action-rulesets"></a>rulesets |  list of labels of the PMD ruleset files   |  none |
 | <a id="pmd_action-report"></a>report |  output file to generate   |  none |
 | <a id="pmd_action-use_exit_code"></a>use_exit_code |  whether to fail the build when a lint violation is reported   |  <code>False</code> |
-
-
-<a id="pmd_aspect"></a>
-
-## pmd_aspect
-
-<pre>
-pmd_aspect(<a href="#pmd_aspect-binary">binary</a>, <a href="#pmd_aspect-rulesets">rulesets</a>)
-</pre>
-
-A factory function to create a linter aspect.
-
-Attrs:
-    binary: a PMD executable. Can be obtained from rules_java like so:
-
-        ```
-        java_binary(
-            name = "pmd",
-            main_class = "net.sourceforge.pmd.PMD",
-            # Point to wherever you have the java_import rule defined, see our example
-            runtime_deps = ["@net_sourceforge_pmd"],
-        )
-        ```
-
-    rulesets: the PMD ruleset XML files
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="pmd_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
-| <a id="pmd_aspect-rulesets"></a>rulesets |  <p align="center"> - </p>   |  none |
 
 

--- a/docs/ruff.md
+++ b/docs/ruff.md
@@ -54,6 +54,41 @@ A repository macro used from WORKSPACE to fetch ruff binaries
 | <a id="fetch_ruff-tag"></a>tag |  a tag of ruff that we have mirrored, e.g. <code>v0.1.0</code>   |  <code>"v0.3.1"</code> |
 
 
+<a id="lint_ruff_aspect"></a>
+
+## lint_ruff_aspect
+
+<pre>
+lint_ruff_aspect(<a href="#lint_ruff_aspect-binary">binary</a>, <a href="#lint_ruff_aspect-configs">configs</a>)
+</pre>
+
+A factory function to create a linter aspect.
+
+Attrs:
+    binary: a ruff executable. Can be obtained like so:
+
+        load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+        http_archive(
+            name = "ruff_bin_linux_amd64",
+            sha256 = "&lt;-sha-&gt;",
+            urls = [
+                "https://github.com/charliermarsh/ruff/releases/download/v&lt;-version-&gt;/ruff-x86_64-unknown-linux-gnu.tar.gz",
+            ],
+            build_file_content = """exports_files(["ruff"])""",
+        )
+
+    configs: ruff config file(s) (`pyproject.toml`, `ruff.toml`, or `.ruff.toml`)
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="lint_ruff_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
+| <a id="lint_ruff_aspect-configs"></a>configs |  <p align="center"> - </p>   |  none |
+
+
 <a id="ruff_action"></a>
 
 ## ruff_action
@@ -89,41 +124,6 @@ However this is needed because:
 | <a id="ruff_action-config"></a>config |  labels of ruff config files (pyproject.toml, ruff.toml, or .ruff.toml)   |  none |
 | <a id="ruff_action-report"></a>report |  output file to generate   |  none |
 | <a id="ruff_action-use_exit_code"></a>use_exit_code |  whether to fail the build when a lint violation is reported   |  <code>False</code> |
-
-
-<a id="ruff_aspect"></a>
-
-## ruff_aspect
-
-<pre>
-ruff_aspect(<a href="#ruff_aspect-binary">binary</a>, <a href="#ruff_aspect-configs">configs</a>)
-</pre>
-
-A factory function to create a linter aspect.
-
-Attrs:
-    binary: a ruff executable. Can be obtained like so:
-
-        load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-        http_archive(
-            name = "ruff_bin_linux_amd64",
-            sha256 = "&lt;-sha-&gt;",
-            urls = [
-                "https://github.com/charliermarsh/ruff/releases/download/v&lt;-version-&gt;/ruff-x86_64-unknown-linux-gnu.tar.gz",
-            ],
-            build_file_content = """exports_files(["ruff"])""",
-        )
-
-    configs: ruff config file(s) (`pyproject.toml`, `ruff.toml`, or `.ruff.toml`)
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="ruff_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
-| <a id="ruff_aspect-configs"></a>configs |  <p align="center"> - </p>   |  none |
 
 
 <a id="ruff_fix"></a>

--- a/docs/shellcheck.md
+++ b/docs/shellcheck.md
@@ -36,6 +36,29 @@ A repository macro used from WORKSPACE to fetch binaries
 | <a id="fetch_shellcheck-version"></a>version |  a version of shellcheck that we have mirrored, e.g. <code>v0.9.0</code>   |  <code>"v0.9.0"</code> |
 
 
+<a id="lint_shellcheck_aspect"></a>
+
+## lint_shellcheck_aspect
+
+<pre>
+lint_shellcheck_aspect(<a href="#lint_shellcheck_aspect-binary">binary</a>, <a href="#lint_shellcheck_aspect-config">config</a>)
+</pre>
+
+A factory function to create a linter aspect.
+
+Attrs:
+    binary: a shellcheck executable.
+    config: the .shellcheckrc file
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="lint_shellcheck_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
+| <a id="lint_shellcheck_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
+
+
 <a id="shellcheck_action"></a>
 
 ## shellcheck_action
@@ -60,29 +83,6 @@ Based on https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md
 | <a id="shellcheck_action-config"></a>config |  label of the .shellcheckrc file   |  none |
 | <a id="shellcheck_action-report"></a>report |  output file to generate   |  none |
 | <a id="shellcheck_action-use_exit_code"></a>use_exit_code |  whether to fail the build when a lint violation is reported   |  <code>False</code> |
-
-
-<a id="shellcheck_aspect"></a>
-
-## shellcheck_aspect
-
-<pre>
-shellcheck_aspect(<a href="#shellcheck_aspect-binary">binary</a>, <a href="#shellcheck_aspect-config">config</a>)
-</pre>
-
-A factory function to create a linter aspect.
-
-Attrs:
-    binary: a shellcheck executable.
-    config: the .shellcheckrc file
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="shellcheck_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
-| <a id="shellcheck_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
 
 
 <a id="shellcheck_binary"></a>

--- a/docs/vale.md
+++ b/docs/vale.md
@@ -82,6 +82,26 @@ A repository macro used from WORKSPACE to fetch vale binaries
 | <a id="fetch_vale-tag"></a>tag |  a tag of vale that we have mirrored, e.g. <code>v3.0.5</code>   |  <code>"v3.1.0"</code> |
 
 
+<a id="lint_vale_aspect"></a>
+
+## lint_vale_aspect
+
+<pre>
+lint_vale_aspect(<a href="#lint_vale_aspect-binary">binary</a>, <a href="#lint_vale_aspect-config">config</a>, <a href="#lint_vale_aspect-styles">styles</a>)
+</pre>
+
+A factory function to create a linter aspect.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="lint_vale_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
+| <a id="lint_vale_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
+| <a id="lint_vale_aspect-styles"></a>styles |  <p align="center"> - </p>   |  <code>Label("//lint:empty_styles")</code> |
+
+
 <a id="vale_action"></a>
 
 ## vale_action
@@ -104,25 +124,5 @@ vale_action(<a href="#vale_action-ctx">ctx</a>, <a href="#vale_action-executable
 | <a id="vale_action-config"></a>config |  <p align="center"> - </p>   |  none |
 | <a id="vale_action-report"></a>report |  <p align="center"> - </p>   |  none |
 | <a id="vale_action-use_exit_code"></a>use_exit_code |  <p align="center"> - </p>   |  <code>False</code> |
-
-
-<a id="vale_aspect"></a>
-
-## vale_aspect
-
-<pre>
-vale_aspect(<a href="#vale_aspect-binary">binary</a>, <a href="#vale_aspect-config">config</a>, <a href="#vale_aspect-styles">styles</a>)
-</pre>
-
-A factory function to create a linter aspect.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="vale_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
-| <a id="vale_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
-| <a id="vale_aspect-styles"></a>styles |  <p align="center"> - </p>   |  <code>Label("//lint:empty_styles")</code> |
 
 

--- a/example/tools/lint/linters.bzl
+++ b/example/tools/lint/linters.bzl
@@ -3,6 +3,7 @@
 load("@aspect_rules_lint//lint:buf.bzl", "lint_buf_aspect")
 load("@aspect_rules_lint//lint:eslint.bzl", "lint_eslint_aspect")
 load("@aspect_rules_lint//lint:flake8.bzl", "lint_flake8_aspect")
+load("@aspect_rules_lint//lint:golangci-lint.bzl", "lint_golangci_aspect")
 load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
 load("@aspect_rules_lint//lint:pmd.bzl", "lint_pmd_aspect")
 load("@aspect_rules_lint//lint:ruff.bzl", "lint_ruff_aspect")
@@ -56,7 +57,7 @@ shellcheck = lint_shellcheck_aspect(
 
 shellcheck_test = lint_test(aspect = shellcheck)
 
-golangci_lint = lint_golangci_lint_aspect(
+golangci_lint = lint_golangci_aspect(
     binary = "@@//tools/lint:golangci_lint",
     config = "@@//:.golangci.yaml",
 )

--- a/example/tools/lint/linters.bzl
+++ b/example/tools/lint/linters.bzl
@@ -1,20 +1,19 @@
 "Define linter aspects"
 
-load("@aspect_rules_lint//lint:buf.bzl", "buf_lint_aspect")
-load("@aspect_rules_lint//lint:eslint.bzl", "eslint_aspect")
-load("@aspect_rules_lint//lint:flake8.bzl", "flake8_aspect")
-load("@aspect_rules_lint//lint:golangci-lint.bzl", "golangci_lint_aspect")
-load("@aspect_rules_lint//lint:lint_test.bzl", "make_lint_test")
-load("@aspect_rules_lint//lint:pmd.bzl", "pmd_aspect")
-load("@aspect_rules_lint//lint:ruff.bzl", "ruff_aspect")
-load("@aspect_rules_lint//lint:shellcheck.bzl", "shellcheck_aspect")
-load("@aspect_rules_lint//lint:vale.bzl", "vale_aspect")
+load("@aspect_rules_lint//lint:buf.bzl", "lint_buf_aspect")
+load("@aspect_rules_lint//lint:eslint.bzl", "lint_eslint_aspect")
+load("@aspect_rules_lint//lint:flake8.bzl", "lint_flake8_aspect")
+load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
+load("@aspect_rules_lint//lint:pmd.bzl", "lint_pmd_aspect")
+load("@aspect_rules_lint//lint:ruff.bzl", "lint_ruff_aspect")
+load("@aspect_rules_lint//lint:shellcheck.bzl", "lint_shellcheck_aspect")
+load("@aspect_rules_lint//lint:vale.bzl", "lint_vale_aspect")
 
-buf = buf_lint_aspect(
+buf = lint_buf_aspect(
     config = "@@//:buf.yaml",
 )
 
-eslint = eslint_aspect(
+eslint = lint_eslint_aspect(
     binary = "@@//tools/lint:eslint",
     # We trust that eslint will locate the correct configuration file for a given source file.
     # See https://eslint.org/docs/latest/use/configure/configuration-files#cascading-and-hierarchy
@@ -24,23 +23,23 @@ eslint = eslint_aspect(
     ],
 )
 
-eslint_test = make_lint_test(aspect = eslint)
+eslint_test = lint_test(aspect = eslint)
 
-flake8 = flake8_aspect(
+flake8 = lint_flake8_aspect(
     binary = "@@//tools/lint:flake8",
     config = "@@//:.flake8",
 )
 
-flake8_test = make_lint_test(aspect = flake8)
+flake8_test = lint_test(aspect = flake8)
 
-pmd = pmd_aspect(
+pmd = lint_pmd_aspect(
     binary = "@@//tools/lint:pmd",
     rulesets = ["@@//:pmd.xml"],
 )
 
-pmd_test = make_lint_test(aspect = pmd)
+pmd_test = lint_test(aspect = pmd)
 
-ruff = ruff_aspect(
+ruff = lint_ruff_aspect(
     binary = "@@//tools/lint:ruff",
     configs = [
         "@@//:.ruff.toml",
@@ -48,23 +47,23 @@ ruff = ruff_aspect(
     ],
 )
 
-ruff_test = make_lint_test(aspect = ruff)
+ruff_test = lint_test(aspect = ruff)
 
-shellcheck = shellcheck_aspect(
+shellcheck = lint_shellcheck_aspect(
     binary = "@@//tools/lint:shellcheck",
     config = "@@//:.shellcheckrc",
 )
 
-shellcheck_test = make_lint_test(aspect = shellcheck)
+shellcheck_test = lint_test(aspect = shellcheck)
 
-golangci_lint = golangci_lint_aspect(
+golangci_lint = lint_golangci_lint_aspect(
     binary = "@@//tools/lint:golangci_lint",
     config = "@@//:.golangci.yaml",
 )
 
-golangci_lint_test = make_lint_test(aspect = golangci_lint)
+golangci_lint_test = lint_test(aspect = golangci_lint)
 
-vale = vale_aspect(
+vale = lint_vale_aspect(
     binary = "@@//tools/lint:vale",
     config = "@@//:.vale.ini",
     styles = "@@//tools/lint:vale_styles",

--- a/lint/buf.bzl
+++ b/lint/buf.bzl
@@ -85,7 +85,7 @@ def _buf_lint_aspect_impl(target, ctx):
     buf_lint_action(ctx, ctx.toolchains[ctx.attr._buf_toolchain], target, report, ctx.attr._options[LintOptionsInfo].fail_on_violation)
     return [info]
 
-def buf_lint_aspect(config, toolchain = "@rules_buf//tools/protoc-gen-buf-lint:toolchain_type"):
+def lint_buf_aspect(config, toolchain = "@rules_buf//tools/protoc-gen-buf-lint:toolchain_type"):
     """A factory function to create a linter aspect.
 
     Args:

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -151,7 +151,7 @@ def _eslint_aspect_impl(target, ctx):
     eslint_fix(ctx, ctx.executable, files_to_lint, patch)
     return [info]
 
-def eslint_aspect(binary, configs):
+def lint_eslint_aspect(binary, configs):
     """A factory function to create a linter aspect.
 
     Args:

--- a/lint/flake8.bzl
+++ b/lint/flake8.bzl
@@ -67,7 +67,7 @@ def _flake8_aspect_impl(target, ctx):
     flake8_action(ctx, ctx.executable._flake8, filter_srcs(ctx.rule), ctx.file._config_file, report, ctx.attr._options[LintOptionsInfo].fail_on_violation)
     return [info]
 
-def flake8_aspect(binary, config):
+def lint_flake8_aspect(binary, config):
     """A factory function to create a linter aspect.
 
     Attrs:

--- a/lint/golangci-lint.bzl
+++ b/lint/golangci-lint.bzl
@@ -77,7 +77,7 @@ def _golangci_lint_aspect_impl(target, ctx):
     golangci_lint_action(ctx, ctx.executable._golangci_lint, srcs, ctx.file._config_file, report, ctx.attr._options[LintOptionsInfo].fail_on_violation)
     return [info]
 
-def golangci_lint_aspect(binary, config):
+def lint_golangci_aspect(binary, config):
     """A factory function to create a linter aspect.
 
     Attrs:

--- a/lint/lint_test.bzl
+++ b/lint/lint_test.bzl
@@ -7,7 +7,7 @@ To use this, in your `linters.bzl` where you define the aspect, just create a te
 For example, with `flake8`:
 
 ```starlark
-load("@aspect_rules_lint//lint:lint_test.bzl", "make_lint_test")
+load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
 load("@aspect_rules_lint//lint:flake8.bzl", "flake8_aspect")
 
 flake8 = flake8_aspect(
@@ -15,7 +15,7 @@ flake8 = flake8_aspect(
     config = "@@//:.flake8",
 )
 
-flake8_test = make_lint_test(aspect = flake8)
+flake8_test = lint_test(aspect = flake8)
 ```
 
 Now in your BUILD files you can add a test:
@@ -55,7 +55,7 @@ def _test_impl(ctx):
         runfiles = ctx.runfiles(reports + [ctx.file._runfiles_lib]),
     )]
 
-def make_lint_test(aspect):
+def lint_test(aspect):
     return rule(
         implementation = _test_impl,
         attrs = {

--- a/lint/pmd.bzl
+++ b/lint/pmd.bzl
@@ -72,7 +72,7 @@ def _pmd_aspect_impl(target, ctx):
     pmd_action(ctx, ctx.executable._pmd, filter_srcs(ctx.rule), ctx.files._rulesets, report, ctx.attr._options[LintOptionsInfo].fail_on_violation)
     return [info]
 
-def pmd_aspect(binary, rulesets):
+def lint_pmd_aspect(binary, rulesets):
     """A factory function to create a linter aspect.
 
     Attrs:

--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -117,7 +117,7 @@ def _ruff_aspect_impl(target, ctx):
     ruff_fix(ctx, ctx.executable, files_to_lint, ctx.files._config_files, patch)
     return [info]
 
-def ruff_aspect(binary, configs):
+def lint_ruff_aspect(binary, configs):
     """A factory function to create a linter aspect.
 
     Attrs:

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -84,7 +84,7 @@ def _shellcheck_aspect_impl(target, ctx):
     shellcheck_action(ctx, ctx.executable._shellcheck, filter_srcs(ctx.rule), ctx.file._config_file, report, ctx.attr._options[LintOptionsInfo].fail_on_violation)
     return [info]
 
-def shellcheck_aspect(binary, config):
+def lint_shellcheck_aspect(binary, config):
     """A factory function to create a linter aspect.
 
     Attrs:

--- a/lint/vale.bzl
+++ b/lint/vale.bzl
@@ -125,7 +125,7 @@ def _vale_aspect_impl(target, ctx):
 
     return []
 
-def vale_aspect(binary, config, styles = Label("//lint:empty_styles")):
+def lint_vale_aspect(binary, config, styles = Label("//lint:empty_styles")):
     """A factory function to create a linter aspect."""
     return aspect(
         implementation = _vale_aspect_impl,


### PR DESCRIPTION
### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)

Linter factory symbols were renamed with a `lint_` prefix.
`multi_formatter_binary` was renamed to `format_multi_binary`.

### Test plan

- Covered by existing test cases