### PR TITLE
ktlint: Add option to use custom rulesets

### DIFF
--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -29,6 +29,28 @@ ktlint = ktlint_aspect(
 )
 ```
 
+If you plan on using Ktlint [custom rulesets](https://pinterest.github.io/ktlint/1.2.1/install/cli/#rule-sets), you can also declare 
+an additional `ruleset_jar` attribute pointing to your custom ruleset jar like this
+
+```
+java_binary(
+    name = "my_ktlint_custom_ruleset",
+    ...
+)
+
+ktlint = ktlint_aspect(
+    binary = "@@com_github_pinterest_ktlint//file",
+    # rules can be enabled/disabled from with this file
+    editorconfig = "@@//:.editorconfig",
+    # a baseline file with exceptions for violations
+    baseline_file = "@@//:.ktlint-baseline.xml",
+    # Run your custom ktlint ruleset on top of standard rules
+    ruleset_jar = "@@//:my_ktlint_custom_ruleset_deploy.jar",
+)
+```
+
+If your custom ruleset is a third-party dependency and not a first-party dependency, you can also fetch it using `http_file` and use it instead.
+
 
 <a id="fetch_ktlint"></a>
 

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -83,20 +83,18 @@ lint_ktlint_aspect(<a href="#lint_ktlint_aspect-binary">binary</a>, <a href="#li
 
 A factory function to create a linter aspect.
 
-Attrs:
-    binary: a ktlint executable, provided as file typically through http_file declaration or using fetch_ktlint in your WORKSPACE.
-    editorconfig: The label of the file pointing to the .editorconfig file used by ktlint.
-    baseline_file: An optional attribute pointing to the label of the baseline file used by ktlint.
-    ruleset_jar: An optional, custom ktlint ruleset provided as a fat jar, and works on top of the standard rules.
-
 **PARAMETERS**
 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="lint_ktlint_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
-| <a id="lint_ktlint_aspect-editorconfig"></a>editorconfig |  <p align="center"> - </p>   |  none |
-| <a id="lint_ktlint_aspect-baseline_file"></a>baseline_file |  <p align="center"> - </p>   |  none |
-| <a id="lint_ktlint_aspect-ruleset_jar"></a>ruleset_jar |  <p align="center"> - </p>   |  <code>None</code> |
+| <a id="lint_ktlint_aspect-binary"></a>binary |  a ktlint executable, provided as file typically through http_file declaration or using fetch_ktlint in your WORKSPACE.   |  none |
+| <a id="lint_ktlint_aspect-editorconfig"></a>editorconfig |  The label of the file pointing to the .editorconfig file used by ktlint.   |  none |
+| <a id="lint_ktlint_aspect-baseline_file"></a>baseline_file |  An optional attribute pointing to the label of the baseline file used by ktlint.   |  none |
+| <a id="lint_ktlint_aspect-ruleset_jar"></a>ruleset_jar |  An optional, custom ktlint ruleset provided as a fat jar, and works on top of the standard rules.   |  <code>None</code> |
+
+**RETURNS**
+
+An aspect definition for ktlint
 
 

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -47,7 +47,7 @@ fetch_ktlint()
 ## ktlint_action
 
 <pre>
-ktlint_action(<a href="#ktlint_action-ctx">ctx</a>, <a href="#ktlint_action-executable">executable</a>, <a href="#ktlint_action-srcs">srcs</a>, <a href="#ktlint_action-editorconfig">editorconfig</a>, <a href="#ktlint_action-report">report</a>, <a href="#ktlint_action-baseline_file">baseline_file</a>, <a href="#ktlint_action-java_runtime">java_runtime</a>,
+ktlint_action(<a href="#ktlint_action-ctx">ctx</a>, <a href="#ktlint_action-executable">executable</a>, <a href="#ktlint_action-srcs">srcs</a>, <a href="#ktlint_action-editorconfig">editorconfig</a>, <a href="#ktlint_action-report">report</a>, <a href="#ktlint_action-baseline_file">baseline_file</a>, <a href="#ktlint_action-java_runtime">java_runtime</a>, <a href="#ktlint_action-ruleset_jar">ruleset_jar</a>,
               <a href="#ktlint_action-use_exit_code">use_exit_code</a>)
 </pre>
 
@@ -69,6 +69,7 @@ https://pinterest.github.io/ktlint/latest/install/cli/
 | <a id="ktlint_action-report"></a>report |  :output:  the stdout of ktlint containing any violations found   |  none |
 | <a id="ktlint_action-baseline_file"></a>baseline_file |  The file object pointing to the baseline file used by ktlint.   |  none |
 | <a id="ktlint_action-java_runtime"></a>java_runtime |  The Java Runtime configured for this build, pulled from the registered toolchain.   |  none |
+| <a id="ktlint_action-ruleset_jar"></a>ruleset_jar |  An optional, custom ktlint ruleset jar.   |  <code>None</code> |
 | <a id="ktlint_action-use_exit_code"></a>use_exit_code |  whether a non-zero exit code from ktlint process will result in a build failure.   |  <code>False</code> |
 
 
@@ -77,7 +78,7 @@ https://pinterest.github.io/ktlint/latest/install/cli/
 ## lint_ktlint_aspect
 
 <pre>
-lint_ktlint_aspect(<a href="#lint_ktlint_aspect-binary">binary</a>, <a href="#lint_ktlint_aspect-editorconfig">editorconfig</a>, <a href="#lint_ktlint_aspect-baseline_file">baseline_file</a>)
+lint_ktlint_aspect(<a href="#lint_ktlint_aspect-binary">binary</a>, <a href="#lint_ktlint_aspect-editorconfig">editorconfig</a>, <a href="#lint_ktlint_aspect-baseline_file">baseline_file</a>, <a href="#lint_ktlint_aspect-ruleset_jar">ruleset_jar</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -86,6 +87,7 @@ Attrs:
     binary: a ktlint executable, provided as file typically through http_file declaration or using fetch_ktlint in your WORKSPACE.
     editorconfig: The label of the file pointing to the .editorconfig file used by ktlint.
     baseline_file: An optional attribute pointing to the label of the baseline file used by ktlint.
+    ruleset_jar: An optional, custom ktlint ruleset provided as a fat jar, and works on top of the standard rules.
 
 **PARAMETERS**
 
@@ -95,5 +97,6 @@ Attrs:
 | <a id="lint_ktlint_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
 | <a id="lint_ktlint_aspect-editorconfig"></a>editorconfig |  <p align="center"> - </p>   |  none |
 | <a id="lint_ktlint_aspect-baseline_file"></a>baseline_file |  <p align="center"> - </p>   |  none |
+| <a id="lint_ktlint_aspect-ruleset_jar"></a>ruleset_jar |  <p align="center"> - </p>   |  <code>None</code> |
 
 

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -162,6 +162,7 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "//lint/private:lint_aspect",
+        "@bazel_skylib//lib:dicts",
         "@bazel_tools//tools/build_defs/repo:http.bzl",
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
     ],

--- a/lint/ktlint.bzl
+++ b/lint/ktlint.bzl
@@ -26,6 +26,28 @@ ktlint = ktlint_aspect(
     baseline_file = "@@//:.ktlint-baseline.xml",
 )
 ```
