### PR TITLE
refactor: produce report and exit code in the same action with fixes

### DIFF
--- a/docs/eslint.md
+++ b/docs/eslint.md
@@ -86,7 +86,7 @@ https://eslint.org/docs/latest/use/command-line-interface
 ## eslint_fix
 
 <pre>
-eslint_fix(<a href="#eslint_fix-ctx">ctx</a>, <a href="#eslint_fix-executable">executable</a>, <a href="#eslint_fix-srcs">srcs</a>, <a href="#eslint_fix-patch">patch</a>)
+eslint_fix(<a href="#eslint_fix-ctx">ctx</a>, <a href="#eslint_fix-executable">executable</a>, <a href="#eslint_fix-srcs">srcs</a>, <a href="#eslint_fix-patch">patch</a>, <a href="#eslint_fix-stdout">stdout</a>, <a href="#eslint_fix-exit_code">exit_code</a>)
 </pre>
 
 Create a Bazel Action that spawns eslint with --fix.
@@ -100,6 +100,8 @@ Create a Bazel Action that spawns eslint with --fix.
 | <a id="eslint_fix-executable"></a>executable |  struct with an eslint field   |  none |
 | <a id="eslint_fix-srcs"></a>srcs |  list of file objects to lint   |  none |
 | <a id="eslint_fix-patch"></a>patch |  output file containing the applied fixes that can be applied with the patch(1) command.   |  none |
+| <a id="eslint_fix-stdout"></a>stdout |  output file containing the stdout or --output-file of eslint   |  none |
+| <a id="eslint_fix-exit_code"></a>exit_code |  output file containing the exit code of eslint   |  none |
 
 
 <a id="lint_eslint_aspect"></a>

--- a/docs/ruff.md
+++ b/docs/ruff.md
@@ -135,6 +135,6 @@ Create a Bazel Action that spawns ruff with --fix.
 | <a id="ruff_fix-config"></a>config |  labels of ruff config files (pyproject.toml, ruff.toml, or .ruff.toml)   |  none |
 | <a id="ruff_fix-patch"></a>patch |  output file containing the applied fixes that can be applied with the patch(1) command.   |  none |
 | <a id="ruff_fix-stdout"></a>stdout |  output file of linter results to generate   |  none |
-| <a id="ruff_fix-exit_code"></a>exit_code |  output file to write the exit code. If None, then fail the build when ruff exits non-zero.   |  none |
+| <a id="ruff_fix-exit_code"></a>exit_code |  output file to write the exit code   |  none |
 
 

--- a/docs/ruff.md
+++ b/docs/ruff.md
@@ -119,7 +119,7 @@ However this is needed because:
 ## ruff_fix
 
 <pre>
-ruff_fix(<a href="#ruff_fix-ctx">ctx</a>, <a href="#ruff_fix-executable">executable</a>, <a href="#ruff_fix-srcs">srcs</a>, <a href="#ruff_fix-config">config</a>, <a href="#ruff_fix-patch">patch</a>)
+ruff_fix(<a href="#ruff_fix-ctx">ctx</a>, <a href="#ruff_fix-executable">executable</a>, <a href="#ruff_fix-srcs">srcs</a>, <a href="#ruff_fix-config">config</a>, <a href="#ruff_fix-patch">patch</a>, <a href="#ruff_fix-stdout">stdout</a>, <a href="#ruff_fix-exit_code">exit_code</a>)
 </pre>
 
 Create a Bazel Action that spawns ruff with --fix.
@@ -134,5 +134,7 @@ Create a Bazel Action that spawns ruff with --fix.
 | <a id="ruff_fix-srcs"></a>srcs |  list of file objects to lint   |  none |
 | <a id="ruff_fix-config"></a>config |  labels of ruff config files (pyproject.toml, ruff.toml, or .ruff.toml)   |  none |
 | <a id="ruff_fix-patch"></a>patch |  output file containing the applied fixes that can be applied with the patch(1) command.   |  none |
+| <a id="ruff_fix-stdout"></a>stdout |  output file of linter results to generate   |  none |
+| <a id="ruff_fix-exit_code"></a>exit_code |  output file to write the exit code. If None, then fail the build when ruff exits non-zero.   |  none |
 
 

