### PR TITLE
fix(format): Skip files with skip-worktree bit set

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -95,7 +95,7 @@ function ls-files {
 
         # TODO: determine which staged changes we should format; avoid formatting unstaged changes
         # TODO: try to format only modified regions of the file (where supported)
-        files=$(git ls-files --cached --modified --other --exclude-standard "${patterns[@]}" "${patterns[@]/#/*/}" | {
+        files=$(git ls-files --cached --modified --other --exclude-standard "${patterns[@]}" "${patterns[@]/#/*/}" | grep -v ^S | cut -f2 -d' ' | {
           grep -vE \
             "^$(git ls-files --deleted)$" \
           || true;

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -95,7 +95,7 @@ function ls-files {
 
         # TODO: determine which staged changes we should format; avoid formatting unstaged changes
         # TODO: try to format only modified regions of the file (where supported)
-        files=$(git ls-files --cached --modified --other --exclude-standard "${patterns[@]}" "${patterns[@]/#/*/}" | grep -v ^S | cut -f2 -d' ' | {
+        files=$(git ls-files -t --cached --modified --other --exclude-standard "${patterns[@]}" "${patterns[@]/#/*/}" | grep -v ^S | cut -f2 -d' ' | {
           grep -vE \
             "^$(git ls-files --deleted)$" \
           || true;

--- a/format/test/ls-files_test.sh
+++ b/format/test/ls-files_test.sh
@@ -60,3 +60,39 @@ go=$(ls-files Go src.go)
     echo >&2 -e "expected ls-files to return src.go, was\n$go"
     exit 1
 }
+
+# sparse-checkout should be supported
+mkdir tree1 tree2
+touch tree1/src.js tree2/src.js
+git add .
+git commit --all --message 'prepare sparse-checkout'
+git sparse-checkout init
+
+js=$(ls-files JavaScript)
+[[ "$js" == "src.js" ]] || {
+    echo >&2 -e "expected ls-files to return src.js, was\n$js"
+    exit 1
+}
+
+git sparse-checkout add tree1
+js=$(ls-files JavaScript)
+expected='src.js
+tree1/src.js'
+
+[[ "$js" == "$expected" ]] || {
+    echo >&2 -e "expected ls-files to return $expected, was\n$js"
+    exit 1
+}
+
+git sparse-checkout add tree2
+js=$(ls-files JavaScript)
+expected='src.js
+tree1/src.js
+tree2/src.js'
+
+[[ "$js" == "$expected" ]] || {
+    echo >&2 -e "expected ls-files to return $expected, was\n$js"
+    exit 1
+}
+
+git sparse-checkout disable


### PR DESCRIPTION
As reported in #233

Fixes #233 

---

### Changes are visible to end-users: yes

Without this change, users would have seen errors, so this is indeed something visible to users as a bug fix.

<!-- If no, please delete this section. -->

- Suggested release notes appear below: yes

### Test plan

I only tested this locally.

<!-- Delete any which do not apply -->

- Automated tests
- Manual testing; please provide instructions so we can reproduce:

```starlark
format_multirun(
    name = "format",
    yaml = "@multitool//tools/yamlfmt",
    ... # everything else as False
)
```

Create a git repo with two folders: `foo`, `bar`, each with an yaml file `foo.yaml` and `bar.yaml`.

```shell
$ git sparse-checkout init
$ git sparse-checkout add foo
$ bazel run //path/to/the/format:target
```

Yaml formatter would complain file not found or similar without this fix.