### PR TITLE
feat: shellcheck apply fixes

### DIFF
--- a/docs/shellcheck.md
+++ b/docs/shellcheck.md
@@ -64,7 +64,7 @@ Attrs:
 ## shellcheck_action
 
 <pre>
-shellcheck_action(<a href="#shellcheck_action-ctx">ctx</a>, <a href="#shellcheck_action-executable">executable</a>, <a href="#shellcheck_action-srcs">srcs</a>, <a href="#shellcheck_action-config">config</a>, <a href="#shellcheck_action-report">report</a>, <a href="#shellcheck_action-use_exit_code">use_exit_code</a>)
+shellcheck_action(<a href="#shellcheck_action-ctx">ctx</a>, <a href="#shellcheck_action-executable">executable</a>, <a href="#shellcheck_action-srcs">srcs</a>, <a href="#shellcheck_action-config">config</a>, <a href="#shellcheck_action-output">output</a>, <a href="#shellcheck_action-use_exit_code">use_exit_code</a>, <a href="#shellcheck_action-options">options</a>)
 </pre>
 
 Run shellcheck as an action under Bazel.
@@ -81,8 +81,9 @@ Based on https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md
 | <a id="shellcheck_action-executable"></a>executable |  label of the the shellcheck program   |  none |
 | <a id="shellcheck_action-srcs"></a>srcs |  bash files to be linted   |  none |
 | <a id="shellcheck_action-config"></a>config |  label of the .shellcheckrc file   |  none |
-| <a id="shellcheck_action-report"></a>report |  output file to generate   |  none |
+| <a id="shellcheck_action-output"></a>output |  output file to generate   |  none |
 | <a id="shellcheck_action-use_exit_code"></a>use_exit_code |  whether to fail the build when a lint violation is reported   |  <code>False</code> |
+| <a id="shellcheck_action-options"></a>options |  additional command-line options, see https://github.com/koalaman/shellcheck/blob/master/shellcheck.hs#L95   |  <code>[]</code> |
 
 
 <a id="shellcheck_binary"></a>


### PR DESCRIPTION
### Type of change

- New feature or functionality (change which adds functionality)

**For changes visible to end-users**

- Relevant documentation has been updated? We don't document which linters have fixes auto-applied, but I'm not sure that we should, since it will be hard to keep that updated.

### Test plan

- Manual testing; please provide instructions so we can reproduce:

```
example% ./lint.sh --fix src:hello_shell
From bazel-out/darwin_arm64-fastbuild/bin/src/shellcheck.hello_shell.aspect_rules_lint.report:

In src/hello.sh line 3:
[ -z $THING ] && echo "hello world"
     ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
[ -z "$THING" ] && echo "hello world"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

patching file 'src/hello.sh'

example % git diff src  
diff --git a/example/src/hello.sh b/example/src/hello.sh
index 51afcbc..64b7956 100644
--- a/example/src/hello.sh
+++ b/example/src/hello.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-[ -z $THING ] && echo "hello world"
+[ -z "$THING" ] && echo "hello world"
 
 # Note, we should not get a lint here because the .shellcheckrc excludes it
 [ ! -z "$foo" ] && echo "foo"
```
