### PR TITLE
feat(format): expose print_command and change default to False

### DIFF
--- a/docs/format.md
+++ b/docs/format.md
@@ -39,7 +39,7 @@ format_multirun(
 ## format_multirun
 
 <pre>
-format_multirun(<a href="#format_multirun-name">name</a>, <a href="#format_multirun-jobs">jobs</a>, <a href="#format_multirun-kwargs">kwargs</a>)
+format_multirun(<a href="#format_multirun-name">name</a>, <a href="#format_multirun-jobs">jobs</a>, <a href="#format_multirun-print_command">print_command</a>, <a href="#format_multirun-kwargs">kwargs</a>)
 </pre>
 
 Create a multirun binary for the given formatters.
@@ -67,6 +67,7 @@ Note that `javascript` is a special case which also formats TypeScript, TSX, JSO
 | :------------- | :------------- | :------------- |
 | <a id="format_multirun-name"></a>name |  name of the resulting target, typically "format"   |  none |
 | <a id="format_multirun-jobs"></a>jobs |  how many language formatters to spawn in parallel, ideally matching how many CPUs are available   |  <code>4</code> |
+| <a id="format_multirun-print_command"></a>print_command |  whether to print a progress message before calling the formatter of each language. Note that a line is printed for a formatter even if no files of that language are to be formatted.   |  <code>False</code> |
 | <a id="format_multirun-kwargs"></a>kwargs |  attributes named for each language, providing Label of a tool that formats it   |  none |
 
 

--- a/format/defs.bzl
+++ b/format/defs.bzl
@@ -55,7 +55,7 @@ def _format_attr_factory(target_name, lang, toolname, tool_label, mode):
         "data": [tool_label],
     }
 
-def format_multirun(name, jobs = 4, **kwargs):
+def format_multirun(name, jobs = 4, print_command = False, **kwargs):
     """Create a multirun binary for the given formatters.
 
     Intended to be used with `bazel run` to update source files in-place.
@@ -76,6 +76,8 @@ def format_multirun(name, jobs = 4, **kwargs):
     Args:
         name: name of the resulting target, typically "format"
         jobs: how many language formatters to spawn in parallel, ideally matching how many CPUs are available
+        print_command: whether to print a progress message before calling the formatter of each language.
+            Note that a line is printed for a formatter even if no files of that language are to be formatted.
         **kwargs: attributes named for each language, providing Label of a tool that formats it
     """
     commands = []
@@ -99,6 +101,7 @@ def format_multirun(name, jobs = 4, **kwargs):
         commands = commands,
         jobs = jobs,
         keep_going = True,
+        print_command = print_command,
         **common_attrs
     )
 
@@ -107,6 +110,7 @@ def format_multirun(name, jobs = 4, **kwargs):
         commands = [c + ".check" for c in commands],
         jobs = jobs,
         keep_going = True,
+        print_command = print_command,
         **common_attrs
     )
 


### PR DESCRIPTION

fixes #197

New behavior:

```
$ bazel run format src/hello.sh
INFO: Analyzed target //:format (2 packages loaded, 26 targets configured).
INFO: Found 1 target...
Target //tools/format:format up-to-date:
  bazel-bin/tools/format/format.bash
INFO: Elapsed time: 0.193s, Critical Path: 0.01s
INFO: 2 processes: 2 internal.
INFO: Build completed successfully, 2 total actions
INFO: Running command line: bazel-bin/tools/format/format.bash src/hello.sh
Formatted Shell in 0m0.004s

alex@a:~/Projects/rules_lint/example$ 2>/dev/null bazel run format README.md 
Formatted Markdown in 0m0.346s

alex@a:~/Projects/rules_lint/example$ bazel run format README.md
INFO: Analyzed target //:format (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tools/format:format up-to-date:
  bazel-bin/tools/format/format.bash
INFO: Elapsed time: 0.075s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/tools/format/format.bash README.md
README.md 30ms
Formatted Markdown in 0m0.335s
```