### PR TITLE
fix(example): demonstrate use of type definitions in eslint aspect

### DIFF
--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -32,6 +32,7 @@ js_library(
     deps = [
         ":node_modules/@eslint/js",
         ":node_modules/typescript-eslint",
+        "//src:tsconfig",
     ],
 )
 

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -32,7 +32,6 @@ js_library(
     deps = [
         ":node_modules/@eslint/js",
         ":node_modules/typescript-eslint",
-        "//src:tsconfig",
     ],
 )
 

--- a/example/eslint.config.mjs
+++ b/example/eslint.config.mjs
@@ -5,8 +5,16 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   eslint.configs.recommended,
-  ...tseslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
   ...tseslint.configs.stylistic,
+  {
+    languageOptions: {
+      parserOptions: {
+        // indicates to find the closest tsconfig.json for each source file
+        project: true,
+      },
+    },
+  },
   // Demonstrate override for a subdirectory.
   // Note that unlike eslint 8 and earlier, it does not resolve to a configuration file
   // in a parent folder of the files being checked; instead it only looks in the working
@@ -16,6 +24,8 @@ export default tseslint.config(
     files: ["src/subdir/**"],
     rules: {
       "no-debugger": "off",
+      "@typescript-eslint/no-redundant-type-constituents": "error",
+      "sort-imports": "error",
     },
   }
 );

--- a/example/eslint.config.mjs
+++ b/example/eslint.config.mjs
@@ -25,7 +25,7 @@ export default tseslint.config(
     rules: {
       "no-debugger": "off",
       "@typescript-eslint/no-redundant-type-constituents": "error",
-      "sort-imports": "error",
+      "sort-imports": "warn",
     },
   }
 );

