### PR TITLE
chore: upgrade rules_multitool for WORKSPACE users

### DIFF
--- a/format/repositories.bzl
+++ b/format/repositories.bzl
@@ -18,9 +18,9 @@ def http_jar(**kwargs):
 def rules_lint_dependencies():
     http_archive(
         name = "rules_multitool",
-        sha256 = "793105ea4bb89cf9d82411cbee40b6874085f530314600887539e214e4970a3a",
-        strip_prefix = "rules_multitool-0.4.0",
-        url = "https://github.com/theoremlp/rules_multitool/releases/download/v0.4.0/rules_multitool-0.4.0.tar.gz",
+        sha256 = "557b71b7d8d9975afc7fc2381c4c0e4220d43a581fb019217ca0a040d6cbebff",
+        strip_prefix = "rules_multitool-0.6.0",
+        url = "https://github.com/theoremlp/rules_multitool/releases/download/v0.6.0/rules_multitool-0.6.0.tar.gz",
     )
 
 def fetch_pmd():


### PR DESCRIPTION
Includes https://github.com/theoremlp/rules_multitool/pull/21 which we want in aspect silo

Note, it's not necessary to increase the lower bound for bzlmod users, as that API already allowed multiple lockfiles.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)
Now requires bazel_features as a transitive WORKSPACE dep of rules_multitool.

### Test plan

- Covered by existing test cases
