### PR TITLE
Revert "Revert "Use multirun (#160)" (#171)"

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,6 +14,7 @@ bazel_dep(name = "aspect_bazel_lib", version = "1.38.0")
 bazel_dep(name = "aspect_rules_js", version = "1.33.1")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "platforms", version = "0.0.7")
+bazel_dep(name = "rules_multirun", version = "0.9.0")
 bazel_dep(name = "rules_multitool", version = "0.4.0")
 
 # Needed in the root because we dereference ProtoInfo in our aspect impl

--- a/docs/format.md
+++ b/docs/format.md
@@ -5,8 +5,8 @@ Produce a multi-formatter that aggregates formatters.
 Some formatter tools are automatically provided by default in rules_lint.
 These are listed as defaults in the API docs below.
 
-Other formatter binaries may be declared in your repository, and you can test them by running
-them with Bazel.
+Other formatter binaries may be declared in your repository.
+You can test that they work by running them directly with `bazel run`.
 
 For example, to add prettier, your `BUILD.bazel` file should contain:
 
@@ -30,44 +30,8 @@ load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
 format_multirun(
     name = "format",
     javascript = ":prettier",
-    ...
 )
 ```
-
-
-<a id="format_multirun_rule"></a>
-
-## format_multirun_rule
-
-<pre>
-format_multirun_rule(<a href="#format_multirun_rule-name">name</a>, <a href="#format_multirun_rule-cc">cc</a>, <a href="#format_multirun_rule-go">go</a>, <a href="#format_multirun_rule-java">java</a>, <a href="#format_multirun_rule-javascript">javascript</a>, <a href="#format_multirun_rule-jsonnet">jsonnet</a>, <a href="#format_multirun_rule-kotlin">kotlin</a>, <a href="#format_multirun_rule-markdown">markdown</a>, <a href="#format_multirun_rule-protocol_buffer">protocol_buffer</a>,
-                     <a href="#format_multirun_rule-python">python</a>, <a href="#format_multirun_rule-scala">scala</a>, <a href="#format_multirun_rule-sh">sh</a>, <a href="#format_multirun_rule-sql">sql</a>, <a href="#format_multirun_rule-starlark">starlark</a>, <a href="#format_multirun_rule-swift">swift</a>, <a href="#format_multirun_rule-terraform">terraform</a>, <a href="#format_multirun_rule-yaml">yaml</a>)
-</pre>
-
-Produces an executable that aggregates the supplied formatter binaries
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="format_multirun_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="format_multirun_rule-cc"></a>cc |  a binary target that runs clang-format (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="format_multirun_rule-go"></a>go |  a binary target that runs gofmt (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="format_multirun_rule-java"></a>java |  a binary target that runs java-format (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="format_multirun_rule-javascript"></a>javascript |  a binary target that runs prettier (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="format_multirun_rule-jsonnet"></a>jsonnet |  a binary target that runs jsonnetfmt (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="format_multirun_rule-kotlin"></a>kotlin |  a binary target that runs ktfmt (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="format_multirun_rule-markdown"></a>markdown |  a binary target that runs prettier-md (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="format_multirun_rule-protocol_buffer"></a>protocol_buffer |  a binary target that runs buf (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="format_multirun_rule-python"></a>python |  a binary target that runs ruff (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="format_multirun_rule-scala"></a>scala |  a binary target that runs scalafmt (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="format_multirun_rule-sh"></a>sh |  a binary target that runs shfmt (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="format_multirun_rule-sql"></a>sql |  a binary target that runs prettier-sql (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="format_multirun_rule-starlark"></a>starlark |  a binary target that runs buildifier (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="format_multirun_rule-swift"></a>swift |  a binary target that runs swiftformat (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="format_multirun_rule-terraform"></a>terraform |  a binary target that runs terraform-fmt (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="format_multirun_rule-yaml"></a>yaml |  a binary target that runs yamlfmt (or another tool with compatible CLI arguments)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 
 
 <a id="format_multirun"></a>
@@ -78,20 +42,29 @@ Produces an executable that aggregates the supplied formatter binaries
 format_multirun(<a href="#format_multirun-name">name</a>, <a href="#format_multirun-kwargs">kwargs</a>)
 </pre>
 
-Wrapper macro around format_multirun_rule that sets defaults for some languages.
+Create a multirun binary for the given formatters.
 
+Intended to be used with `bazel run` to update source files in-place.
+
+Also produces a target `[name].check` which does not edit files, rather it exits non-zero
+if any sources require formatting.
+
+Tools are provided by default for some languages.
 These come from the `@multitool` repo.
 Under --enable_bzlmod, rules_lint creates this automatically.
 WORKSPACE users will have to set this up manually. See the release install snippet for an example.
 
 Set any attribute to `False` to turn off that language altogether, rather than use a default tool.
 
+Note that `javascript` is a special case which also formats TypeScript, TSX, JSON, CSS, and HTML.
+
+
 **PARAMETERS**
 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="format_multirun-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="format_multirun-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+| <a id="format_multirun-name"></a>name |  name of the resulting target, typically "format"   |  none |
+| <a id="format_multirun-kwargs"></a>kwargs |  attributes named for each language, providing Label of a tool that formats it   |  none |
 
 

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -67,7 +67,7 @@ If you don't use pre-commit, you can just wire directly into the git hook, howev
 this option will always run the formatter over all files, not just changed files.
 
 ```bash
