### PR TITLE
refactor: bring linters under rules_multitool

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,4 +29,5 @@ bazel_dep(name = "rules_go", version = "0.39.1", repo_name = "io_bazel_rules_go"
 
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
 multitool.hub(lockfile = "//format:multitool.lock.json")
+multitool.hub(lockfile = "//lint:multitool.lock.json")
 use_repo(multitool, "multitool")

--- a/docs/golangci-lint.md
+++ b/docs/golangci-lint.md
@@ -6,28 +6,10 @@ API for declaring a golangci-lint lint aspect that visits go_library, go_test, a
 load("@aspect_rules_lint//lint:golangci-lint.bzl", "golangci_lint_aspect")
 
 golangci_lint = golangci_lint_aspect(
-    binary = "@@//tools/lint:golangci_lint",
+    binary = "@multitool//tools/golangci-lint",
     config = "@@//:.golangci.yaml",
 )
 ```
-
-
-<a id="fetch_golangci_lint"></a>
-
-## fetch_golangci_lint
-
-<pre>
-fetch_golangci_lint(<a href="#fetch_golangci_lint-version">version</a>)
-</pre>
-
-Naive macro that fetches a specific version of the golangci-lint from GitHub releases, for commonly-used platforms
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="fetch_golangci_lint-version"></a>version |  must be the default value. In the future this could be honored when we support multiple versions.   |  <code>"1.55.2"</code> |
 
 
 <a id="golangci_lint_action"></a>

--- a/docs/shellcheck.md
+++ b/docs/shellcheck.md
@@ -4,36 +4,16 @@ API for declaring a shellcheck lint aspect that visits sh_library rules.
 
 Typical usage:
 
-1. Use [fetch_shellcheck](#fetch_shellcheck) in WORKSPACE to call the `http_archive` calls to download binaries.
-2. Use [shellcheck_binary](#shellcheck_binary) to declare the shellcheck target, typically in in `tools/lint/BUILD.bazel`
-3. Use [shellcheck_aspect](#shellcheck_aspect) to declare the shellcheck linter aspect, typically in in `tools/lint/linters.bzl`:
+Use [shellcheck_aspect](#shellcheck_aspect) to declare the shellcheck linter aspect, typically in in `tools/lint/linters.bzl`:
 
 ```
 load("@aspect_rules_lint//lint:shellcheck.bzl", "shellcheck_aspect")
 
 shellcheck = shellcheck_aspect(
-    binary = "@@//tools/lint:shellcheck",
+    binary = "@multitool//tools/shellcheck",
     config = "@@//:.shellcheckrc",
 )
 ```
-
-
-<a id="fetch_shellcheck"></a>
-
-## fetch_shellcheck
-
-<pre>
-fetch_shellcheck(<a href="#fetch_shellcheck-version">version</a>)
-</pre>
-
-A repository macro used from WORKSPACE to fetch binaries
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="fetch_shellcheck-version"></a>version |  a version of shellcheck that we have mirrored, e.g. <code>v0.9.0</code>   |  <code>"v0.9.0"</code> |
 
 
 <a id="lint_shellcheck_aspect"></a>
@@ -84,23 +64,5 @@ Based on https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md
 | <a id="shellcheck_action-output"></a>output |  output file to generate   |  none |
 | <a id="shellcheck_action-use_exit_code"></a>use_exit_code |  whether to fail the build when a lint violation is reported   |  <code>False</code> |
 | <a id="shellcheck_action-options"></a>options |  additional command-line options, see https://github.com/koalaman/shellcheck/blob/master/shellcheck.hs#L95   |  <code>[]</code> |
-
-
-<a id="shellcheck_binary"></a>
-
-## shellcheck_binary
-
-<pre>
-shellcheck_binary(<a href="#shellcheck_binary-name">name</a>)
-</pre>
-
-Wrapper around native_binary to select the correct shellcheck executable for the execution platform.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="shellcheck_binary-name"></a>name |  <p align="center"> - </p>   |  none |
 
 

--- a/example/.aspect/cli/config.yaml
+++ b/example/.aspect/cli/config.yaml
@@ -3,6 +3,7 @@ lint:
     - //tools/lint:linters.bzl%eslint
     - //tools/lint:linters.bzl%buf
     - //tools/lint:linters.bzl%flake8
+    - //tools/lint:linters.bzl%golangci_lint
     - //tools/lint:linters.bzl%pmd
     - //tools/lint:linters.bzl%ruff
     - //tools/lint:linters.bzl%vale

--- a/example/MODULE.bazel
+++ b/example/MODULE.bazel
@@ -1,7 +1,7 @@
 "Bazel dependencies"
 
 bazel_dep(name = "aspect_rules_lint", version = "0.0.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.5.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.6.1")
 bazel_dep(name = "aspect_rules_js", version = "1.40.0")
 bazel_dep(name = "aspect_rules_ts", version = "2.2.0")
 bazel_dep(name = "rules_buf", version = "0.2.0")

--- a/example/WORKSPACE.bazel
+++ b/example/WORKSPACE.bazel
@@ -234,10 +234,6 @@ load("@aspect_rules_lint//lint:ruff.bzl", "fetch_ruff")
 # https://github.com/astral-sh/ruff/pull/8631#issuecomment-2022746290
 fetch_ruff("v0.3.2")
 
-load("@aspect_rules_lint//lint:golangci-lint.bzl", "fetch_golangci_lint")
-
-fetch_golangci_lint()
-
 load("@aspect_rules_lint//lint:vale.bzl", "fetch_vale")
 
 fetch_vale()

--- a/example/WORKSPACE.bazel
+++ b/example/WORKSPACE.bazel
@@ -238,10 +238,6 @@ load("@aspect_rules_lint//lint:golangci-lint.bzl", "fetch_golangci_lint")
 
 fetch_golangci_lint()
 
-load("@aspect_rules_lint//lint:shellcheck.bzl", "fetch_shellcheck")
-
-fetch_shellcheck()
-
 load("@aspect_rules_lint//lint:vale.bzl", "fetch_vale")
 
 fetch_vale()
@@ -255,5 +251,8 @@ load("@rules_multitool//multitool:multitool.bzl", "multitool")
 
 multitool(
     name = "multitool",
-    lockfile = "@aspect_rules_lint//format:multitool.lock.json",
+    lockfiles = [
+        "@aspect_rules_lint//format:multitool.lock.json",
+        "@aspect_rules_lint//lint:multitool.lock.json",
+    ],
 )

--- a/example/WORKSPACE.bzlmod
+++ b/example/WORKSPACE.bzlmod
@@ -27,10 +27,6 @@ load("@aspect_rules_lint//lint:golangci-lint.bzl", "fetch_golangci_lint")
 
 fetch_golangci_lint()
 
-load("@aspect_rules_lint//lint:shellcheck.bzl", "fetch_shellcheck")
-
-fetch_shellcheck()
-
 load("@aspect_rules_lint//lint:vale.bzl", "fetch_vale")
 
 fetch_vale()

--- a/example/WORKSPACE.bzlmod
+++ b/example/WORKSPACE.bzlmod
@@ -23,10 +23,6 @@ fetch_swiftformat()
 # https://github.com/astral-sh/ruff/pull/8631#issuecomment-2022746290
 fetch_ruff("v0.3.2")
 
-load("@aspect_rules_lint//lint:golangci-lint.bzl", "fetch_golangci_lint")
-
-fetch_golangci_lint()
-
 load("@aspect_rules_lint//lint:vale.bzl", "fetch_vale")
 
 fetch_vale()

--- a/example/tools/lint/BUILD.bazel
+++ b/example/tools/lint/BUILD.bazel
@@ -44,19 +44,6 @@ java_binary(
 )
 
 native_binary(
-    name = "golangci_lint",
-    src = select(
-        {
-            "@bazel_tools//src/conditions:linux_x86_64": "@golangci_lint_linux_x86_64//:golangci-lint",
-            "@bazel_tools//src/conditions:linux_aarch64": "@golangci_lint_linux_aarch64//:golangci-lint",
-            "@bazel_tools//src/conditions:darwin_x86_64": "@golangci_lint_macos_x86_64//:golangci-lint",
-            "@bazel_tools//src/conditions:darwin_arm64": "@golangci_lint_macos_aarch64//:golangci-lint",
-        },
-    ),
-    out = "golangci-lint",
-)
-
-native_binary(
     name = "vale",
     src = select(
         {

--- a/example/tools/lint/BUILD.bazel
+++ b/example/tools/lint/BUILD.bazel
@@ -5,7 +5,6 @@ we don't want to trigger eager fetches of these for builds that don't want to ru
 """
 
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@aspect_rules_lint//lint:shellcheck.bzl", "shellcheck_binary")
 load("@aspect_rules_lint//lint:vale_library.bzl", "VALE_STYLES")
 load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")
@@ -82,6 +81,3 @@ copy_to_directory(
     ],
     include_external_repositories = ["vale_*"],
 )
-
-# bazel run :shellcheck -- --help
-shellcheck_binary(name = "shellcheck")

--- a/example/tools/lint/linters.bzl
+++ b/example/tools/lint/linters.bzl
@@ -58,7 +58,7 @@ shellcheck = lint_shellcheck_aspect(
 shellcheck_test = lint_test(aspect = shellcheck)
 
 golangci_lint = lint_golangci_aspect(
-    binary = "@@//tools/lint:golangci_lint",
+    binary = "@multitool//tools/golangci-lint",
     config = "@@//:.golangci.yaml",
 )
 

--- a/example/tools/lint/linters.bzl
+++ b/example/tools/lint/linters.bzl
@@ -51,7 +51,7 @@ ruff = lint_ruff_aspect(
 ruff_test = lint_test(aspect = ruff)
 
 shellcheck = lint_shellcheck_aspect(
-    binary = "@@//tools/lint:shellcheck",
+    binary = "@multitool//tools/shellcheck",
     config = "@@//:.shellcheckrc",
 )
 

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -120,9 +120,6 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "//lint/private:lint_aspect",
-        "@bazel_skylib//rules:native_binary",
-        "@bazel_tools//tools/build_defs/repo:http.bzl",
-        "@bazel_tools//tools/build_defs/repo:utils.bzl",
         "@io_bazel_rules_go//go:def",
     ],
 )
@@ -131,13 +128,7 @@ bzl_library(
     name = "shellcheck",
     srcs = ["shellcheck.bzl"],
     visibility = ["//visibility:public"],
-    deps = [
-        "//lint/private:lint_aspect",
-        "//lint/private:maybe",
-        "@bazel_skylib//rules:native_binary",
-        "@bazel_tools//tools/build_defs/repo:http.bzl",
-        "@bazel_tools//tools/build_defs/repo:utils.bzl",
-    ],
+    deps = ["//lint/private:lint_aspect"],
 )
 
 bzl_library(

--- a/lint/golangci-lint.bzl
+++ b/lint/golangci-lint.bzl
@@ -4,13 +4,12 @@
 load("@aspect_rules_lint//lint:golangci-lint.bzl", "golangci_lint_aspect")
 
 golangci_lint = golangci_lint_aspect(
-    binary = "@@//tools/lint:golangci_lint",
+    binary = "@multitool//tools/golangci-lint",
     config = "@@//:.golangci.yaml",
 )
 ```
 """
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_bazel_rules_go//go:def.bzl", "go_context")
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "report_file")
 
@@ -102,41 +101,4 @@ def lint_golangci_aspect(binary, config):
             ),
         },
         toolchains = ["@io_bazel_rules_go//go:toolchain"],
-    )
-
-def fetch_golangci_lint(version = "1.55.2"):
-    """Naive macro that fetches a specific version of the golangci-lint from GitHub releases, for commonly-used platforms
-
-    Args:
-        version: must be the default value. In the future this could be honored when we support multiple versions.
-    """
-    if version != "1.55.2":
-        fail("Only a single version of golangci-lint is currently mirrored. Please file an issue if you need a different version.")
-    http_archive(
-        name = "golangci_lint_linux_x86_64",
-        build_file_content = "exports_files([\"golangci-lint\"])",
-        strip_prefix = "golangci-lint-{}-linux-amd64".format(version),
-        sha256 = "ca21c961a33be3bc15e4292dc40c98c8dcc5463a7b6768a3afc123761630c09c",
-        urls = ["https://github.com/golangci/golangci-lint/releases/download/v{0}/golangci-lint-{0}-linux-amd64.tar.gz".format(version)],
-    )
-    http_archive(
-        name = "golangci_lint_linux_aarch64",
-        build_file_content = "exports_files([\"golangci-lint\"])",
-        strip_prefix = "golangci-lint-{}-linux-arm64".format(version),
-        sha256 = "8eb0cee9b1dbf0eaa49871798c7f8a5b35f2960c52d776a5f31eb7d886b92746",
-        urls = ["https://github.com/golangci/golangci-lint/releases/download/v{0}/golangci-lint-{0}-linux-arm64.tar.gz".format(version)],
-    )
-    http_archive(
-        name = "golangci_lint_macos_x86_64",
-        build_file_content = "exports_files([\"golangci-lint\"])",
-        strip_prefix = "golangci-lint-{}-darwin-amd64".format(version),
-        sha256 = "632e96e6d5294fbbe7b2c410a49c8fa01c60712a0af85a567de85bcc1623ea21",
-        urls = ["https://github.com/golangci/golangci-lint/releases/download/v{0}/golangci-lint-{0}-darwin-amd64.tar.gz".format(version)],
-    )
-    http_archive(
-        name = "golangci_lint_macos_aarch64",
-        build_file_content = "exports_files([\"golangci-lint\"])",
-        strip_prefix = "golangci-lint-{}-darwin-arm64".format(version),
-        sha256 = "234463f059249f82045824afdcdd5db5682d0593052f58f6a3039a0a1c3899f6",
-        urls = ["https://github.com/golangci/golangci-lint/releases/download/v{0}/golangci-lint-{0}-darwin-arm64.tar.gz".format(version)],
     )

--- a/lint/multitool.lock.json
+++ b/lint/multitool.lock.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://raw.githubusercontent.com/theoremlp/rules_multitool/main/lockfile.schema.json",
+  "shellcheck": {
+    "binaries": [
+      {
+        "kind": "archive",
+        "os": "macos",
+        "cpu": "x86_64",
+        "url": "https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.darwin.x86_64.tar.xz",
+        "sha256": "ef27684f23279d112d8ad84e0823642e43f838993bbb8c0963db9b58a90464c2",
+        "file": "shellcheck-v0.10.0/shellcheck"
+      },
+      {
+        "kind": "archive",
+        "os": "macos",
+        "cpu": "arm64",
+        "url": "https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.darwin.aarch64.tar.xz",
+        "sha256": "bbd2f14826328eee7679da7221f2bc3afb011f6a928b848c80c321f6046ddf81",
+        "file": "shellcheck-v0.10.0/shellcheck"
+      },
+      {
+        "kind": "archive",
+        "os": "linux",
+        "cpu": "arm64",
+        "url": "https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.aarch64.tar.xz",
+        "sha256": "324a7e89de8fa2aed0d0c28f3dab59cf84c6d74264022c00c22af665ed1a09bb",
+        "file": "shellcheck-v0.10.0/shellcheck"
+      },
+      {
+        "kind": "archive",
+        "os": "linux",
+        "cpu": "x86_64",
+        "url": "https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz",
+        "sha256": "6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87",
+        "file": "shellcheck-v0.10.0/shellcheck"
+      }
+    ]
+  }
+}

--- a/lint/multitool.lock.json
+++ b/lint/multitool.lock.json
@@ -1,5 +1,41 @@
 {
   "$schema": "https://raw.githubusercontent.com/theoremlp/rules_multitool/main/lockfile.schema.json",
+  "golangci-lint": {
+    "binaries": [
+      {
+        "os": "linux",
+        "cpu": "x86_64",
+        "kind": "archive",
+        "url": "https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-linux-amd64.tar.gz",
+        "sha256": "ca21c961a33be3bc15e4292dc40c98c8dcc5463a7b6768a3afc123761630c09c",
+        "file": "golangci-lint-1.55.2-linux-amd64/golangci-lint"
+      },
+      {
+        "os": "linux",
+        "cpu": "arm64",
+        "kind": "archive",
+        "url": "https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-linux-arm64.tar.gz",
+        "sha256": "8eb0cee9b1dbf0eaa49871798c7f8a5b35f2960c52d776a5f31eb7d886b92746",
+        "file": "golangci-lint-1.55.2-linux-arm64/golangci-lint"
+      },
+      {
+        "os": "macos",
+        "cpu": "x86_64",
+        "kind": "archive",
+        "url": "https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-darwin-amd64.tar.gz",
+        "sha256": "632e96e6d5294fbbe7b2c410a49c8fa01c60712a0af85a567de85bcc1623ea21",
+        "file": "golangci-lint-1.55.2-darwin-amd64/golangci-lint"
+      },
+      {
+        "os": "macos",
+        "cpu": "arm64",
+        "kind": "archive",
+        "url": "https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-darwin-arm64.tar.gz",
+        "sha256": "234463f059249f82045824afdcdd5db5682d0593052f58f6a3039a0a1c3899f6",
+        "file": "golangci-lint-1.55.2-darwin-arm64/golangci-lint"
+      }
+    ]
+  },
   "shellcheck": {
     "binaries": [
       {

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -2,15 +2,13 @@
 
 Typical usage:
 
-1. Use [fetch_shellcheck](#fetch_shellcheck) in WORKSPACE to call the `http_archive` calls to download binaries.
-2. Use [shellcheck_binary](#shellcheck_binary) to declare the shellcheck target, typically in in `tools/lint/BUILD.bazel`
-3. Use [shellcheck_aspect](#shellcheck_aspect) to declare the shellcheck linter aspect, typically in in `tools/lint/linters.bzl`:
+Use [shellcheck_aspect](#shellcheck_aspect) to declare the shellcheck linter aspect, typically in in `tools/lint/linters.bzl`:
 
 ```
 load("@aspect_rules_lint//lint:shellcheck.bzl", "shellcheck_aspect")
 
 shellcheck = shellcheck_aspect(
-    binary = "@@//tools/lint:shellcheck",
+    binary = "@multitool//tools/shellcheck",
     config = "@@//:.shellcheckrc",
 )
 ```


### PR DESCRIPTION
Continues the work from setting up formatters this way.

Includes an upgrade of shellcheck to the latest release.

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)
    1. Remove any `fetch_shellcheck` or `fetch-golangci_lint` calls.
    2. Replace references of a local shellcheck binary with `@multitool//tools/shellcheck` and delete the local binary
    3. Replace references of golangci-lint binary with `@multitool//tools/golangci-lint` and delete local binary or alias

### Test plan

- Covered by existing test cases
