### PR TITLE
Use explicit labels to allow using from other repositories

### DIFF
--- a/format/defs.bzl
+++ b/format/defs.bzl
@@ -89,7 +89,7 @@ def format_multirun(name, jobs = 4, print_command = False, **kwargs):
     for lang, toolname, tool_label, target_name in _tools_loop(name, kwargs):
         for mode in ["check", "fix"]:
             command(
-                command = "@aspect_rules_lint//format/private:format",
+                command = Label("@aspect_rules_lint//format/private:format"),
                 description = "Formatting {} with {}...".format(lang, toolname),
                 **_format_attr_factory(target_name, lang, toolname, tool_label, mode)
             )
@@ -154,8 +154,8 @@ def format_test(name, srcs = None, workspace = None, no_sandbox = False, tags = 
             attrs["env"]["WORKSPACE"] = "$(location {})".format(workspace)
 
         native.sh_test(
-            srcs = ["@aspect_rules_lint//format/private:format.sh"],
-            deps = ["@bazel_tools//tools/bash/runfiles"],
+            srcs = [Label("@aspect_rules_lint//format/private:format.sh")],
+            deps = [Label("@bazel_tools//tools/bash/runfiles")],
             tags = unique(tags + (["no-sandbox", "no-cache", "external"] if workspace else [])),
             **attrs
         )


### PR DESCRIPTION
I use rules_lint via a macro in my own company rules--this allows it to work that way via bzlmod.

---

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Create a macro containing `format_multirun` and `format_test` in one repository/module, and call that macro from the root module.