+
+If you plan on using Ktlint [custom rulesets](https://pinterest.github.io/ktlint/1.2.1/install/cli/#rule-sets), you can also declare 
+an additional `ruleset_jar` attribute pointing to your custom ruleset jar like this
+
+```
+java_binary(
+    name = "my_ktlint_custom_ruleset",
+    ...
+)
+
+ktlint = ktlint_aspect(
+    binary = "@@com_github_pinterest_ktlint//file",
+    # rules can be enabled/disabled from with this file
+    editorconfig = "@@//:.editorconfig",
+    # a baseline file with exceptions for violations
+    baseline_file = "@@//:.ktlint-baseline.xml",
+    # Run your custom ktlint ruleset on top of standard rules
+    ruleset_jar = "@@//:my_ktlint_custom_ruleset_deploy.jar",
+)
+```
+
+If your custom ruleset is a third-party dependency and not a first-party dependency, you can also fetch it using `http_file` and use it instead.
 """
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")

--- a/lint/ktlint.bzl
+++ b/lint/ktlint.bzl
@@ -179,7 +179,7 @@ def lint_ktlint_aspect(binary, editorconfig, baseline_file, ruleset_jar = None):
 def fetch_ktlint():
     http_file(
         name = "com_github_pinterest_ktlint",
-        sha256 = "89491ea865d369b39cfaca2dcf60b38adbdcd74985f5e0170c0bb73034000135",
-        url = "https://github.com/pinterest/ktlint/releases/download/0.45.2/ktlint",
+        sha256 = "2e28cf46c27d38076bf63beeba0bdef6a845688d6c5dccd26505ce876094eb92",
+        url = "https://github.com/pinterest/ktlint/releases/download/1.2.1/ktlint",
         executable = True,
     )


### PR DESCRIPTION
Follow-up on https://github.com/aspect-build/rules_lint/pull/215, this adds support for the `--ruleset` argument with `ktlint` https://pinterest.github.io/ktlint/1.2.1/install/cli/#rule-sets

For most people, the standard rulesets may suffice. However, in large codebases it's common to write your own custom rules and use them on top of standard rules. This adds support for it by updating the `ktlint` aspect.

### Test plan

- Covered by existing test cases

This is not a breaking change and existing test cases should pass. I'd like to add testcases for this code path, but that'd require adding a custom ruleset dependency here. There's no popular OSS custom rulesets and not sure it has to live here (although I'd be happy to add). I've tested this against our custom rules and it seems to work as expected.
