### PR TITLE
Use multirun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@ bazel-*
 .idea/
 .ijwb/
 node_modules
-
-# TODO: enable when it is more stable, maybe Bazel 7.1
+# Until it gets more stable
 MODULE.bazel.lock

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ bazel-*
 .idea/
 .ijwb/
 node_modules
-# Until it gets more stable
+
+# TODO: enable when it is more stable, maybe Bazel 7.1
 MODULE.bazel.lock

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,6 +14,7 @@ bazel_dep(name = "aspect_bazel_lib", version = "1.38.0")
 bazel_dep(name = "aspect_rules_js", version = "1.33.1")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "platforms", version = "0.0.7")
+bazel_dep(name = "rules_multirun", version = "0.7.0")
 bazel_dep(name = "rules_multitool", version = "0.4.0")
 
 # Needed in the root because we dereference ProtoInfo in our aspect impl

--- a/docs/format.md
+++ b/docs/format.md
@@ -5,8 +5,8 @@ Produce a multi-formatter that aggregates formatters.
 Some formatter tools are automatically provided by default in rules_lint.
 These are listed as defaults in the API docs below.
 
-Other formatter binaries may be declared in your repository, and you can test them by running
-them with Bazel.
+Other formatter binaries may be declared in your repository.
+You can test that they work by running them directly with `bazel run`.
 
 For example, to add prettier, your `BUILD.bazel` file should contain:
 
