### PR TITLE
feat(lint): plumb exit codes as outputs rather than dropping them

### DIFF
--- a/example/WORKSPACE.bazel
+++ b/example/WORKSPACE.bazel
@@ -256,8 +256,7 @@ fetch_pmd()
 
 load("@aspect_rules_lint//lint:ruff.bzl", "fetch_ruff")
 
-# https://github.com/astral-sh/ruff/pull/8631#issuecomment-2022746290
-fetch_ruff("v0.3.2")
+fetch_ruff()
 
 load("@aspect_rules_lint//lint:vale.bzl", "fetch_vale")
 

--- a/example/WORKSPACE.bzlmod
+++ b/example/WORKSPACE.bzlmod
@@ -17,8 +17,7 @@ fetch_ktfmt()
 
 fetch_swiftformat()
 
-# https://github.com/astral-sh/ruff/pull/8631#issuecomment-2022746290
-fetch_ruff("v0.3.2")
+fetch_ruff()
 
 load("@aspect_rules_lint//lint:pmd.bzl", "fetch_pmd")
 

--- a/example/lint.sh
+++ b/example/lint.sh
@@ -26,10 +26,10 @@ filter='.namedSetOfFiles | values | .files[] | ((.pathPrefix | join("/")) + "/" 
 args=(
 	"--aspects=$(echo //tools/lint:linters.bzl%{buf,eslint,flake8,ktlint,pmd,ruff,shellcheck,vale} | tr ' ' ',')"
 	"--build_event_json_file=$buildevents"
+	"--remote_download_regex='.*aspect_rules_lint.*'"
 )
 report_args=(
 	"--output_groups=rules_lint_report"
-	"--remote_download_regex='.*aspect_rules_lint.report'"
 )
 
 # This is a rudimentary flag parser.
@@ -45,7 +45,6 @@ if [ $1 == "--fix" ]; then
 	# override this flag
 	patch_args=(
 		"--output_groups=rules_lint_patch"
-		"--remote_download_regex='.*aspect_rules_lint.patch'"
 	)
 	shift
 fi

--- a/example/src/unused_import.py
+++ b/example/src/unused_import.py
@@ -5,7 +5,7 @@
 # Error: bazel exited with exit code: 1
 
 # Demo with just running ruff:
-# $ bazel run --run_under="cd $PWD &&" -- :ruff --config=.ruff.toml --exit-zero src/*.py
+# $ bazel run --run_under="cd $PWD &&" -- //tools/lint:ruff check --config=.ruff.toml src/*.py
 # INFO: Build completed successfully, 1 total action
 # src/unused_import.py:12:8: F401 [*] `os` imported but unused
 # Found 1 error.

--- a/lint/buf.bzl
+++ b/lint/buf.bzl
@@ -19,7 +19,7 @@ _MNEMONIC = "buf"
 def _short_path(file, _):
     return file.path
 
