### PR TITLE
fix: guard lookups into DEFAULT_TOOL_LABELS

### DIFF
--- a/format/defs.bzl
+++ b/format/defs.bzl
@@ -62,13 +62,14 @@ def format_multirun(name, **kwargs):
         lang_attribute = to_attribute_name(lang)
 
         # Logic:
-        # - if there's no value for this key, the user omitted it, so use our default
+        # - if there's no value for this key, the user omitted it, so use our default if we have one
         # - if there is a value, and it's False, then skip this language
         #   (and make sure we don't eagerly reference @multitool in case it isn't defined)
         # - otherwise use the user-supplied value
+        tool_label = False
         if lang_attribute in kwargs.keys():
             tool_label = kwargs.pop(lang_attribute)
-        else:
+        elif lang in DEFAULT_TOOL_LABELS.keys():
             tool_label = Label(DEFAULT_TOOL_LABELS[lang])
         if not tool_label:
             continue


### PR DESCRIPTION
Fixes a bug introduced in 0.14.0 like 'Markdown': key not found in dict

---