@@ -22,76 +22,49 @@ prettier.prettier_binary(
 
 and you can test it with `bazel run //path/to:prettier -- --help`.
 
-Then you can register it with `multi_formatter_binary`:
+Then you can register it with `format_multirun`:
 
 ```
-load("@aspect_rules_lint//format:defs.bzl", "multi_formatter_binary")
+load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
 
-multi_formatter_binary(
+format_multirun(
     name = "format",
     javascript = ":prettier",
-    ...
 )
 ```
 
 
-<a id="multi_formatter_binary_rule"></a>
+<a id="format_multirun"></a>
 
-## multi_formatter_binary_rule
-
-<pre>
-multi_formatter_binary_rule(<a href="#multi_formatter_binary_rule-name">name</a>, <a href="#multi_formatter_binary_rule-cc">cc</a>, <a href="#multi_formatter_binary_rule-go">go</a>, <a href="#multi_formatter_binary_rule-java">java</a>, <a href="#multi_formatter_binary_rule-javascript">javascript</a>, <a href="#multi_formatter_binary_rule-jsonnet">jsonnet</a>, <a href="#multi_formatter_binary_rule-kotlin">kotlin</a>, <a href="#multi_formatter_binary_rule-markdown">markdown</a>, <a href="#multi_formatter_binary_rule-protobuf">protobuf</a>,
-                            <a href="#multi_formatter_binary_rule-python">python</a>, <a href="#multi_formatter_binary_rule-scala">scala</a>, <a href="#multi_formatter_binary_rule-sh">sh</a>, <a href="#multi_formatter_binary_rule-sql">sql</a>, <a href="#multi_formatter_binary_rule-starlark">starlark</a>, <a href="#multi_formatter_binary_rule-swift">swift</a>, <a href="#multi_formatter_binary_rule-terraform">terraform</a>, <a href="#multi_formatter_binary_rule-yaml">yaml</a>)
-</pre>
-
-Produces an executable that aggregates the supplied formatter binaries
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="multi_formatter_binary_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="multi_formatter_binary_rule-cc"></a>cc |  a binary target that runs clang-format (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="multi_formatter_binary_rule-go"></a>go |  a binary target that runs gofmt (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="multi_formatter_binary_rule-java"></a>java |  a binary target that runs java-format (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="multi_formatter_binary_rule-javascript"></a>javascript |  a binary target that runs prettier (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="multi_formatter_binary_rule-jsonnet"></a>jsonnet |  a binary target that runs jsonnetfmt (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="multi_formatter_binary_rule-kotlin"></a>kotlin |  a binary target that runs ktfmt (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="multi_formatter_binary_rule-markdown"></a>markdown |  a binary target that runs prettier-md (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="multi_formatter_binary_rule-protobuf"></a>protobuf |  a binary target that runs buf (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="multi_formatter_binary_rule-python"></a>python |  a binary target that runs ruff (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="multi_formatter_binary_rule-scala"></a>scala |  a binary target that runs scalafmt (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="multi_formatter_binary_rule-sh"></a>sh |  a binary target that runs shfmt (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="multi_formatter_binary_rule-sql"></a>sql |  a binary target that runs prettier-sql (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="multi_formatter_binary_rule-starlark"></a>starlark |  a binary target that runs buildifier (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="multi_formatter_binary_rule-swift"></a>swift |  a binary target that runs swiftformat (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="multi_formatter_binary_rule-terraform"></a>terraform |  a binary target that runs terraform-fmt (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="multi_formatter_binary_rule-yaml"></a>yaml |  a binary target that runs yamlfmt (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-
-
-<a id="multi_formatter_binary"></a>
-
-## multi_formatter_binary
+## format_multirun
 
 <pre>
-multi_formatter_binary(<a href="#multi_formatter_binary-name">name</a>, <a href="#multi_formatter_binary-kwargs">kwargs</a>)
+format_multirun(<a href="#format_multirun-name">name</a>, <a href="#format_multirun-kwargs">kwargs</a>)
 </pre>
 
-Wrapper macro around multi_formatter_binary_rule that sets defaults for some languages.
+Create a multirun binary for the given formatters.
 
+Intended to be used with `bazel run` to update source files in-place.
+
+Also produces a target `[name].check` which does not edit files, rather it exits non-zero
+if any sources require formatting.
+
+Tools are provided by default for some languages.
 These come from the `@multitool` repo.
 Under --enable_bzlmod, rules_lint creates this automatically.
 WORKSPACE users will have to set this up manually. See the release install snippet for an example.
 
 Set any attribute to `False` to turn off that language altogether, rather than use a default tool.
 
+Note that `javascript` is a special case which also formats TypeScript, TSX, JSON, CSS, and HTML.
+
+
 **PARAMETERS**
 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="multi_formatter_binary-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="multi_formatter_binary-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+| <a id="format_multirun-name"></a>name |  name of the resulting target, typically "format"   |  none |
+| <a id="format_multirun-kwargs"></a>kwargs |  attributes named for each language, providing Label of a tool that formats it   |  none |
 
 

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -10,9 +10,9 @@ A formatter is just an executable target.
 Then register them on the `formatters` attribute, for example:
 
 ```starlark
-load("@aspect_rules_lint//format:defs.bzl", "multi_formatter_binary")
+load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
 
-multi_formatter_binary(
+format_multirun(
     name = "format",
     # register languages, e.g.
     # python = "//:ruff",
@@ -67,7 +67,7 @@ If you don't use pre-commit, you can just wire directly into the git hook, howev
 this option will always run the formatter over all files, not just changed files.
 
 ```bash
-$ echo "bazel run //:format -- --mode check" >> .git/hooks/pre-commit
+$ echo "bazel run //:format.check" >> .git/hooks/pre-commit
 $ chmod u+x .git/hooks/pre-commit
 ```
 
@@ -75,4 +75,4 @@ $ chmod u+x .git/hooks/pre-commit
 
 This will exit non-zero if formatting is needed. You would typically run the check mode on CI.
 
-`bazel run //:format -- --mode check`
+`bazel run //tools/format:format.check`

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -6,6 +6,7 @@ package(default_visibility = ["//visibility:public"])
 
 compile_pip_requirements(
     name = "requirements",
+    requirements_in = "requirements.in",
 )
 
 npm_link_all_packages(name = "node_modules")

--- a/example/tools/format/BUILD.bazel
+++ b/example/tools/format/BUILD.bazel
@@ -4,7 +4,7 @@ This is in its own package because it has so many loading-time symbols,
 we don't want to trigger eager fetches of these for builds that don't want to run format.
 """
 
-load("@aspect_rules_lint//format:defs.bzl", "multi_formatter_binary")
+load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
 load("@npm//:prettier/package_json.bzl", prettier = "bin")
 load("@rules_java//java:defs.bzl", "java_binary")
 
@@ -59,7 +59,7 @@ java_binary(
     runtime_deps = ["@maven//:org_scalameta_scalafmt_cli_2_13"],
 )
 
-multi_formatter_binary(
+format_multirun(
     name = "format",
     cc = "@llvm_toolchain_llvm//:bin/clang-format",
     # You can use standard gofmt instead of stricter gofumpt:
@@ -68,7 +68,7 @@ multi_formatter_binary(
     javascript = ":prettier",
     kotlin = ":ktfmt",
     markdown = ":prettier",
-    protobuf = "//tools/lint:buf",
+    protocol_buffer = "//tools/lint:buf",
     python = "//tools/lint:ruff",
     scala = ":scalafmt",
     sql = ":prettier",

--- a/format/BUILD.bazel
+++ b/format/BUILD.bazel
@@ -6,7 +6,10 @@ bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],
-    deps = ["//format/private:formatter_binary"],
+    deps = [
+        "//format/private:formatter_binary",
+        "@rules_multirun//:defs",
+    ],
 )
 
 bzl_library(

--- a/format/defs.bzl
+++ b/format/defs.bzl
@@ -67,7 +67,7 @@ def format_multirun(name, **kwargs):
         #   (and make sure we don't eagerly reference @multitool in case it isn't defined)
         # - otherwise use the user-supplied value
         if lang_attribute in kwargs.keys():
-            tool_label = kwargs.pop("lang_attribute")
+            tool_label = kwargs.pop(lang_attribute)
         else:
             tool_label = Label(DEFAULT_TOOL_LABELS[lang])
         if not tool_label:

--- a/format/defs.bzl
+++ b/format/defs.bzl
@@ -3,8 +3,8 @@
 Some formatter tools are automatically provided by default in rules_lint.
 These are listed as defaults in the API docs below.
 
-Other formatter binaries may be declared in your repository, and you can test them by running
-them with Bazel.
+Other formatter binaries may be declared in your repository.
+You can test that they work by running them directly with `bazel run`.
 
 For example, to add prettier, your `BUILD.bazel` file should contain:
 
@@ -20,43 +20,93 @@ prettier.prettier_binary(
 
 and you can test it with `bazel run //path/to:prettier -- --help`.
 
-Then you can register it with `multi_formatter_binary`:
+Then you can register it with `format_multirun`:
 
 ```
-load("@aspect_rules_lint//format:defs.bzl", "multi_formatter_binary")
+load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
 
-multi_formatter_binary(
+format_multirun(
     name = "format",
     javascript = ":prettier",
-    ...
 )
 ```
 """
 
-load("//format/private:formatter_binary.bzl", _fmt = "multi_formatter_binary")
+load("@rules_multirun//:defs.bzl", "command", "multirun")
+load("//format/private:formatter_binary.bzl", "CHECK_FLAGS", "DEFAULT_TOOL_LABELS", "FIX_FLAGS", "TOOLS", "to_attribute_name")
 
-multi_formatter_binary_rule = _fmt
+def format_multirun(name, **kwargs):
+    """Create a multirun binary for the given formatters.
 
-def multi_formatter_binary(name, **kwargs):
-    """Wrapper macro around multi_formatter_binary_rule that sets defaults for some languages.
+    Intended to be used with `bazel run` to update source files in-place.
 
+    Also produces a target `[name].check` which does not edit files, rather it exits non-zero
+    if any sources require formatting.
+
+    Tools are provided by default for some languages.
     These come from the `@multitool` repo.
     Under --enable_bzlmod, rules_lint creates this automatically.
     WORKSPACE users will have to set this up manually. See the release install snippet for an example.
 
     Set any attribute to `False` to turn off that language altogether, rather than use a default tool.
-    """
 
-    _fmt(
-        name = name,
+    Note that `javascript` is a special case which also formats TypeScript, TSX, JSON, CSS, and HTML.
+
+    Args:
+        name: name of the resulting target, typically "format"
+        **kwargs: attributes named for each language, providing Label of a tool that formats it
+    """
+    commands = []
+
+    for lang, toolname in TOOLS.items():
+        lang_attribute = to_attribute_name(lang)
+
         # Logic:
         # - if there's no value for this key, the user omitted it, so use our default
-        # - if there is a value, and it's False, then pass None to the underlying rule
+        # - if there is a value, and it's False, then skip this language
         #   (and make sure we don't eagerly reference @multitool in case it isn't defined)
         # - otherwise use the user-supplied value
-        jsonnet = kwargs.pop("jsonnet", Label("@multitool//tools/jsonnetfmt")) or None,
-        go = kwargs.pop("go", Label("@multitool//tools/gofumpt")) or None,
-        sh = kwargs.pop("sh", Label("@multitool//tools/shfmt")) or None,
-        yaml = kwargs.pop("yaml", Label("@multitool//tools/yamlfmt")) or None,
-        **kwargs
+        if lang_attribute in kwargs.keys():
+            tool_label = kwargs.pop("lang_attribute")
+        else:
+            tool_label = Label(DEFAULT_TOOL_LABELS[lang])
+        if not tool_label:
+            continue
+
+        target_name = "_".join([name, lang.replace(" ", "_"), "with", toolname])
+
+        for mode in ["check", "fix"]:
+            command(
+                name = target_name + (".check" if mode == "check" else ""),
+                command = "@aspect_rules_lint//format/private:format",
+                description = "Formatting {} with {}...".format(lang, toolname),
+                environment = {
+                    # NB: can't use str(Label(target_name)) here because bzlmod makes it
+                    # the apparent repository, starts with @@aspect_rules_lint~override
+                    "FIX_TARGET": "//{}:{}".format(native.package_name(), target_name),
+                    "tool": "$(rlocationpaths %s)" % tool_label,
+                    "lang": lang,
+                    "flags": FIX_FLAGS[toolname] if mode == "fix" else CHECK_FLAGS[toolname],
+                    "mode": mode,
+                },
+                data = [tool_label],
+            )
+        commands.append(target_name)
+
+    # Error checking in case some user keys were unmatched and therefore not pop'ed
+    for attr in kwargs.keys():
+        fail("""Unknown language "{}". Valid values: {}""".format(attr, [to_attribute_name(lang) for lang in TOOLS.keys()]))
+
+    multirun(
+        name = name,
+        buffer_output = True,
+        commands = commands,
+        # Run up to 4 formatters at the same time. This is an arbitrary choice, based on some idea that 4-core machines are typical.
+        jobs = 4,
+        keep_going = True,
+    )
+
+    multirun(
+        name = name + ".check",
+        commands = [c + ".check" for c in commands],
     )

--- a/format/private/BUILD.bazel
+++ b/format/private/BUILD.bazel
@@ -1,6 +1,11 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-exports_files(["format.sh"])
+sh_binary(
+    name = "format",
+    srcs = ["format.sh"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
 
 bzl_library(
     name = "formatter_binary",

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
-# Template file for a formatter binary. This is expanded by a Bazel action in formatter_binary.bzl
-# to produce an actual Bash script.
-# Expansions are written in "mustache" syntax like {{interpolate_this}}.
+# Wrapper around a formatter tool
 
-{{BASH_RLOCATION_FUNCTION}}
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+# https://github.com/bazelbuild/bazel/blob/master/tools/bash/runfiles/runfiles.bash
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: runfiles.bash initializer cannot find $f. An executable rule may have forgotten to expose it in the runfiles, or the binary may require RUNFILES_DIR to be set."; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
 
 if [[ -z "$BUILD_WORKSPACE_DIRECTORY" ]]; then
   echo >&2 "$0: FATAL: \$BUILD_WORKSPACE_DIRECTORY not set. This program should be executed under 'bazel run'."
@@ -21,7 +29,7 @@ function on_exit {
       ;;
     *)
       echo >&2 "FAILED: A formatter tool exited with code $code"
-      echo >&2 "Try running 'bazel run {{fix_target}}' to fix this."
+      echo >&2 "Try running 'bazel run $FIX_TARGET' to fix this."
       ;;
   esac
 }
@@ -95,51 +103,6 @@ function ls-files {
     fi
 }
 
-# Define the flags for the tools based on the mode of operation
-mode=fix
-if [ "${1:-}" == "--mode" ]; then
-  readonly mode=$2
-  shift 2
-fi
-
-case "$mode" in
- check)
-   swiftmode="--lint"
-   prettiermode="--check"
-   ruffmode="format --check"
-   shfmtmode="-l"
-   javamode="--set-exit-if-changed --dry-run"
-   ktmode="--set-exit-if-changed --dry-run"
-   gofmtmode="-l"
-   bufmode="format -d --exit-code"
-   tfmode="-check -diff"
-   jsonnetmode="--test"
-   scalamode="--test"
-   clangformatmode="--style=file --fallback-style=none --dry-run -Werror"
-   yamlfmtmode="-lint"
-   ;;
- fix)
-   swiftmode=""
-   prettiermode="--write"
-   # Force exclusions in the configuration file to be honored even when file paths are supplied
-   # as command-line arguments; see
-   # https://github.com/astral-sh/ruff/discussions/5857#discussioncomment-6583943
-   ruffmode="format --force-exclude"
-   # NB: apply-ignore added in https://github.com/mvdan/sh/issues/1037
-   shfmtmode="-w --apply-ignore"
-   javamode="--replace"
-   ktmode=""
-   gofmtmode="-w"
-   bufmode="format -w"
-   tfmode=""
-   jsonnetmode="--in-place"
-   scalamode=""
-   clangformatmode="-style=file --fallback-style=none -i"
-   yamlfmtmode=""
-   ;;
- *) echo >&2 "unknown mode $mode";;
-esac
-
 function time-run {
   local files="$1" && shift
   local bin="$1" && shift
@@ -154,7 +117,6 @@ function time-run {
 
 function run-format {
   local lang="$1" && shift
-  local fmtname="$1" && shift
   local bin="$1" && shift
   local args="$1" && shift
   local tuser
@@ -162,7 +124,6 @@ function run-format {
 
   local files=$(ls-files "$lang" $@)
   if [ -n "$files" ] && [ -n "$bin" ]; then
-    echo "Formatting ${lang} with ${fmtname}..."
     case "$lang" in
     'Protocol Buffer')
         ( for file in $files; do
@@ -201,26 +162,20 @@ function run-format {
   fi
 }
 
-# Run each supplied formatter over the files it owns
+bin="$(rlocation $tool)"
+if [ ! -e "$bin" ]; then
+  echo >&2 "cannot locate binary $tool"
+  exit 1
+fi
 
-run-format Starlark Buildifier "$(rlocation {{buildifier}})" "-mode=$mode" $@
-run-format Markdown Prettier "$(rlocation {{prettier-md}})" "$prettiermode" $@
-run-format JSON Prettier "$(rlocation {{prettier}})" "$prettiermode" $@
-run-format JavaScript Prettier "$(rlocation {{prettier}})" "$prettiermode" $@
-run-format CSS Prettier "$(rlocation {{prettier}})" "$prettiermode" $@
-run-format HTML Prettier "$(rlocation {{prettier}})" "$prettiermode" $@
-run-format TypeScript Prettier "$(rlocation {{prettier}})" "$prettiermode" $@
-run-format TSX Prettier "$(rlocation {{prettier}})" "$prettiermode" $@
-run-format SQL Prettier "$(rlocation {{prettier-sql}})" "$prettiermode" $@
-run-format Python Ruff "$(rlocation {{ruff}})" "$ruffmode" $@
-run-format Terraform "terraform fmt" "$(rlocation {{terraform-fmt}})" "fmt $tfmode" $@
-run-format Jsonnet jsonnetfmt "$(rlocation {{jsonnetfmt}})" "$jsonnetmode" $@
-run-format Java java-format "$(rlocation {{java-format}})" "$javamode" $@
-run-format Kotlin ktfmt "$(rlocation {{ktfmt}})" "$ktmode" $@
-run-format Scala scalafmt "$(rlocation {{scalafmt}})" "$scalamode" $@
-run-format Go gofmt "$(rlocation {{gofmt}})" "$gofmtmode" $@
-run-format C++ clang-format "$(rlocation {{clang-format}})" "$clangformatmode" $@
-run-format Shell shfmt "$(rlocation {{shfmt}})" "$shfmtmode" $@
-run-format Swift swiftfmt "$(rlocation {{swiftformat}})" "$swiftmode" $@
-run-format 'Protocol Buffer' buf "$(rlocation {{buf}})" "$bufmode" $@
-run-format YAML yamlfmt "$(rlocation {{yamlfmt}})" "$yamlfmtmode" $@
+run-format "$lang" "$bin" "${flags:-""}" $@
+
+# Currently these aren't exposed as separate languages to the attributes of format_multirun
+# So we format all these languages as part of "JavaScript".
+if [[ "$lang" == "JavaScript" ]]; then
+  run-format "CSS" "$bin" "${flags:-""}" $@
+  run-format "HTML" "$bin" "${flags:-""}" $@
+  run-format "JSON" "$bin" "${flags:-""}" $@
+  run-format "TSX" "$bin" "${flags:-""}" $@
+  run-format "TypeScript" "$bin" "${flags:-""}" $@
+fi

--- a/format/repositories.bzl
+++ b/format/repositories.bzl
@@ -17,6 +17,13 @@ def http_jar(**kwargs):
 
 def rules_lint_dependencies():
     http_archive(
+        name = "rules_multirun",
+        sha256 = "7b699b3922919d727e7f5aa868286e59cc69fa6aa14f6c3e54a4674010bd1582",
+        strip_prefix = "rules_multirun-0.7.0",
+        url = "https://github.com/keith/rules_multirun/releases/download/0.7.0/rules_multirun-0.7.0.tar.gz",
+    )
+
+    http_archive(
         name = "rules_multitool",
         sha256 = "793105ea4bb89cf9d82411cbee40b6874085f530314600887539e214e4970a3a",
         strip_prefix = "rules_multitool-0.4.0",

--- a/format/test/BUILD.bazel
+++ b/format/test/BUILD.bazel
@@ -1,6 +1,9 @@
+load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("//format:defs.bzl", "multi_formatter_binary")
+load("//format:defs.bzl", "format_multirun")
 load("//format/private:formatter_binary.bzl", "TOOLS")
+
+UNIQUE_TOOLS = sets.to_list(sets.make(TOOLS.values()))
 
 # Avoid depending on a bunch of actual tools in the root module.
 # That's the job of the example/ submodule.
@@ -14,7 +17,7 @@ load("//format/private:formatter_binary.bzl", "TOOLS")
             "echo + {} $*".format(t),
         ],
     )
-    for t in TOOLS.values()
+    for t in UNIQUE_TOOLS
 ]
 
 [
@@ -22,88 +25,26 @@ load("//format/private:formatter_binary.bzl", "TOOLS")
         name = "mock_" + t,
         srcs = ["mock_{}.sh".format(t)],
     )
-    for t in TOOLS.values()
+    for t in UNIQUE_TOOLS
 ]
 
-# Make a separate formatter binary to test each language in isolation.
-# Users should NOT do it this way!
-multi_formatter_binary(
-    name = "format_javascript",
+format_multirun(
+    name = "format",
+    cc = ":mock_clang-format.sh",
+    go = ":mock_gofmt.sh",
+    java = ":mock_java-format.sh",
     javascript = ":mock_prettier.sh",
-)
-
-multi_formatter_binary(
-    name = "format_starlark",
-    starlark = ":mock_buildifier.sh",
-)
-
-multi_formatter_binary(
-    name = "format_markdown",
+    jsonnet = ":mock_jsonnetfmt.sh",
+    kotlin = ":mock_ktfmt.sh",
     markdown = ":mock_prettier.sh",
-)
-
-multi_formatter_binary(
-    name = "format_sql",
-    sql = ":mock_prettier.sh",
-)
-
-multi_formatter_binary(
-    name = "format_python",
+    protocol_buffer = ":mock_buf.sh",
     python = ":mock_ruff.sh",
-)
-
-multi_formatter_binary(
-    name = "format_hcl",
+    scala = ":mock_scalafmt.sh",
+    shell = ":mock_shfmt.sh",
+    sql = ":mock_prettier.sh",
+    starlark = ":mock_buildifier.sh",
+    swift = ":mock_swiftformat.sh",
     # TODO: this attribute should be renamed to hcl
     terraform = ":mock_terraform-fmt.sh",
-)
-
-multi_formatter_binary(
-    name = "format_jsonnet",
-    jsonnet = ":mock_jsonnetfmt.sh",
-)
-
-multi_formatter_binary(
-    name = "format_java",
-    java = ":mock_java-format.sh",
-)
-
-multi_formatter_binary(
-    name = "format_kotlin",
-    kotlin = ":mock_ktfmt.sh",
-)
-
-multi_formatter_binary(
-    name = "format_scala",
-    scala = ":mock_scalafmt.sh",
-)
-
-multi_formatter_binary(
-    name = "format_go",
-    go = ":mock_gofmt.sh",
-)
-
-multi_formatter_binary(
-    name = "format_cc",
-    cc = ":mock_clang-format.sh",
-)
-
-multi_formatter_binary(
-    name = "format_sh",
-    sh = ":mock_shfmt.sh",
-)
-
-multi_formatter_binary(
-    name = "format_swift",
-    swift = ":mock_swiftformat.sh",
-)
-
-multi_formatter_binary(
-    name = "format_protobuf",
-    protobuf = ":mock_buf.sh",
-)
-
-multi_formatter_binary(
-    name = "format_yaml",
     yaml = ":mock_yamlfmt.sh",
 )

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -6,151 +6,130 @@ bats_load_library "bats-assert"
 
 # No arguments: will use git ls-files
 @test "should run prettier on javascript using git ls-files" {
-    run bazel run //format/test:format_javascript
+    run bazel run //format/test:format_JavaScript_with_prettier
     assert_success
 
-    assert_output --partial "Formatting JavaScript with Prettier..."
     assert_output --partial "+ prettier --write example/.eslintrc.cjs"
-    assert_output --partial "Formatting TypeScript with Prettier..."
     assert_output --partial "+ prettier --write example/src/file.ts example/test/no_violations.ts"
-    assert_output --partial "Formatting TSX with Prettier..."
     assert_output --partial "+ prettier --write example/src/hello.tsx"
-    assert_output --partial "Formatting JSON with Prettier..."
     assert_output --partial "+ prettier --write .bcr/metadata.template.json"
-    assert_output --partial "Formatting CSS with Prettier..."
     assert_output --partial "+ prettier --write example/src/hello.css"
-    assert_output --partial "Formatting HTML with Prettier..."
     assert_output --partial "+ prettier --write example/src/index.html"
 }
 
 # File arguments: will filter with find
 @test "should run prettier on javascript using find" {
-    run bazel run //format/test:format_javascript README.md example/.eslintrc.cjs
+    run bazel run //format/test:format_JavaScript_with_prettier README.md example/.eslintrc.cjs
     assert_success
 
-    assert_output --partial "Formatting JavaScript with Prettier..."
-    refute_output --partial "Formatting TypeScript with Prettier..."
+    assert_output --partial "README.md"
+    refute_output --partial "file.ts"
 }
 
 @test "should run buildozer on starlark" {
-    run bazel run //format/test:format_starlark
+    run bazel run //format/test:format_Starlark_with_buildifier
     assert_success
 
-    assert_output --partial "Formatting Starlark with Buildifier..."
     assert_output --partial "+ buildifier -mode=fix BUILD.bazel"
     assert_output --partial "format/private/BUILD.bazel"
 }
 
 @test "should run prettier on Markdown" {
-    run bazel run //format/test:format_markdown
+    run bazel run //format/test:format_Markdown_with_prettier
     assert_success
 
-    assert_output --partial "Formatting Markdown with Prettier..."
     assert_output --partial "+ prettier --write .bcr/README.md CONTRIBUTING.md README.md"
 }
 
 @test "should run prettier on SQL" {
-    run bazel run //format/test:format_sql
+    run bazel run //format/test:format_SQL_with_prettier
     assert_success
 
-    assert_output --partial "Formatting SQL with Prettier..."
     assert_output --partial "+ prettier --write example/src/hello.sql"
 }
 
 @test "should run ruff on Python" {
-    run bazel run //format/test:format_python
+    run bazel run //format/test:format_Python_with_ruff
     assert_success
 
-    assert_output --partial "Formatting Python with Ruff..."
     assert_output --partial "+ ruff format --force-exclude example/src/subdir/unused_import.py"
 }
 
 @test "should run terraform fmt on HCL" {
-    run bazel run //format/test:format_hcl
+    run bazel run //format/test:format_Terraform_with_terraform-fmt
     assert_success
 
-    assert_output --partial "Formatting Terraform with terraform fmt..."
     assert_output --partial "+ terraform-fmt fmt example/src/hello.tf"
 }
 
 @test "should run jsonnet-fmt on Jsonnet" {
-    run bazel run //format/test:format_jsonnet
+    run bazel run //format/test:format_Jsonnet_with_jsonnetfmt
     assert_success
 
-    assert_output --partial "Formatting Jsonnet with jsonnetfmt..."
     assert_output --partial "+ jsonnetfmt --in-place example/src/hello.jsonnet example/src/hello.libsonnet"
 }
 
 @test "should run java-format on Java" {
-    run bazel run //format/test:format_java
+    run bazel run //format/test:format_Java_with_java-format
     assert_success
 
-    assert_output --partial "Formatting Java with java-format..."
     assert_output --partial "+ java-format --replace example/src/Foo.java"
 }
 
 @test "should run ktfmt on Kotlin" {
-    run bazel run //format/test:format_kotlin
+    run bazel run //format/test:format_Kotlin_with_ktfmt
     assert_success
 
-    assert_output --partial "Formatting Kotlin with ktfmt..."
     assert_output --partial "+ ktfmt example/src/hello.kt"
 }
 
 @test "should run scalafmt on Scala" {
-    run bazel run //format/test:format_scala
+    run bazel run //format/test:format_Scala_with_scalafmt
     assert_success
 
-    assert_output --partial "Formatting Scala with scalafmt..."
     assert_output --partial "+ scalafmt example/src/hello.scala"
 }
 
 @test "should run gofmt on Go" {
-    run bazel run //format/test:format_go
+    run bazel run //format/test:format_Go_with_gofmt
     assert_success
 
-    assert_output --partial "Formatting Go with gofmt..."
     assert_output --partial "+ gofmt -w example/src/hello.go"
 }
 
 @test "should run clang-format on C++" {
-    run bazel run //format/test:format_cc
+    run bazel run //format/test:format_C++_with_clang-format
     assert_success
 
-    assert_output --partial "Formatting C++ with clang-format..."
     assert_output --partial "+ clang-format -style=file --fallback-style=none -i example/src/hello.cpp"
 }
 
 @test "should run shfmt on Shell" {
-    run bazel run //format/test:format_sh
+    run bazel run //format/test:format_Shell_with_shfmt
     assert_success
 
-    assert_output --partial "Formatting Shell with shfmt..."
     assert_output --partial "+ shfmt -w --apply-ignore .github/workflows/release_prep.sh"
 }
 
 @test "should run swiftformat on Swift" {
-    run bazel run //format/test:format_swift
+    run bazel run //format/test:format_Swift_with_swiftformat
     assert_success
 
-    # The real swiftformat prints the "Formatting..." output so we don't
     assert_output --partial "+ swiftformat example/src/hello.swift"
 }
 
 @test "should run buf on Protobuf" {
-    run bazel run //format/test:format_protobuf
+    run bazel run //format/test:format_Protocol_Buffer_with_buf
     assert_success
 
-    assert_output --partial "Formatting Protocol Buffer with buf..."
     # Buf only formats one file at a time
     assert_output --partial "+ buf format -w example/src/file.proto"
     assert_output --partial "+ buf format -w example/src/unused.proto"
 }
 
 @test "should run yamlfmt on YAML" {
-    run bazel run //format/test:format_yaml
+    run bazel run //format/test:format_YAML_with_yamlfmt
     assert_success
 
-    assert_output --partial "Formatting YAML with yamlfmt..."
     assert_output --partial "+ yamlfmt .bcr/config.yml"
 }


### PR DESCRIPTION
This has the side-effect of making a formatter binary per-language, which was one of our design review outcomes, since Aspect Workflows might want to be able to run them individually or in parallel.

FYI @keith since it's taking a dependency on your repo

Also now formats-in-parallel using the `jobs` attribute of `multirun`.

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)

`multi_formatter_binary` is renamed to `format_multirun` and some attributes were renamed: 

- `sh` is now `shell`
- `protobuf` is now `protocol_buffer`.

### Test plan

- Covered by existing test cases
