### PR TITLE
fix: pass flag to shfmt to ignore passed files in check mode

### DIFF
--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -34,7 +34,7 @@ CHECK_FLAGS = {
     "swiftformat": "--lint",
     "prettier": "--check",
     "ruff": "format --check --force-exclude",
-    "shfmt": "--diff",
+    "shfmt": "--diff --apply-ignore",
     "java-format": "--set-exit-if-changed --dry-run",
     "ktfmt": "--set-exit-if-changed --dry-run",
     "gofmt": "-l",


### PR DESCRIPTION
---

Pass the `--apply-ignore` flag the shfmt when checking to see if files are already formatted.

### Type of change

- Bug fix (change which fixes an issue)

**For changes visible to end-users**

- Suggested release notes are provided below:

shfmt will now respect ignores in .editorconfig even in check mode.

### Test plan

I didn't see any existing tests for check mode.