--- a/example/eslint.config.mjs
+++ b/example/eslint.config.mjs
@@ -6,7 +6,7 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
-  ...tseslint.configs.stylistic,
+  ...tseslint.configs.stylisticTypeChecked,
   {
     languageOptions: {
       parserOptions: {

--- a/example/eslint.config.mjs
+++ b/example/eslint.config.mjs
@@ -5,9 +5,12 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   eslint.configs.recommended,
-  ...tseslint.configs.recommendedTypeChecked,
-  ...tseslint.configs.stylisticTypeChecked,
   {
+    files: ["src/**/*.ts"],
+    extends: [
+      ...tseslint.configs.recommendedTypeChecked,
+      ...tseslint.configs.stylisticTypeChecked,
+    ],
     languageOptions: {
       parserOptions: {
         // indicates to find the closest tsconfig.json for each source file

--- a/example/package.json
+++ b/example/package.json
@@ -1,4 +1,7 @@
 {
+  "dependencies": {
+    "moment": "*"
+  },
   "devDependencies": {
     "@eslint/js": "^9",
     "eslint": "^9",

--- a/example/package.json
+++ b/example/package.json
@@ -4,6 +4,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9",
+    "@types/node": "^18",
     "eslint": "^9",
     "prettier": "^2.8.7",
     "prettier-plugin-sql": "^0.14.0",

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -6,9 +6,14 @@ settings:
 
 packageExtensionsChecksum: 19f0d7e792b840865d8c76630f5d93fb
 
+dependencies:
+  moment:
+    specifier: "*"
+    version: 1.0.0
+
 devDependencies:
   "@eslint/js":
-    specifier: ^9.3.0
+    specifier: ^9
     version: 9.3.0
   eslint:
     specifier: ^9
@@ -982,6 +987,13 @@ packages:
     dependencies:
       brace-expansion: 2.0.1
     dev: true
+
+  /moment@1.0.0:
+    resolution:
+      {
+        integrity: sha512-OJ+qbuimy8etd9x6HbyUdB0vaneRbm7EXuXs/EewK93a9GwoJfx/E15kbBAMQzZq3N7IdEFY3jwcOzNwILJWoA==,
+      }
+    dev: false
 
   /moo@0.5.2:
     resolution:

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -15,6 +15,9 @@ devDependencies:
   "@eslint/js":
     specifier: ^9
     version: 9.3.0
+  "@types/node":
+    specifier: ^18
+    version: 18.0.0
   eslint:
     specifier: ^9
     version: 9.3.0
@@ -146,6 +149,13 @@ packages:
     dependencies:
       "@nodelib/fs.scandir": 2.1.5
       fastq: 1.15.0
+    dev: true
+
+  /@types/node@18.0.0:
+    resolution:
+      {
+        integrity: sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==,
+      }
     dev: true
 
   /@typescript-eslint/eslint-plugin@7.10.0(@typescript-eslint/parser@7.10.0)(eslint@9.3.0)(typescript@4.9.5):

--- a/example/src/BUILD.bazel
+++ b/example/src/BUILD.bazel
@@ -20,6 +20,7 @@ filegroup(
 ts_project(
     name = "ts",
     srcs = ["file.ts"],
+    declaration = True,
     transpiler = "tsc",
 )
 

--- a/example/src/BUILD.bazel
+++ b/example/src/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@aspect_rules_lint//format:defs.bzl", "format_test")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+)
 
 filegroup(
     name = "md",

--- a/example/src/subdir/BUILD.bazel
+++ b/example/src/subdir/BUILD.bazel
@@ -20,6 +20,7 @@ ts_project(
     transpiler = "tsc",
     tsconfig = "//src:tsconfig",
     deps = [
+        "//:node_modules/@types/node",
         "//:node_modules/moment",
     ],
 )

--- a/example/src/subdir/BUILD.bazel
+++ b/example/src/subdir/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 
 exports_files(["ruff.toml"])
 
@@ -10,4 +11,15 @@ py_library(
 js_library(
     name = "eslint-override",
     srcs = ["index.js"],
+)
+
+ts_project(
+    name = "ts",
+    srcs = ["test.ts"],
+    declaration = True,
+    transpiler = "tsc",
+    tsconfig = "//src:tsconfig",
+    deps = [
+        "//:node_modules/moment",
+    ],
 )

--- a/example/src/subdir/test.ts
+++ b/example/src/subdir/test.ts
@@ -1,0 +1,7 @@
+import { Moment } from "moment";
+// intentionally out-of-order import
+import { IncomingHttpHeaders } from "http";
+
+// typescript-eslint should error with
+// 'any' overrides all other types in this union type
+export type MomentOrNull = Moment | null;

--- a/example/src/tsconfig.json
+++ b/example/src/tsconfig.json
@@ -1,1 +1,6 @@
-{}
+{
+  "compilerOptions": {
+    "declaration": true,
+    "esModuleInterop": true
+  }
+}

--- a/example/src/tsconfig.json
+++ b/example/src/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "strictNullChecks": true
   }
 }

--- a/example/tools/lint/linters.bzl
+++ b/example/tools/lint/linters.bzl
@@ -18,7 +18,11 @@ eslint = lint_eslint_aspect(
     binary = "@@//tools/lint:eslint",
     # ESLint will resolve the configuration file by looking in the working directory first.
     # See https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file-resolution
-    configs = ["@@//:eslintrc"],
+    # We must also include any other config files we expect eslint to be able to locate, e.g. tsconfigs
+    configs = [
+        "@@//:eslintrc",
+        "@@//src:tsconfig",
+    ],
 )
 
 eslint_test = lint_test(aspect = eslint)

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -10,7 +10,7 @@ bats_load_library "bats-assert"
     assert_success
 
     assert_output --partial "+ prettier --write example/eslint.config.mjs"
-    assert_output --partial "+ prettier --write example/src/file.ts example/test/no_violations.ts"
+    assert_output --partial "+ prettier --write example/src/file.ts example/src/subdir/test.ts example/test/no_violations.ts"
     assert_output --partial "+ prettier --write example/src/hello.tsx"
     assert_output --partial "+ prettier --write example/src/hello.vue"
     assert_output --partial "+ prettier --write .bcr/metadata.template.json"

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -68,7 +68,7 @@ def _gather_inputs(ctx, srcs):
         js_inputs = js_lib_helpers.gather_files_from_js_providers(
             ctx.attr._config_files + [ctx.attr._workaround_17660, ctx.attr._formatter],
             include_transitive_sources = True,
-            include_declarations = False,
+            include_declarations = True,
             include_npm_linked_packages = True,
         )
     else:
@@ -77,8 +77,8 @@ def _gather_inputs(ctx, srcs):
             ctx.attr._config_files + [ctx.attr._workaround_17660, ctx.attr._formatter],
             include_sources = True,
             include_transitive_sources = True,
-            include_types = False,
-            include_transitive_types = False,
+            include_types = True,
+            include_transitive_types = True,
             include_npm_sources = True,
         )
     inputs.extend(js_inputs.to_list())


### PR DESCRIPTION

### Test plan

```
example % bazel lint src/subdir:ts
WARNING: Option 'experimental_remote_download_regex' is deprecated: Use --remote_download_regex instead
WARNING: Option 'experimental_remote_download_regex' is deprecated: Use --remote_download_regex instead
INFO: Analyzed target //src/subdir:ts (0 packages loaded, 0 targets configured).
[4 / 5] ESLint src/subdir/ESLint.ts.aspect_rules_lint.report; 0s darwin-sandbox
From //src/subdir:ts:
1
From //src/subdir:ts:
src/subdir/test.ts: line 3, col 1, Warning - Imports should be sorted alphabetically. (sort-imports)
src/subdir/test.ts: line 3, col 10, Error - 'IncomingHttpHeaders' is defined but never used. (@typescript-eslint/no-unused-vars)
src/subdir/test.ts: line 7, col 28, Error - 'any' overrides all other types in this union type. (@typescript-eslint/no-redundant-type-constituents)
```