### PR TITLE
fix(format): don't bail check mode on first error

### DIFF
--- a/format/defs.bzl
+++ b/format/defs.bzl
@@ -110,4 +110,5 @@ def format_multirun(name, **kwargs):
     multirun(
         name = name + ".check",
         commands = [c + ".check" for c in commands],
+        keep_going = True,
     )


### PR DESCRIPTION
fixes #97

---

### Type of change

- Bug fix (change which fixes an issue)


### Test plan

- Manual testing; please provide instructions so we can reproduce:

Introduced .js file format violation in silo, it now continues on to check formatting of other languages