--- a/docs/ruff.md
+++ b/docs/ruff.md
@@ -65,19 +65,7 @@ lint_ruff_aspect(<a href="#lint_ruff_aspect-binary">binary</a>, <a href="#lint_r
 A factory function to create a linter aspect.
 
 Attrs:
-    binary: a ruff executable. Can be obtained like so:
-
-        load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-        http_archive(
-            name = "ruff_bin_linux_amd64",
-            sha256 = "&lt;-sha-&gt;",
-            urls = [
-                "https://github.com/charliermarsh/ruff/releases/download/v&lt;-version-&gt;/ruff-x86_64-unknown-linux-gnu.tar.gz",
-            ],
-            build_file_content = """exports_files(["ruff"])""",
-        )
-
+    binary: a ruff executable
     configs: ruff config file(s) (`pyproject.toml`, `ruff.toml`, or `.ruff.toml`)
 
 **PARAMETERS**

--- a/example/src/file.ts
+++ b/example/src/file.ts
@@ -4,6 +4,8 @@ console.log(a);
 
 // linting violation; not auto-fixable
 // Should be reported under `--fix` and lint will exit 1.
-function* foo() {
-  return 10;
+try {
+  console.log();
+} catch (e) {
+  throw e;
 }

--- a/example/src/file.ts
+++ b/example/src/file.ts
@@ -1,3 +1,9 @@
-// this is a linting violation
+// this is a linting violation, and is auto-fixed under `--fix`
 const a: string = "a";
 console.log(a);
+
+// linting violation; not auto-fixable
+// Should be reported under `--fix` and lint will exit 1.
+function* foo() {
+  return 10;
+}

--- a/example/src/hello.sh
+++ b/example/src/hello.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+# Missing quotes, auto-fixable under `--fix`
 [ -z $THING ] && echo "hello world"
 
 # Note, we should not get a lint here because the .shellcheckrc excludes it
 [ ! -z "$foo" ] && echo "foo"
+
+# Not auto-fixable. Should be reported under `--fix` and lint exits 1
+grep '*foo*' file

--- a/example/src/unused_import.py
+++ b/example/src/unused_import.py
@@ -11,3 +11,5 @@
 # Found 1 error.
 # [*] 1 potentially fixable with the --fix option.
 import os
+
+print("{".format("something"))

--- a/example/src/unused_import.py
+++ b/example/src/unused_import.py
@@ -12,4 +12,6 @@
 # [*] 1 potentially fixable with the --fix option.
 import os
 
+# Another lint violation, which is not auto-fixable.
+# When running with `--fix` this one should be reported and lint should exit 1.
 print("{".format("something"))

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("//lint/private:lint_aspect.bzl", "fail_on_violation_flag")
+load("//lint/private:lint_aspect.bzl", "lint_options")
 
 exports_files(glob(["*.bzl"]) + ["lint_test.sh"])
 
@@ -34,17 +34,48 @@ bool_flag(
     visibility = ["//visibility:public"],
 )
 
-fail_on_violation_flag(
+config_setting(
+    name = "debug.enabled",
+    flag_values = {":debug": "true"},
+)
+
+bool_flag(
     name = "fail_on_violation",
     build_setting_default = False,
     visibility = ["//visibility:public"],
 )
 
 config_setting(
-    name = "debug_flag",
-    flag_values = {
-        ":debug": "true",
-    },
+    name = "fail_on_violation.enabled",
+    flag_values = {":fail_on_violation": "true"},
+)
+
+bool_flag(
+    name = "fix",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "fix.enabled",
+    flag_values = {":fix": "true"},
+)
+
+lint_options(
+    name = "options",
+    debug = select({
+        ":debug.enabled": True,
+        "//conditions:default": False,
+    }),
+    fail_on_violation = select({
+        ":fail_on_violation.enabled": True,
+        "//conditions:default": False,
+    }),
+    fix = select({
+        ":fix.enabled": True,
+        "//conditions:default": False,
+    }),
+    visibility = ["//visibility:public"],
 )
 
 js_library(

--- a/lint/buf.bzl
+++ b/lint/buf.bzl
@@ -109,7 +109,7 @@ def lint_buf_aspect(config, toolchain = "@rules_buf//tools/protoc-gen-buf-lint:t
         attr_aspects = ["deps"],
         attrs = {
             "_options": attr.label(
-                default = "//lint:fail_on_violation",
+                default = "//lint:options",
                 providers = [LintOptionsInfo],
             ),
             "_buf_toolchain": attr.string(

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -187,7 +187,7 @@ def lint_eslint_aspect(binary, configs):
         implementation = _eslint_aspect_impl,
         attrs = {
             "_options": attr.label(
-                default = "//lint:fail_on_violation",
+                default = "//lint:options",
                 providers = [LintOptionsInfo],
             ),
             "_eslint": attr.label(

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -141,7 +141,7 @@ def eslint_fix(ctx, executable, srcs, patch, stdout, exit_code):
         output = patch_cfg,
         content = json.encode({
             "linter": executable._eslint.path,
-            "args": ["--fix"] + [s.short_path for s in srcs],
+            "args": ["--fix", "--format", "../../../" + ctx.file._formatter.path] + [s.short_path for s in srcs],
             "env": {"BAZEL_BINDIR": ctx.bin_dir.path},
             "files_to_diff": [s.path for s in srcs],
             "output": patch.path,
@@ -157,6 +157,7 @@ def eslint_fix(ctx, executable, srcs, patch, stdout, exit_code):
             "BAZEL_BINDIR": ".",
             "JS_BINARY__EXIT_CODE_OUTPUT_FILE": exit_code.path,
             "JS_BINARY__STDOUT_OUTPUT_FILE": stdout.path,
+            "JS_BINARY__SILENT_ON_SUCCESS": "1",
         },
         tools = [executable._eslint],
         mnemonic = _MNEMONIC,

--- a/lint/flake8.bzl
+++ b/lint/flake8.bzl
@@ -100,7 +100,7 @@ def lint_flake8_aspect(binary, config):
         # attr_aspects = ["deps"],
         attrs = {
             "_options": attr.label(
-                default = "//lint:fail_on_violation",
+                default = "//lint:options",
                 providers = [LintOptionsInfo],
             ),
             "_flake8": attr.label(

--- a/lint/ktlint.bzl
+++ b/lint/ktlint.bzl
@@ -168,7 +168,7 @@ def lint_ktlint_aspect(binary, editorconfig, baseline_file, ruleset_jar = None):
         # attr_aspects = ["deps"],
         attrs = dicts.add({
             "_options": attr.label(
-                default = "//lint:fail_on_violation",
+                default = "//lint:options",
                 providers = [LintOptionsInfo],
             ),
             "_ktlint": attr.label(

--- a/lint/pmd.bzl
+++ b/lint/pmd.bzl
@@ -108,7 +108,7 @@ def lint_pmd_aspect(binary, rulesets):
         # attr_aspects = ["deps"],
         attrs = {
             "_options": attr.label(
-                default = "//lint:fail_on_violation",
+                default = "//lint:options",
                 providers = [LintOptionsInfo],
             ),
             "_pmd": attr.label(

--- a/lint/private/BUILD.bazel
+++ b/lint/private/BUILD.bazel
@@ -17,7 +17,7 @@ js_binary(
     name = "patcher",
     entry_point = "patcher.mjs",
     log_level = select({
-        "@aspect_rules_lint//lint:debug_flag": "debug",
+        "@aspect_rules_lint//lint:debug.enabled": "debug",
         "//conditions:default": "error",
     }),
     # Because aspect visibility rules are not on by default.

--- a/lint/private/lint_aspect.bzl
+++ b/lint/private/lint_aspect.bzl
@@ -2,15 +2,27 @@
 
 LintOptionsInfo = provider(
     doc = "Global options for running linters",
-    fields = {"fail_on_violation": "whether to honor the exit code of linter tools run as actions"},
+    fields = {
+        "debug": "print additional information for rules_lint developers",
+        "fail_on_violation": "whether to honor the exit code of linter tools run as actions",
+        "fix": "whether to run linters in their --fix mode. Fixes are collected into patch files.",
+    },
 )
 
-def _fail_on_violation_flag_impl(ctx):
-    return LintOptionsInfo(fail_on_violation = ctx.build_setting_value)
+def _lint_options_impl(ctx):
+    return LintOptionsInfo(
+        debug = ctx.attr.debug,
+        fail_on_violation = ctx.attr.fail_on_violation,
+        fix = ctx.attr.fix,
+    )
 
-fail_on_violation_flag = rule(
-    implementation = _fail_on_violation_flag_impl,
-    build_setting = config.bool(flag = True),
+lint_options = rule(
+    implementation = _lint_options_impl,
+    attrs = {
+        "debug": attr.bool(),
+        "fix": attr.bool(),
+        "fail_on_violation": attr.bool(),
+    },
 )
 
 # buildifier: disable=function-docstring

--- a/lint/private/patcher.mjs
+++ b/lint/private/patcher.mjs
@@ -75,6 +75,8 @@ async function main(args, sandbox) {
     env: config.env || {},
   });
 
+  // Check if we failed to spawn the process.
+  // If it ran normally and exited non-zero, ret.error will still be undefined
   if (ret.error) {
     console.error(ret.error);
     process.exit(1);
@@ -108,6 +110,8 @@ async function main(args, sandbox) {
   }
 
   diffOut.close();
+
+  return ret.status;
 }
 
 (async () => {
@@ -117,7 +121,8 @@ async function main(args, sandbox) {
       await fs.promises.mkdtemp(path.join(os.tmpdir(), "rules_lint_patcher-")),
       process.env.JS_BINARY__WORKSPACE
     );
-    await main(process.argv.slice(2), sandbox);
+    // Propagate the exit code of the subprocess so the caller can interpret it.
+    process.exitCode = await main(process.argv.slice(2), sandbox);
   } catch (e) {
     console.error(e);
     process.exit(1);

--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -15,7 +15,7 @@ ruff = ruff_aspect(
 load("@bazel_skylib//lib:versions.bzl", "versions")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "patch_and_report_files")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "patch_and_report_files", "report_files")
 load(":ruff_versions.bzl", "RUFF_VERSIONS")
 
 _MNEMONIC = "ruff"
@@ -115,11 +115,12 @@ def _ruff_aspect_impl(target, ctx):
     if ctx.rule.kind not in ["py_binary", "py_library", "py_test"]:
         return []
 
-    patch, report, exit_code, info = patch_and_report_files(_MNEMONIC, target, ctx)
     files_to_lint = filter_srcs(ctx.rule)
     if ctx.attr._options[LintOptionsInfo].fix:
+        patch, report, exit_code, info = patch_and_report_files(_MNEMONIC, target, ctx)
         ruff_fix(ctx, ctx.executable, files_to_lint, ctx.files._config_files, patch, report, exit_code)
     else:
+        report, exit_code, info = report_files(_MNEMONIC, target, ctx)
         ruff_action(ctx, ctx.executable._ruff, files_to_lint, ctx.files._config_files, report, exit_code)
     return [info]
 

--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -81,8 +81,7 @@ def ruff_fix(ctx, executable, srcs, config, patch, stdout, exit_code):
         config: labels of ruff config files (pyproject.toml, ruff.toml, or .ruff.toml)
         patch: output file containing the applied fixes that can be applied with the patch(1) command.
         stdout: output file of linter results to generate
-        exit_code: output file to write the exit code.
-            If None, then fail the build when ruff exits non-zero.
+        exit_code: output file to write the exit code
     """
     patch_cfg = ctx.actions.declare_file("_{}.patch_cfg".format(ctx.label.name))
 

--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -104,6 +104,7 @@ def ruff_fix(ctx, executable, srcs, config, patch, stdout, exit_code):
             "BAZEL_BINDIR": ".",
             "JS_BINARY__EXIT_CODE_OUTPUT_FILE": exit_code.path,
             "JS_BINARY__STDOUT_OUTPUT_FILE": stdout.path,
+            "JS_BINARY__SILENT_ON_SUCCESS": "1",
         },
         tools = [executable._ruff],
         mnemonic = _MNEMONIC,

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -84,7 +84,7 @@ def lint_shellcheck_aspect(binary, config):
         implementation = _shellcheck_aspect_impl,
         attrs = {
             "_options": attr.label(
-                default = "//lint:fail_on_violation",
+                default = "//lint:options",
                 providers = [LintOptionsInfo],
             ),
             "_shellcheck": attr.label(

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -14,7 +14,7 @@ shellcheck = shellcheck_aspect(
 ```
 """
 
-load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "patch_and_report_files")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "patch_and_report_files", "report_files")
 
 _MNEMONIC = "shellcheck"
 
@@ -67,10 +67,17 @@ def _shellcheck_aspect_impl(target, ctx):
     if ctx.rule.kind not in ["sh_binary", "sh_library"]:
         return []
 
-    patch, report, exit_code, info = patch_and_report_files(_MNEMONIC, target, ctx)
-    shellcheck_action(ctx, ctx.executable._shellcheck, filter_srcs(ctx.rule), ctx.file._config_file, report, exit_code)
-    discard_exit_code = ctx.actions.declare_file("{}.{}.aspect_rules_lint.patch_exit_code".format(_MNEMONIC, target.label.name))
-    shellcheck_action(ctx, ctx.executable._shellcheck, filter_srcs(ctx.rule), ctx.file._config_file, patch, discard_exit_code, ["--format", "diff"])
+    files_to_lint = filter_srcs(ctx.rule)
+    if ctx.attr._options[LintOptionsInfo].fix:
+        patch, report, exit_code, info = patch_and_report_files(_MNEMONIC, target, ctx)
+        discard_exit_code = ctx.actions.declare_file("{}.{}.aspect_rules_lint.patch_exit_code".format(_MNEMONIC, target.label.name))
+        shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, patch, discard_exit_code, ["--format", "diff"])
+    else:
+        report, exit_code, info = report_files(_MNEMONIC, target, ctx)
+
+    # shellcheck does not have a --fix mode that applies fixes for some violations while reporting others.
+    # So we must run a second action to populate the human-readable report.
+    shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, report, exit_code)
     return [info]
 
 def lint_shellcheck_aspect(binary, config):

--- a/lint/vale.bzl
+++ b/lint/vale.bzl
@@ -145,7 +145,7 @@ def lint_vale_aspect(binary, config, styles = Label("//lint:empty_styles")):
         implementation = _vale_aspect_impl,
         attrs = {
             "_options": attr.label(
-                default = "//lint:fail_on_violation",
+                default = "//lint:options",
                 providers = [LintOptionsInfo],
             ),
             "_vale": attr.label(


### PR DESCRIPTION
ruff and eslint both have the ability to produce the report of unfixable violations in the same execution that applies fixes.
We can use this to avoid having a second action run under `--fix`
For eslint in particular, this is a required performance improvement.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes, slightly
- Suggested release notes appear below: yes

To produce fixes, users must now pass the `--@aspect_rules_lint//lint:fix` flag.
The `lint.sh` helper script has been updated accordingly, and will need to be re-vendored into your repository.

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:


```
$ ./lint.sh --fix --dry-run src:unused_import
INFO: Analyzed target //src:unused_import (0 packages loaded, 2 targets configured).
From bazel-out/k8-fastbuild/bin/src/ruff.unused_import.aspect_rules_lint.report:
src/unused_import.py:16:7: F521 `.format` call has invalid format string: Single '{' encountered in format string
Found 2 errors (1 fixed, 1 remaining).

From bazel-out/k8-fastbuild/bin/src/flake8.unused_import.aspect_rules_lint.report:
src/unused_import.py:13:1: F401 'os' imported but unused
src/unused_import.py:17:7: F521 '...'.format(...) has invalid format string: Single '{' encountered in format string

From bazel-out/k8-fastbuild/bin/src/ruff.unused_import.aspect_rules_lint.patch:
--- a/src/unused_import.py
+++ b/src/unused_import.py
@@ -10,7 +10,6 @@
 # src/unused_import.py:12:8: F401 [*] `os` imported but unused
 # Found 1 error.
 # [*] 1 potentially fixable with the --fix option.
-import os
 
 # Another lint violation, which is not auto-fixable.
 # When running with `--fix` this one should be reported and lint should exit 1.

```

```
$ ./lint.sh --fix --dry-run src:ts
INFO: Analyzed target //src:ts (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
From bazel-out/k8-fastbuild/bin/src/ESLint.ts.aspect_rules_lint.report:
src/file.ts: line 7, col 1, Error - Unnecessary try/catch wrapper. (no-useless-catch)

1 problem

From bazel-out/k8-fastbuild/bin/src/ESLint.ts.aspect_rules_lint.patch:
--- a/src/file.ts
+++ b/src/file.ts
@@ -1,5 +1,5 @@
 // this is a linting violation, and is auto-fixed under `--fix`
-const a: string = "a";
+const a = "a";
 console.log(a);
 
 // linting violation; not auto-fixable
```