-def buf_lint_action(ctx, buf, protoc, target, report, use_exit_code = False):
+def buf_lint_action(ctx, buf, protoc, target, report, exit_code = None):
     """Runs the buf lint tool as a Bazel action.
 
     Args:
@@ -28,7 +28,8 @@ def buf_lint_action(ctx, buf, protoc, target, report, use_exit_code = False):
         protoc: the protoc executable
         target: the proto_library target to run on
         report: output file to generate
-        use_exit_code: whether the protoc process exiting non-zero will be a build failure
+        exit_code: output file to write the exit code.
+            If None, then fail the build when protoc exits non-zero.
     """
     config = json.encode({
         "input_config": "" if ctx.file._config == None else ctx.file._config.short_path,
@@ -57,11 +58,14 @@ def buf_lint_action(ctx, buf, protoc, target, report, use_exit_code = False):
     args.add_joined("--descriptor_set_in", deps, join_with = ":", map_each = _short_path)
     args.add_joined(["--buf-plugin_out", "."], join_with = "=")
     args.add_all(sources)
+    outputs = [report]
 
-    if use_exit_code:
-        command = "{protoc} $@ && touch {report}"
+    if exit_code:
+        command = "{protoc} $@ 2>{report}; echo $? > " + exit_code.path
+        outputs.append(exit_code)
     else:
-        command = "{protoc} $@ 2>{report} || true"
+        # Create empty report file on success, as Bazel expects one
+        command = "{protoc} $@ && touch {report}"
 
     ctx.actions.run_shell(
         inputs = depset([
@@ -69,7 +73,7 @@ def buf_lint_action(ctx, buf, protoc, target, report, use_exit_code = False):
             protoc,
             buf,
         ], transitive = [deps]),
-        outputs = [report],
+        outputs = outputs,
         command = command.format(
             protoc = protoc.path,
             report = report.path,
@@ -82,14 +86,14 @@ def _buf_lint_aspect_impl(target, ctx):
     if ctx.rule.kind not in ["proto_library"]:
         return []
 
-    report, info = report_file(_MNEMONIC, target, ctx)
+    report, exit_code, info = report_file(_MNEMONIC, target, ctx)
     buf_lint_action(
         ctx,
         ctx.toolchains[ctx.attr._buf_toolchain].cli,
         ctx.toolchains["@rules_proto//proto:toolchain_type"].proto.proto_compiler.executable,
         target,
         report,
-        ctx.attr._options[LintOptionsInfo].fail_on_violation,
+        exit_code,
     )
     return [info]
 

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -72,7 +72,7 @@ def _gather_inputs(ctx, srcs):
 
     return inputs
 
-def eslint_action(ctx, executable, srcs, report, use_exit_code = False):
+def eslint_action(ctx, executable, srcs, report, exit_code = None):
     """Create a Bazel Action that spawns an eslint process.
 
     Adapter for wrapping Bazel around
@@ -83,7 +83,8 @@ def eslint_action(ctx, executable, srcs, report, use_exit_code = False):
         executable: struct with an eslint field
         srcs: list of file objects to lint
         report: output: the stdout of eslint containing any violations found
-        use_exit_code: whether an eslint process exiting non-zero will be a build failure
+        exit_code: output file to write the exit code.
+            If None, then fail the build when eslint exits non-zero.
     """
 
     args = ctx.actions.args()
@@ -96,7 +97,7 @@ def eslint_action(ctx, executable, srcs, report, use_exit_code = False):
 
     env = {"BAZEL_BINDIR": ctx.bin_dir.path}
 
-    if use_exit_code:
+    if not exit_code:
         ctx.actions.run_shell(
             inputs = _gather_inputs(ctx, srcs),
             outputs = [report],
@@ -112,12 +113,11 @@ def eslint_action(ctx, executable, srcs, report, use_exit_code = False):
         args.add_joined(["--node_options", "--require", "../../../" + ctx.file._workaround_17660.path], join_with = "=")
 
         args.add_all(["--output-file", report.short_path])
-        exit_code_out = ctx.actions.declare_file("_{}.exit_code_out".format(ctx.label.name))
-        env["JS_BINARY__EXIT_CODE_OUTPUT_FILE"] = exit_code_out.path
+        env["JS_BINARY__EXIT_CODE_OUTPUT_FILE"] = exit_code.path
 
         ctx.actions.run(
             inputs = _gather_inputs(ctx, srcs),
-            outputs = [report, exit_code_out],
+            outputs = [report, exit_code],
             executable = executable._eslint,
             arguments = [args],
             env = env,
@@ -161,9 +161,9 @@ def _eslint_aspect_impl(target, ctx):
     if ctx.rule.kind not in ["js_library", "ts_project", "ts_project_rule"]:
         return []
 
-    patch, report, info = patch_and_report_files(_MNEMONIC, target, ctx)
+    patch, report, exit_code, info = patch_and_report_files(_MNEMONIC, target, ctx)
     files_to_lint = filter_srcs(ctx.rule)
-    eslint_action(ctx, ctx.executable, files_to_lint, report, ctx.attr._options[LintOptionsInfo].fail_on_violation)
+    eslint_action(ctx, ctx.executable, files_to_lint, report, exit_code)
     eslint_fix(ctx, ctx.executable, files_to_lint, patch)
     return [info]
 

--- a/lint/flake8.bzl
+++ b/lint/flake8.bzl
@@ -30,7 +30,7 @@ load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "report
 
 _MNEMONIC = "flake8"
 
-def flake8_action(ctx, executable, srcs, config, report, use_exit_code = False):
+def flake8_action(ctx, executable, srcs, config, report, exit_code = None):
     """Run flake8 as an action under Bazel.
 
     Based on https://flake8.pycqa.org/en/latest/user/invocation.html
@@ -41,7 +41,8 @@ def flake8_action(ctx, executable, srcs, config, report, use_exit_code = False):
         srcs: python files to be linted
         config: label of the flake8 config file (setup.cfg, tox.ini, or .flake8)
         report: output file to generate
-        use_exit_code: whether to fail the build when a lint violation is reported
+        exit_code: output file to write the exit code.
+            If None, then fail the build when flake8 exits non-zero.
     """
     inputs = srcs + [config]
     outputs = [report]
@@ -51,34 +52,30 @@ def flake8_action(ctx, executable, srcs, config, report, use_exit_code = False):
     args = ctx.actions.args()
     args.add_all(srcs)
     args.add(config, format = "--config=%s")
-    if use_exit_code:
-        ctx.actions.run_shell(
-            inputs = inputs,
-            outputs = outputs,
-            tools = [executable],
-            command = executable.path + " $@ && touch " + report.path,
-            arguments = [args],
-            mnemonic = _MNEMONIC,
-        )
-    else:
-        args.add(report, format = "--output-file=%s")
-        args.add("--exit-zero")
 
-        ctx.actions.run(
-            inputs = inputs,
-            outputs = outputs,
-            executable = executable,
-            arguments = [args],
-            mnemonic = _MNEMONIC,
-        )
+    if exit_code:
+        command = "{flake8} $@ >{report}; echo $? > " + exit_code.path
+        outputs.append(exit_code)
+    else:
+        # Create empty report file on success, as Bazel expects one
+        command = "{flake8} $@ && touch {report}"
+
+    ctx.actions.run_shell(
+        inputs = inputs,
+        outputs = outputs,
+        tools = [executable],
+        command = command.format(flake8 = executable.path, report = report.path),
+        arguments = [args],
+        mnemonic = _MNEMONIC,
+    )
 
 # buildifier: disable=function-docstring
 def _flake8_aspect_impl(target, ctx):
     if ctx.rule.kind not in ["py_binary", "py_library"]:
         return []
 
-    report, info = report_file(_MNEMONIC, target, ctx)
-    flake8_action(ctx, ctx.executable._flake8, filter_srcs(ctx.rule), ctx.file._config_file, report, ctx.attr._options[LintOptionsInfo].fail_on_violation)
+    report, exit_code, info = report_file(_MNEMONIC, target, ctx)
+    flake8_action(ctx, ctx.executable._flake8, filter_srcs(ctx.rule), ctx.file._config_file, report, exit_code)
     return [info]
 
 def lint_flake8_aspect(binary, config):

--- a/lint/pmd.bzl
+++ b/lint/pmd.bzl
@@ -32,7 +32,7 @@ load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "report
 
 _MNEMONIC = "PMD"
 
-def pmd_action(ctx, executable, srcs, rulesets, report, use_exit_code = False):
+def pmd_action(ctx, executable, srcs, rulesets, report, exit_code = None):
     """Run PMD as an action under Bazel.
 
     Based on https://docs.pmd-code.org/latest/pmd_userdocs_installation.html#running-pmd-via-command-line
@@ -43,9 +43,11 @@ def pmd_action(ctx, executable, srcs, rulesets, report, use_exit_code = False):
         srcs: java files to be linted
         rulesets: list of labels of the PMD ruleset files
         report: output file to generate
-        use_exit_code: whether to fail the build when a lint violation is reported
+        exit_code: output file to write the exit code.
+            If None, then fail the build when PMD exits non-zero.
     """
     inputs = srcs + rulesets
+    outputs = [report]
 
     # Wire command-line options, see
     # https://docs.pmd-code.org/latest/pmd_userdocs_cli_reference.html
@@ -57,35 +59,29 @@ def pmd_action(ctx, executable, srcs, rulesets, report, use_exit_code = False):
     src_args.use_param_file("%s", use_always = True)
     src_args.add_all(srcs)
 
-    if use_exit_code:
-        ctx.actions.run_shell(
-            inputs = inputs,
-            outputs = [report],
-            command = executable.path + " $@ && touch " + report.path,
-            arguments = [args, "--file-list", src_args],
-            mnemonic = _MNEMONIC,
-            tools = [executable],
-        )
+    if exit_code:
+        command = "{PMD} $@ >{report}; echo $? > " + exit_code.path
+        outputs.append(exit_code)
     else:
-        args.add_all(["--report-file", report])
+        # Create empty report file on success, as Bazel expects one
+        command = "{PMD} $@ && touch {report}"
 
-        # NB: this arg changes in PMD 7
-        args.add_all(["--fail-on-violation", "false"])
-        ctx.actions.run(
-            inputs = inputs,
-            outputs = [report],
-            executable = executable,
-            arguments = [args, "--file-list", src_args],
-            mnemonic = _MNEMONIC,
-        )
+    ctx.actions.run_shell(
+        inputs = inputs,
+        outputs = outputs,
+        command = command.format(PMD = executable.path, report = report.path),
+        arguments = [args, "--file-list", src_args],
+        mnemonic = _MNEMONIC,
+        tools = [executable],
+    )
 
 # buildifier: disable=function-docstring
 def _pmd_aspect_impl(target, ctx):
     if ctx.rule.kind not in ["java_binary", "java_library"]:
         return []
 
-    report, info = report_file(_MNEMONIC, target, ctx)
-    pmd_action(ctx, ctx.executable._pmd, filter_srcs(ctx.rule), ctx.files._rulesets, report, ctx.attr._options[LintOptionsInfo].fail_on_violation)
+    report, exit_code, info = report_file(_MNEMONIC, target, ctx)
+    pmd_action(ctx, ctx.executable._pmd, filter_srcs(ctx.rule), ctx.files._rulesets, report, exit_code)
     return [info]
 
 def lint_pmd_aspect(binary, rulesets):


### PR DESCRIPTION
This allows downstream tools to return a correct exit code based on 'errors were reported by at least one linter'

---

### Changes are visible to end-users: yes

It's only slightly visible, in that `lint.sh` now prints exit codes as well:

```
rules_lint/example$ ./lint.sh src:unused_import
INFO: Analyzed target //src:unused_import (5 packages loaded, 492 targets configured).
INFO: Found 1 target...
INFO: Elapsed time: 0.309s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build Event Protocol files produced successfully.
From bazel-out/k8-fastbuild/bin/src/ruff.unused_import.aspect_rules_lint.report:
src/unused_import.py:13:8: F401 [*] `os` imported but unused
Found 1 error.
[*] 1 fixable with the `--fix` option.

From bazel-out/k8-fastbuild/bin/src/ruff.unused_import.aspect_rules_lint.exit_code:
1

From bazel-out/k8-fastbuild/bin/src/flake8.unused_import.aspect_rules_lint.report:
src/unused_import.py:13:1: F401 'os' imported but unused

From bazel-out/k8-fastbuild/bin/src/flake8.unused_import.aspect_rules_lint.exit_code:
1
```

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
