### PR TITLE
fix: use `allow_files` in `lint_ruff_aspect`

### DIFF
--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -153,7 +153,7 @@ def lint_ruff_aspect(binary, configs):
             ),
             "_ruff": attr.label(
                 default = binary,
-                allow_single_file = True,
+                allow_files = True,
                 executable = True,
                 cfg = "exec",
             ),


### PR DESCRIPTION
`lint_ruff_aspect` currently uses `allow_single_file` for the executable `_ruff` aspect. This is an unnecessary restriction: since we don't use `ctx.file._ruff` (only `ctx.executable._ruff`), we are needlessly blocking the use of rule targets that produce multiple default output files in addition to the necessary executable file.

This is a problem, for example, when trying to use an `sh_binary` target as `binary` for `lint_ruff_aspect`, since `sh_binary` produces all the srcs scripts as well as a generated entrypoint. Currently, `lint_ruff_aspect` refuses this, as it's not a single-file target. But it shouldn't matter, because `sh_binary` does produce an executable file for use as `ctx.executable._ruff`.

I haven't added a test for this, since testing multiple different `lint_ruff_aspect`s seems unnecessarily complicated. Testing is as simple as trying to pass an `sh_binary` target as `binary` to `lint_ruff_aspect`. It should be allowed and work without issue.