### PR TITLE
chore: update aspect-cli to latest

### DIFF
--- a/example/.bazeliskrc
+++ b/example/.bazeliskrc
@@ -1,2 +1,2 @@
 BAZELISK_BASE_URL=https://github.com/aspect-build/aspect-cli/releases/download
-USE_BAZEL_VERSION=aspect/5.8.20
+USE_BAZEL_VERSION=aspect/5.9.24

--- a/example/WORKSPACE.bazel
+++ b/example/WORKSPACE.bazel
@@ -223,7 +223,8 @@ fetch_swiftformat()
 
 load("@aspect_rules_lint//lint:ruff.bzl", "fetch_ruff")
 
-fetch_ruff()
+# https://github.com/astral-sh/ruff/pull/8631#issuecomment-2022746290
+fetch_ruff("v0.3.2")
 
 load("@aspect_rules_lint//lint:golangci-lint.bzl", "fetch_golangci_lint")
 

--- a/example/WORKSPACE.bzlmod
+++ b/example/WORKSPACE.bzlmod
@@ -23,7 +23,8 @@ fetch_ktfmt()
 
 fetch_swiftformat()
 
-fetch_ruff()
+# https://github.com/astral-sh/ruff/pull/8631#issuecomment-2022746290
+fetch_ruff("v0.3.2")
 
 load("@aspect_rules_lint//lint:golangci-lint.bzl", "fetch_golangci_lint")
 


### PR DESCRIPTION
Verified that the `bazel lint --fix` flow does the right thing.