### PR TITLE
refactor: use an explicit flag rather than attr_attribute

### DIFF
--- a/docs/linting.md
+++ b/docs/linting.md
@@ -59,8 +59,8 @@ This is the same flag many linters support.
 
 ### 4. Errors during `bazel build`
 
-By adding `--aspects_parameters=fail_on_violation=true` to the command-line, we pass a parameter
-to our linter aspects that cause them to honor the exit code of the lint tool.
+Add `--@aspect_rules_lint//lint:fail_on_violation` to the command-line,
+to cause all linter aspects to honor the exit code of the lint tool.
 
 This makes the build fail when any lint violations are present.
 

--- a/example/lint.sh
+++ b/example/lint.sh
@@ -32,7 +32,7 @@ report_args=(
 # This is a rudimentary flag parser.
 if [ $1 == "--fail-on-violation" ]; then
 	args+=(
-		"--aspects_parameters=fail_on_violation=true"
+		"--@aspect_rules_lint//lint:fail_on_violation"
 		"--keep_going"
 	)
 	shift

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("//lint/private:lint_aspect.bzl", "fail_on_violation_flag")
 
 exports_files(glob(["*.bzl"]) + ["lint_test.sh"])
 
@@ -29,6 +30,12 @@ config_setting(
 
 bool_flag(
     name = "debug",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+fail_on_violation_flag(
+    name = "fail_on_violation",
     build_setting_default = False,
     visibility = ["//visibility:public"],
 )

--- a/lint/buf.bzl
+++ b/lint/buf.bzl
@@ -12,7 +12,7 @@ buf = buf_lint_aspect(
 """
 
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
-load("//lint/private:lint_aspect.bzl", "report_file")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "report_file")
 
 _MNEMONIC = "buf"
 
@@ -82,7 +82,7 @@ def _buf_lint_aspect_impl(target, ctx):
         return []
 
     report, info = report_file(_MNEMONIC, target, ctx)
-    buf_lint_action(ctx, ctx.toolchains[ctx.attr._buf_toolchain], target, report, ctx.attr.fail_on_violation)
+    buf_lint_action(ctx, ctx.toolchains[ctx.attr._buf_toolchain], target, report, ctx.attr._options[LintOptionsInfo].fail_on_violation)
     return [info]
 
 def buf_lint_aspect(config, toolchain = "@rules_buf//tools/protoc-gen-buf-lint:toolchain_type"):
@@ -96,7 +96,10 @@ def buf_lint_aspect(config, toolchain = "@rules_buf//tools/protoc-gen-buf-lint:t
         implementation = _buf_lint_aspect_impl,
         attr_aspects = ["deps"],
         attrs = {
-            "fail_on_violation": attr.bool(),
+            "_options": attr.label(
+                default = "//lint:fail_on_violation",
+                providers = [LintOptionsInfo],
+            ),
             "_buf_toolchain": attr.string(
                 default = toolchain,
             ),

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -39,7 +39,7 @@ See the [react example](https://github.com/bazelbuild/examples/blob/b498bb106b20
 
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "copy_files_to_bin_actions")
 load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
-load("//lint/private:lint_aspect.bzl", "filter_srcs", "patch_and_report_files")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "patch_and_report_files")
 
 _MNEMONIC = "ESLint"
 
@@ -147,7 +147,7 @@ def _eslint_aspect_impl(target, ctx):
 
     patch, report, info = patch_and_report_files(_MNEMONIC, target, ctx)
     files_to_lint = filter_srcs(ctx.rule)
-    eslint_action(ctx, ctx.executable, files_to_lint, report, ctx.attr.fail_on_violation)
+    eslint_action(ctx, ctx.executable, files_to_lint, report, ctx.attr._options[LintOptionsInfo].fail_on_violation)
     eslint_fix(ctx, ctx.executable, files_to_lint, patch)
     return [info]
 
@@ -170,7 +170,10 @@ def eslint_aspect(binary, configs):
     return aspect(
         implementation = _eslint_aspect_impl,
         attrs = {
-            "fail_on_violation": attr.bool(),
+            "_options": attr.label(
+                default = "//lint:fail_on_violation",
+                providers = [LintOptionsInfo],
+            ),
             "_eslint": attr.label(
                 default = binary,
                 executable = True,

--- a/lint/flake8.bzl
+++ b/lint/flake8.bzl
@@ -12,7 +12,7 @@ flake8 = flake8_aspect(
 ```
 """
 
-load("//lint/private:lint_aspect.bzl", "filter_srcs", "report_file")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "report_file")
 
 _MNEMONIC = "flake8"
 
@@ -64,7 +64,7 @@ def _flake8_aspect_impl(target, ctx):
         return []
 
     report, info = report_file(_MNEMONIC, target, ctx)
-    flake8_action(ctx, ctx.executable._flake8, filter_srcs(ctx.rule), ctx.file._config_file, report, ctx.attr.fail_on_violation)
+    flake8_action(ctx, ctx.executable._flake8, filter_srcs(ctx.rule), ctx.file._config_file, report, ctx.attr._options[LintOptionsInfo].fail_on_violation)
     return [info]
 
 def flake8_aspect(binary, config):
@@ -88,7 +88,10 @@ def flake8_aspect(binary, config):
         # Needed for linters that need semantic information like transitive type declarations.
         # attr_aspects = ["deps"],
         attrs = {
-            "fail_on_violation": attr.bool(),
+            "_options": attr.label(
+                default = "//lint:fail_on_violation",
+                providers = [LintOptionsInfo],
+            ),
             "_flake8": attr.label(
                 default = binary,
                 executable = True,

--- a/lint/golangci-lint.bzl
+++ b/lint/golangci-lint.bzl
@@ -12,7 +12,7 @@ golangci_lint = golangci_lint_aspect(
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_bazel_rules_go//go:def.bzl", "go_context")
-load("//lint/private:lint_aspect.bzl", "filter_srcs", "report_file")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "report_file")
 
 _MNEMONIC = "golangcilint"
 
@@ -74,7 +74,7 @@ def _golangci_lint_aspect_impl(target, ctx):
     if not srcs:
         return []
 
-    golangci_lint_action(ctx, ctx.executable._golangci_lint, srcs, ctx.file._config_file, report, ctx.attr.fail_on_violation)
+    golangci_lint_action(ctx, ctx.executable._golangci_lint, srcs, ctx.file._config_file, report, ctx.attr._options[LintOptionsInfo].fail_on_violation)
     return [info]
 
 def golangci_lint_aspect(binary, config):
@@ -87,7 +87,10 @@ def golangci_lint_aspect(binary, config):
     return aspect(
         implementation = _golangci_lint_aspect_impl,
         attrs = {
-            "fail_on_violation": attr.bool(),
+            "_options": attr.label(
+                default = "//lint:fail_on_violation",
+                providers = [LintOptionsInfo],
+            ),
             "_golangci_lint": attr.label(
                 default = binary,
                 executable = True,

--- a/lint/lint_test.bzl
+++ b/lint/lint_test.bzl
@@ -60,9 +60,6 @@ def make_lint_test(aspect):
         implementation = _test_impl,
         attrs = {
             "srcs": attr.label_list(doc = "*_library targets", aspects = [aspect]),
-            # Note, we don't use this in the test, but the user passes an aspect that has this aspect_attribute,
-            # and that requires that we list it here as well.
-            "fail_on_violation": attr.bool(),
             "_bin": attr.label(default = ":lint_test.sh", allow_single_file = True, executable = True, cfg = "exec"),
             "_runfiles_lib": attr.label(default = "@bazel_tools//tools/bash/runfiles", allow_single_file = True),
         },

--- a/lint/pmd.bzl
+++ b/lint/pmd.bzl
@@ -12,7 +12,7 @@ pmd = pmd_aspect(
 ```
 """
 
-load("//lint/private:lint_aspect.bzl", "filter_srcs", "report_file")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "report_file")
 
 _MNEMONIC = "PMD"
 
@@ -69,7 +69,7 @@ def _pmd_aspect_impl(target, ctx):
         return []
 
     report, info = report_file(_MNEMONIC, target, ctx)
-    pmd_action(ctx, ctx.executable._pmd, filter_srcs(ctx.rule), ctx.files._rulesets, report, ctx.attr.fail_on_violation)
+    pmd_action(ctx, ctx.executable._pmd, filter_srcs(ctx.rule), ctx.files._rulesets, report, ctx.attr._options[LintOptionsInfo].fail_on_violation)
     return [info]
 
 def pmd_aspect(binary, rulesets):
@@ -95,7 +95,10 @@ def pmd_aspect(binary, rulesets):
         # Needed for linters that need semantic information like transitive type declarations.
         # attr_aspects = ["deps"],
         attrs = {
-            "fail_on_violation": attr.bool(),
+            "_options": attr.label(
+                default = "//lint:fail_on_violation",
+                providers = [LintOptionsInfo],
+            ),
             "_pmd": attr.label(
                 default = binary,
                 executable = True,

--- a/lint/private/lint_aspect.bzl
+++ b/lint/private/lint_aspect.bzl
@@ -1,5 +1,18 @@
 "Helpers to reduce boilerplate for writing linter aspects"
 
+LintOptionsInfo = provider(
+    doc = "Global options for running linters",
+    fields = {"fail_on_violation": "whether to honor the exit code of linter tools run as actions"},
+)
+
+def _fail_on_violation_flag_impl(ctx):
+    return LintOptionsInfo(fail_on_violation = ctx.build_setting_value)
+
+fail_on_violation_flag = rule(
+    implementation = _fail_on_violation_flag_impl,
+    build_setting = config.bool(flag = True),
+)
+
 def report_file(mnemonic, target, ctx):
     report = ctx.actions.declare_file("{}.{}.aspect_rules_lint.report".format(mnemonic, target.label.name))
     return report, OutputGroupInfo(rules_lint_report = depset([report]))

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -17,7 +17,7 @@ shellcheck = shellcheck_aspect(
 """
 
 load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
-load("//lint/private:lint_aspect.bzl", "filter_srcs", "report_file")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "report_file")
 load("//lint/private:maybe.bzl", http_archive = "maybe_http_archive")
 
 _MNEMONIC = "shellcheck"
@@ -81,7 +81,7 @@ def _shellcheck_aspect_impl(target, ctx):
         return []
 
     report, info = report_file(_MNEMONIC, target, ctx)
-    shellcheck_action(ctx, ctx.executable._shellcheck, filter_srcs(ctx.rule), ctx.file._config_file, report, ctx.attr.fail_on_violation)
+    shellcheck_action(ctx, ctx.executable._shellcheck, filter_srcs(ctx.rule), ctx.file._config_file, report, ctx.attr._options[LintOptionsInfo].fail_on_violation)
     return [info]
 
 def shellcheck_aspect(binary, config):
@@ -94,7 +94,10 @@ def shellcheck_aspect(binary, config):
     return aspect(
         implementation = _shellcheck_aspect_impl,
         attrs = {
-            "fail_on_violation": attr.bool(),
+            "_options": attr.label(
+                default = "//lint:fail_on_violation",
+                providers = [LintOptionsInfo],
+            ),
             "_shellcheck": attr.label(
                 default = binary,
                 executable = True,

--- a/lint/vale.bzl
+++ b/lint/vale.bzl
@@ -64,7 +64,7 @@ vale = vale_aspect(
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("//lint/private:lint_aspect.bzl", "report_file")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "report_file")
 load(":vale_library.bzl", "fetch_styles")
 load(":vale_versions.bzl", "VALE_VERSIONS")
 
@@ -120,7 +120,7 @@ def _vale_aspect_impl(target, ctx):
             styles = ctx.files._styles[0]
             if not styles.is_directory:
                 fail("Styles should be a directory containing installed styles")
-        vale_action(ctx, ctx.executable._vale, ctx.rule.files.srcs, styles, ctx.file._config, report, ctx.attr.fail_on_violation)
+        vale_action(ctx, ctx.executable._vale, ctx.rule.files.srcs, styles, ctx.file._config, report, ctx.attr._options[LintOptionsInfo].fail_on_violation)
         return [info]
 
     return []
@@ -130,7 +130,10 @@ def vale_aspect(binary, config, styles = Label("//lint:empty_styles")):
     return aspect(
         implementation = _vale_aspect_impl,
         attrs = {
-            "fail_on_violation": attr.bool(),
+            "_options": attr.label(
+                default = "//lint:fail_on_violation",
+                providers = [LintOptionsInfo],
+            ),
             "_vale": attr.label(
                 default = binary,
                 executable = True,


### PR DESCRIPTION
The latter is a global namespace, and also leaked into a test where it shouldn't have been needed

---

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)

`--aspects_parameters=fail_on_violation=true` must be replaced with `--@aspect_rules_lint//lint:fail_on_violation`

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:

Ran `lint.sh --fail-on-violation //src:all` in the example.