-$ echo "bazel run //:format -- --mode check" >> .git/hooks/pre-commit
+$ echo "bazel run //:format.check" >> .git/hooks/pre-commit
 $ chmod u+x .git/hooks/pre-commit
 ```
 
@@ -75,4 +75,4 @@ $ chmod u+x .git/hooks/pre-commit
 
 This will exit non-zero if formatting is needed. You would typically run the check mode on CI.
 
-`bazel run //:format -- --mode check`
+`bazel run //tools/format:format.check`

--- a/format/BUILD.bazel
+++ b/format/BUILD.bazel
@@ -6,7 +6,10 @@ bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],
-    deps = ["//format/private:formatter_binary"],
+    deps = [
+        "//format/private:formatter_binary",
+        "@rules_multirun//:defs",
+    ],
 )
 
 bzl_library(

--- a/format/defs.bzl
+++ b/format/defs.bzl
@@ -3,8 +3,8 @@
 Some formatter tools are automatically provided by default in rules_lint.
 These are listed as defaults in the API docs below.
 
-Other formatter binaries may be declared in your repository, and you can test them by running
-them with Bazel.
+Other formatter binaries may be declared in your repository.
+You can test that they work by running them directly with `bazel run`.
 
 For example, to add prettier, your `BUILD.bazel` file should contain:
 
@@ -28,35 +28,86 @@ load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
 format_multirun(
     name = "format",
     javascript = ":prettier",
-    ...
 )
 ```
 """
 
-load("//format/private:formatter_binary.bzl", _fmt = "format_multirun")
-
-format_multirun_rule = _fmt
+load("@rules_multirun//:defs.bzl", "command", "multirun")
+load("//format/private:formatter_binary.bzl", "CHECK_FLAGS", "DEFAULT_TOOL_LABELS", "FIX_FLAGS", "TOOLS", "to_attribute_name")
 
 def format_multirun(name, **kwargs):
-    """Wrapper macro around format_multirun_rule that sets defaults for some languages.
+    """Create a multirun binary for the given formatters.
 
+    Intended to be used with `bazel run` to update source files in-place.
+
+    Also produces a target `[name].check` which does not edit files, rather it exits non-zero
+    if any sources require formatting.
+
+    Tools are provided by default for some languages.
     These come from the `@multitool` repo.
     Under --enable_bzlmod, rules_lint creates this automatically.
     WORKSPACE users will have to set this up manually. See the release install snippet for an example.
 
     Set any attribute to `False` to turn off that language altogether, rather than use a default tool.
-    """
 
-    _fmt(
-        name = name,
+    Note that `javascript` is a special case which also formats TypeScript, TSX, JSON, CSS, and HTML.
+
+    Args:
+        name: name of the resulting target, typically "format"
+        **kwargs: attributes named for each language, providing Label of a tool that formats it
+    """
+    commands = []
+
+    for lang, toolname in TOOLS.items():
+        lang_attribute = to_attribute_name(lang)
+
         # Logic:
-        # - if there's no value for this key, the user omitted it, so use our default
-        # - if there is a value, and it's False, then pass None to the underlying rule
+        # - if there's no value for this key, the user omitted it, so use our default if we have one
+        # - if there is a value, and it's False, then skip this language
         #   (and make sure we don't eagerly reference @multitool in case it isn't defined)
         # - otherwise use the user-supplied value
-        jsonnet = kwargs.pop("jsonnet", Label("@multitool//tools/jsonnetfmt")) or None,
-        go = kwargs.pop("go", Label("@multitool//tools/gofumpt")) or None,
-        sh = kwargs.pop("sh", Label("@multitool//tools/shfmt")) or None,
-        yaml = kwargs.pop("yaml", Label("@multitool//tools/yamlfmt")) or None,
-        **kwargs
+        tool_label = False
+        if lang_attribute in kwargs.keys():
+            tool_label = kwargs.pop(lang_attribute)
+        elif lang in DEFAULT_TOOL_LABELS.keys():
+            tool_label = Label(DEFAULT_TOOL_LABELS[lang])
+        if not tool_label:
+            continue
+
+        target_name = "_".join([name, lang.replace(" ", "_"), "with", toolname])
+
+        for mode in ["check", "fix"]:
+            command(
+                name = target_name + (".check" if mode == "check" else ""),
+                command = "@aspect_rules_lint//format/private:format",
+                description = "Formatting {} with {}...".format(lang, toolname),
+                environment = {
+                    # NB: can't use str(Label(target_name)) here because bzlmod makes it
+                    # the apparent repository, starts with @@aspect_rules_lint~override
+                    "FIX_TARGET": "//{}:{}".format(native.package_name(), target_name),
+                    "tool": "$(rlocationpaths %s)" % tool_label,
+                    "lang": lang,
+                    "flags": FIX_FLAGS[toolname] if mode == "fix" else CHECK_FLAGS[toolname],
+                    "mode": mode,
+                },
+                data = [tool_label],
+            )
+        commands.append(target_name)
+
+    # Error checking in case some user keys were unmatched and therefore not pop'ed
+    for attr in kwargs.keys():
+        fail("""Unknown language "{}". Valid values: {}""".format(attr, [to_attribute_name(lang) for lang in TOOLS.keys()]))
+
+    multirun(
+        name = name,
+        buffer_output = True,
+        commands = commands,
+        # Run up to 4 formatters at the same time. This is an arbitrary choice, based on some idea that 4-core machines are typical.
+        jobs = 4,
+        keep_going = True,
+    )
+
+    multirun(
+        name = name + ".check",
+        commands = [c + ".check" for c in commands],
     )

--- a/format/private/BUILD.bazel
+++ b/format/private/BUILD.bazel
@@ -1,6 +1,11 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-exports_files(["format.sh"])
+sh_binary(
+    name = "format",
+    srcs = ["format.sh"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
 
 bzl_library(
     name = "formatter_binary",

--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -1,88 +1,72 @@
 "Implementation of formatter_binary"
 
-load("@aspect_bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
-
 # Per the formatter design, each language can only have a single formatter binary
+# Keys in this map must match the `case "$language" in` block in format.sh
 TOOLS = {
-    "javascript": "prettier",
-    "markdown": "prettier-md",
-    "python": "ruff",
-    "starlark": "buildifier",
-    "jsonnet": "jsonnetfmt",
-    "terraform": "terraform-fmt",
-    "kotlin": "ktfmt",
-    "java": "java-format",
-    "scala": "scalafmt",
-    "swift": "swiftformat",
-    "go": "gofmt",
-    "sql": "prettier-sql",
-    "sh": "shfmt",
-    "protocol_buffer": "buf",
-    "cc": "clang-format",
-    "yaml": "yamlfmt",
+    "JavaScript": "prettier",
+    "Markdown": "prettier",
+    "Python": "ruff",
+    "Starlark": "buildifier",
+    "Jsonnet": "jsonnetfmt",
+    "Terraform": "terraform-fmt",
+    "Kotlin": "ktfmt",
+    "Java": "java-format",
+    "Scala": "scalafmt",
+    "Swift": "swiftformat",
+    "Go": "gofmt",
+    "SQL": "prettier",
+    "Shell": "shfmt",
+    "Protocol Buffer": "buf",
+    "C++": "clang-format",
+    "YAML": "yamlfmt",
 }
 
-def _formatter_binary_impl(ctx):
-    substitutions = {}
-    tools = {v: getattr(ctx.attr, k) for k, v in TOOLS.items()}
-    for tool, attr in tools.items():
-        if attr:
-            substitutions["{{%s}}" % tool] = to_rlocation_path(ctx, attr.files_to_run.executable)
-    if len(substitutions) == 0:
-        fail("format_multirun should have at least one language attribute set to a formatter tool")
+DEFAULT_TOOL_LABELS = {
+    "Jsonnet": "@multitool//tools/jsonnetfmt",
+    "Go": "@multitool//tools/gofumpt",
+    "Shell": "@multitool//tools/shfmt",
+    "YAML": "@multitool//tools/yamlfmt",
+}
 
-    substitutions.update({
-        # We need to fill in the rlocation paths in the shell script
-        "{{BASH_RLOCATION_FUNCTION}}": BASH_RLOCATION_FUNCTION,
-        # Support helpful error reporting
-        "{{fix_target}}": str(ctx.label),
-    })
+CHECK_FLAGS = {
+    "buildifier": "-mode=check",
+    "swiftformat": "--lint",
+    "prettier": "--check",
+    "ruff": "format --check --force-exclude",
+    "shfmt": "--diff",
+    "java-format": "--set-exit-if-changed --dry-run",
+    "ktfmt": "--set-exit-if-changed --dry-run",
+    "gofmt": "-l",
+    "buf": "format -d --exit-code",
+    "terraform-fmt": "fmt -check -diff",
+    "jsonnetfmt": "--test",
+    "scalafmt": "--test",
+    "clang-format": "--style=file --fallback-style=none --dry-run -Werror",
+    "yamlfmt": "-lint",
+}
 
-    # Uniquely named output file allowing more than one formatter in a package
-    bin = ctx.actions.declare_file("_{}.fmt.sh".format(ctx.label.name))
-    ctx.actions.expand_template(
-        template = ctx.file._bin,
-        output = bin,
-        substitutions = substitutions,
-        is_executable = True,
-    )
+FIX_FLAGS = {
+    "buildifier": "-mode=fix",
+    "swiftformat": "",
+    "prettier": "--write",
+    # Force exclusions in the configuration file to be honored even when file paths are supplied
+    # as command-line arguments; see
+    # https://github.com/astral-sh/ruff/discussions/5857#discussioncomment-6583943
+    "ruff": "format --force-exclude",
+    # NB: apply-ignore added in https://github.com/mvdan/sh/issues/1037
+    "shfmt": "-w --apply-ignore",
+    "java-format": "--replace",
+    "ktfmt": "",
+    "gofmt": "-w",
+    "buf": "format -w",
+    "terraform-fmt": "fmt",
+    "jsonnetfmt": "--in-place",
+    "scalafmt": "",
+    "clang-format": "-style=file --fallback-style=none -i",
+    "yamlfmt": "",
+}
 
-    runfiles = ctx.runfiles(files = [ctx.file._runfiles_lib] + [
-        f.files_to_run.executable
-        for f in tools.values()
-        if f
-    ] + [
-        f.files_to_run.runfiles_manifest
-        for f in tools.values()
-        if f and f.files_to_run.runfiles_manifest
-    ])
-    runfiles = runfiles.merge_all([
-        f.default_runfiles
-        for f in tools.values()
-        if f
-    ])
-
-    return [
-        DefaultInfo(
-            executable = bin,
-            runfiles = runfiles,
-        ),
-    ]
-
-formatter_binary_lib = struct(
-    implementation = _formatter_binary_impl,
-    attrs = dict({
-        k: attr.label(doc = "a binary target that runs {} (or another tool with compatible CLI arguments)".format(v), executable = True, cfg = "exec", allow_files = True)
-        for k, v in TOOLS.items()
-    }, **{
-        "_bin": attr.label(default = "//format/private:format.sh", allow_single_file = True),
-        "_runfiles_lib": attr.label(default = "@bazel_tools//tools/bash/runfiles", allow_single_file = True),
-    }),
-)
-
-format_multirun = rule(
-    doc = "Produces an executable that aggregates the supplied formatter binaries",
-    implementation = formatter_binary_lib.implementation,
-    attrs = formatter_binary_lib.attrs,
-    executable = True,
-)
+def to_attribute_name(lang):
+    if lang == "C++":
+        return "cc"
+    return lang.lower().replace(" ", "_")

--- a/format/repositories.bzl
+++ b/format/repositories.bzl
@@ -17,6 +17,12 @@ def http_jar(**kwargs):
 
 def rules_lint_dependencies():
     http_archive(
+        name = "rules_multirun",
+        sha256 = "0e124567fa85287874eff33a791c3bbdcc5343329a56faa828ef624380d4607c",
+        url = "https://github.com/keith/rules_multirun/releases/download/0.9.0/rules_multirun.0.9.0.tar.gz",
+    )
+
+    http_archive(
         name = "rules_multitool",
         sha256 = "793105ea4bb89cf9d82411cbee40b6874085f530314600887539e214e4970a3a",
         strip_prefix = "rules_multitool-0.4.0",

--- a/format/test/BUILD.bazel
+++ b/format/test/BUILD.bazel
@@ -1,6 +1,9 @@
+load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//format:defs.bzl", "format_multirun")
 load("//format/private:formatter_binary.bzl", "TOOLS")
+
+UNIQUE_TOOLS = sets.to_list(sets.make(TOOLS.values()))
 
 # Avoid depending on a bunch of actual tools in the root module.
 # That's the job of the example/ submodule.
@@ -14,7 +17,7 @@ load("//format/private:formatter_binary.bzl", "TOOLS")
             "echo + {} $*".format(t),
         ],
     )
-    for t in TOOLS.values()
+    for t in UNIQUE_TOOLS
 ]
 
 [
@@ -22,88 +25,26 @@ load("//format/private:formatter_binary.bzl", "TOOLS")
         name = "mock_" + t,
         srcs = ["mock_{}.sh".format(t)],
     )
-    for t in TOOLS.values()
+    for t in UNIQUE_TOOLS
 ]
 
-# Make a separate formatter binary to test each language in isolation.
-# Users should NOT do it this way!
 format_multirun(
-    name = "format_javascript",
+    name = "format",
+    cc = ":mock_clang-format.sh",
+    go = ":mock_gofmt.sh",
+    java = ":mock_java-format.sh",
     javascript = ":mock_prettier.sh",
-)
-
-format_multirun(
-    name = "format_starlark",
-    starlark = ":mock_buildifier.sh",
-)
-
-format_multirun(
-    name = "format_markdown",
+    jsonnet = ":mock_jsonnetfmt.sh",
+    kotlin = ":mock_ktfmt.sh",
     markdown = ":mock_prettier.sh",
-)
-
-format_multirun(
-    name = "format_sql",
-    sql = ":mock_prettier.sh",
-)
-
-format_multirun(
-    name = "format_python",
+    protocol_buffer = ":mock_buf.sh",
     python = ":mock_ruff.sh",
-)
-
-format_multirun(
-    name = "format_hcl",
+    scala = ":mock_scalafmt.sh",
+    shell = ":mock_shfmt.sh",
+    sql = ":mock_prettier.sh",
+    starlark = ":mock_buildifier.sh",
+    swift = ":mock_swiftformat.sh",
     # TODO: this attribute should be renamed to hcl
     terraform = ":mock_terraform-fmt.sh",
-)
-
-format_multirun(
-    name = "format_jsonnet",
-    jsonnet = ":mock_jsonnetfmt.sh",
-)
-
-format_multirun(
-    name = "format_java",
-    java = ":mock_java-format.sh",
-)
-
-format_multirun(
-    name = "format_kotlin",
-    kotlin = ":mock_ktfmt.sh",
-)
-
-format_multirun(
-    name = "format_scala",
-    scala = ":mock_scalafmt.sh",
-)
-
-format_multirun(
-    name = "format_go",
-    go = ":mock_gofmt.sh",
-)
-
-format_multirun(
-    name = "format_cc",
-    cc = ":mock_clang-format.sh",
-)
-
-format_multirun(
-    name = "format_sh",
-    sh = ":mock_shfmt.sh",
-)
-
-format_multirun(
-    name = "format_swift",
-    swift = ":mock_swiftformat.sh",
-)
-
-format_multirun(
-    name = "format_protobuf",
-    protocol_buffer = ":mock_buf.sh",
-)
-
-format_multirun(
-    name = "format_yaml",
     yaml = ":mock_yamlfmt.sh",
 )

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -6,151 +6,130 @@ bats_load_library "bats-assert"
 
 # No arguments: will use git ls-files
 @test "should run prettier on javascript using git ls-files" {
-    run bazel run //format/test:format_javascript
+    run bazel run //format/test:format_JavaScript_with_prettier
     assert_success
 
-    assert_output --partial "Formatting JavaScript with Prettier..."
     assert_output --partial "+ prettier --write example/.eslintrc.cjs"
-    assert_output --partial "Formatting TypeScript with Prettier..."
     assert_output --partial "+ prettier --write example/src/file.ts example/test/no_violations.ts"
-    assert_output --partial "Formatting TSX with Prettier..."
     assert_output --partial "+ prettier --write example/src/hello.tsx"
-    assert_output --partial "Formatting JSON with Prettier..."
     assert_output --partial "+ prettier --write .bcr/metadata.template.json"
-    assert_output --partial "Formatting CSS with Prettier..."
     assert_output --partial "+ prettier --write example/src/hello.css"
-    assert_output --partial "Formatting HTML with Prettier..."
     assert_output --partial "+ prettier --write example/src/index.html"
 }
 
 # File arguments: will filter with find
 @test "should run prettier on javascript using find" {
-    run bazel run //format/test:format_javascript README.md example/.eslintrc.cjs
+    run bazel run //format/test:format_JavaScript_with_prettier README.md example/.eslintrc.cjs
     assert_success
 
-    assert_output --partial "Formatting JavaScript with Prettier..."
-    refute_output --partial "Formatting TypeScript with Prettier..."
+    assert_output --partial "README.md"
+    refute_output --partial "file.ts"
 }
 
 @test "should run buildozer on starlark" {
-    run bazel run //format/test:format_starlark
+    run bazel run //format/test:format_Starlark_with_buildifier
     assert_success
 
-    assert_output --partial "Formatting Starlark with Buildifier..."
     assert_output --partial "+ buildifier -mode=fix BUILD.bazel"
     assert_output --partial "format/private/BUILD.bazel"
 }
 
 @test "should run prettier on Markdown" {
-    run bazel run //format/test:format_markdown
+    run bazel run //format/test:format_Markdown_with_prettier
     assert_success
 
-    assert_output --partial "Formatting Markdown with Prettier..."
     assert_output --partial "+ prettier --write .bcr/README.md CONTRIBUTING.md README.md"
 }
 
 @test "should run prettier on SQL" {
-    run bazel run //format/test:format_sql
+    run bazel run //format/test:format_SQL_with_prettier
     assert_success
 
-    assert_output --partial "Formatting SQL with Prettier..."
     assert_output --partial "+ prettier --write example/src/hello.sql"
 }
 
 @test "should run ruff on Python" {
-    run bazel run //format/test:format_python
+    run bazel run //format/test:format_Python_with_ruff
     assert_success
 
-    assert_output --partial "Formatting Python with Ruff..."
     assert_output --partial "+ ruff format --force-exclude example/src/subdir/unused_import.py"
 }
 
 @test "should run terraform fmt on HCL" {
-    run bazel run //format/test:format_hcl
+    run bazel run //format/test:format_Terraform_with_terraform-fmt
     assert_success
 
-    assert_output --partial "Formatting Terraform with terraform fmt..."
     assert_output --partial "+ terraform-fmt fmt example/src/hello.tf"
 }
 
 @test "should run jsonnet-fmt on Jsonnet" {
-    run bazel run //format/test:format_jsonnet
+    run bazel run //format/test:format_Jsonnet_with_jsonnetfmt
     assert_success
 
-    assert_output --partial "Formatting Jsonnet with jsonnetfmt..."
     assert_output --partial "+ jsonnetfmt --in-place example/src/hello.jsonnet example/src/hello.libsonnet"
 }
 
 @test "should run java-format on Java" {
-    run bazel run //format/test:format_java
+    run bazel run //format/test:format_Java_with_java-format
     assert_success
 
-    assert_output --partial "Formatting Java with java-format..."
     assert_output --partial "+ java-format --replace example/src/Foo.java"
 }
 
 @test "should run ktfmt on Kotlin" {
-    run bazel run //format/test:format_kotlin
+    run bazel run //format/test:format_Kotlin_with_ktfmt
     assert_success
 
-    assert_output --partial "Formatting Kotlin with ktfmt..."
     assert_output --partial "+ ktfmt example/src/hello.kt"
 }
 
 @test "should run scalafmt on Scala" {
-    run bazel run //format/test:format_scala
+    run bazel run //format/test:format_Scala_with_scalafmt
     assert_success
 
-    assert_output --partial "Formatting Scala with scalafmt..."
     assert_output --partial "+ scalafmt example/src/hello.scala"
 }
 
 @test "should run gofmt on Go" {
-    run bazel run //format/test:format_go
+    run bazel run //format/test:format_Go_with_gofmt
     assert_success
 
-    assert_output --partial "Formatting Go with gofmt..."
     assert_output --partial "+ gofmt -w example/src/hello.go"
 }
 
 @test "should run clang-format on C++" {
-    run bazel run //format/test:format_cc
+    run bazel run //format/test:format_C++_with_clang-format
     assert_success
 
-    assert_output --partial "Formatting C++ with clang-format..."
     assert_output --partial "+ clang-format -style=file --fallback-style=none -i example/src/hello.cpp"
 }
 
 @test "should run shfmt on Shell" {
-    run bazel run //format/test:format_sh
+    run bazel run //format/test:format_Shell_with_shfmt
     assert_success
 
-    assert_output --partial "Formatting Shell with shfmt..."
     assert_output --partial "+ shfmt -w --apply-ignore .github/workflows/release_prep.sh"
 }
 
 @test "should run swiftformat on Swift" {
-    run bazel run //format/test:format_swift
+    run bazel run //format/test:format_Swift_with_swiftformat
     assert_success
 
-    # The real swiftformat prints the "Formatting..." output so we don't
     assert_output --partial "+ swiftformat example/src/hello.swift"
 }
 
 @test "should run buf on Protobuf" {
-    run bazel run //format/test:format_protobuf
+    run bazel run //format/test:format_Protocol_Buffer_with_buf
     assert_success
 
-    assert_output --partial "Formatting Protocol Buffer with buf..."
     # Buf only formats one file at a time
     assert_output --partial "+ buf format -w example/src/file.proto"
     assert_output --partial "+ buf format -w example/src/unused.proto"
 }
 
 @test "should run yamlfmt on YAML" {
-    run bazel run //format/test:format_yaml
+    run bazel run //format/test:format_YAML_with_yamlfmt
     assert_success
 
-    assert_output --partial "Formatting YAML with yamlfmt..."
     assert_output --partial "+ yamlfmt .bcr/config.yml"
 }


### PR DESCRIPTION
This reverts commit 1fbcfee669b0b546071a85fb48e927dc3fe33662.

The broken feature for passing filename arguments is fixed in https://github.com/keith/rules_multirun/releases/tag/0.9.0

---

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

### Test plan

- Covered by existing test cases
