### PR TITLE
feat: eslint and ruff should operate in quiet mode

### DIFF
--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -104,6 +104,7 @@ def eslint_action(ctx, executable, srcs, report, exit_code = None):
     # TODO: enable if debug config, similar to rules_ts
     # args.add("--debug")
 
+    args.add("--quiet")
     args.add_all(["--format", "../../../" + ctx.file._formatter.path])
     args.add_all([s.short_path for s in srcs])
 

--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -91,6 +91,7 @@ def ruff_fix(ctx, executable, srcs, config, patch, stdout, exit_code):
             "args": ["check", "--fix"] + [s.path for s in srcs],
             "files_to_diff": [s.path for s in srcs],
             "output": patch.path,
+            "quiet": True,
         }),
     )
 
@@ -98,7 +99,7 @@ def ruff_fix(ctx, executable, srcs, config, patch, stdout, exit_code):
         inputs = srcs + config + [patch_cfg],
         outputs = [patch, exit_code, stdout],
         executable = executable._patcher,
-        arguments = [patch_cfg.path],
+        arguments = ["--quiet", patch_cfg.path],
         env = {
             "BAZEL_BINDIR": ".",
             "JS_BINARY__EXIT_CODE_OUTPUT_FILE": exit_code.path,


### PR DESCRIPTION
If `eslint` and `ruff` are not operating in quiet mode, they spit out success messages when all the linter rules pass. For a project with a many linter targets, this is superfluous and annoying.

---

### Changes are visible to end-users: yes

- Users will no longer see stdout output from `eslint` or `ruff` when targets that pass lint

### Test plan

Running `bazel lint` in `examples` shows the behavior.