### PR TITLE
fix: lint.sh pass norun_validations

### DIFF
--- a/example/lint.sh
+++ b/example/lint.sh
@@ -25,6 +25,7 @@ filter='.namedSetOfFiles | values | .files[] | ((.pathPrefix | join("/")) + "/" 
 # NB: perhaps --remote_download_toplevel is needed as well with remote execution?
 args=(
 	"--aspects=$(echo //tools/lint:linters.bzl%{buf,eslint,flake8,ktlint,pmd,ruff,shellcheck,vale} | tr ' ' ',')"
+	"--norun_validations"
 	"--build_event_json_file=$buildevents"
 )
 report_args=(

--- a/example/lint.sh
+++ b/example/lint.sh
@@ -25,7 +25,9 @@ filter='.namedSetOfFiles | values | .files[] | ((.pathPrefix | join("/")) + "/" 
 # NB: perhaps --remote_download_toplevel is needed as well with remote execution?
 args=(
 	"--aspects=$(echo //tools/lint:linters.bzl%{buf,eslint,flake8,ktlint,pmd,ruff,shellcheck,vale} | tr ' ' ',')"
-	"--norun_validations"
+	# Allow lints of code that fails some validation check
+        # See https://github.com/aspect-build/rules_ts/pull/574#issuecomment-2073632879
+        "--norun_validations"
 	"--build_event_json_file=$buildevents"
 )
 report_args=(


### PR DESCRIPTION
Linting is generally orthogonal to other "validation" actions - users want to see lint reports even if some validation actions are in a failing state.
See https://github.com/aspect-build/rules_ts/pull/574#issuecomment-2073632879

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:
Ran `lint.sh`.