### PR TITLE
feat: format.sh has same behavior with arguments

### DIFF
--- a/docs/format.md
+++ b/docs/format.md
@@ -76,7 +76,7 @@ Note that `javascript` is a special case which also formats TypeScript, TSX, JSO
 ## format_test
 
 <pre>
-format_test(<a href="#format_test-name">name</a>, <a href="#format_test-srcs">srcs</a>, <a href="#format_test-workspace">workspace</a>, <a href="#format_test-no_sandbox">no_sandbox</a>, <a href="#format_test-tags">tags</a>, <a href="#format_test-kwargs">kwargs</a>)
+format_test(<a href="#format_test-name">name</a>, <a href="#format_test-srcs">srcs</a>, <a href="#format_test-workspace">workspace</a>, <a href="#format_test-no_sandbox">no_sandbox</a>, <a href="#format_test-disable_git_attribute_checks">disable_git_attribute_checks</a>, <a href="#format_test-tags">tags</a>, <a href="#format_test-kwargs">kwargs</a>)
 </pre>
 
 Create test for the given formatters.
@@ -94,6 +94,7 @@ To format with `bazel run`, see [format_multirun](#format_multirun).
 | <a id="format_test-srcs"></a>srcs |  list of files to verify formatting. Required when no_sandbox is False.   |  <code>None</code> |
 | <a id="format_test-workspace"></a>workspace |  a file in the root directory to verify formatting. Required when no_sandbox is True. Typically <code>//:WORKSPACE</code> or <code>//:MODULE.bazel</code> may be used.   |  <code>None</code> |
 | <a id="format_test-no_sandbox"></a>no_sandbox |  Set to True to enable formatting all files in the workspace. This mode causes the test to be non-hermetic and it cannot be cached. Read the documentation in /docs/formatting.md.   |  <code>False</code> |
+| <a id="format_test-disable_git_attribute_checks"></a>disable_git_attribute_checks |  Set to True to disable honoring .gitattributes filters   |  <code>False</code> |
 | <a id="format_test-tags"></a>tags |  tags to apply to generated targets. In 'no_sandbox' mode, <code>["no-sandbox", "no-cache", "external"]</code> are added to the tags.   |  <code>[]</code> |
 | <a id="format_test-kwargs"></a>kwargs |  attributes named for each language, providing Label of a tool that formats it   |  none |
 

--- a/format/defs.bzl
+++ b/format/defs.bzl
@@ -114,7 +114,7 @@ def format_multirun(name, jobs = 4, print_command = False, **kwargs):
         **common_attrs
     )
 
-def format_test(name, srcs = None, workspace = None, no_sandbox = False, tags = [], **kwargs):
+def format_test(name, srcs = None, workspace = None, no_sandbox = False, disable_git_attribute_checks = False, tags = [], **kwargs):
     """Create test for the given formatters.
 
     Intended to be used with `bazel test` to verify files are formatted.
@@ -127,6 +127,7 @@ def format_test(name, srcs = None, workspace = None, no_sandbox = False, tags = 
             Typically `//:WORKSPACE` or `//:MODULE.bazel` may be used.
         no_sandbox: Set to True to enable formatting all files in the workspace.
             This mode causes the test to be non-hermetic and it cannot be cached. Read the documentation in /docs/formatting.md.
+        disable_git_attribute_checks: Set to True to disable honoring .gitattributes filters
         tags: tags to apply to generated targets. In 'no_sandbox' mode, `["no-sandbox", "no-cache", "external"]` are added to the tags.
         **kwargs: attributes named for each language, providing Label of a tool that formats it
     """
@@ -152,6 +153,9 @@ def format_test(name, srcs = None, workspace = None, no_sandbox = False, tags = 
         else:
             attrs["data"] = [tool_label, workspace]
             attrs["env"]["WORKSPACE"] = "$(location {})".format(workspace)
+
+        if disable_git_attribute_checks:
+            attrs["args"].push("--disable_git_attribute_checks")
 
         native.sh_test(
             srcs = [Label("@aspect_rules_lint//format/private:format.sh")],

--- a/format/test/ls-files_test.sh
+++ b/format/test/ls-files_test.sh
@@ -45,6 +45,16 @@ js=$(ls-files JavaScript)
     echo >&2 -e "expected ls-files to return src.js, was\n$js"
     exit 1
 }
+js=$(ls-files JavaScript src.js gen1.js gen2.js gen3.js)
+[[ "$js" == "src.js" ]] || {
+    echo >&2 -e "expected ls-files to return src.js, was\n$js"
+    exit 1
+}
+js=$(ls-files JavaScript src.js gen1.js gen2.js gen3.js --disable_git_attribute_checks)
+[[ "$js" == "src.js gen1.js gen2.js gen3.js" ]] || {
+    echo >&2 -e "expected ls-files to return src.js gen1.js gen2.js gen3.js, was\n$js"
+    exit 1
+}
 
 # deleted files should be ignored
 git rm src.css


### PR DESCRIPTION
Previously, format.sh only took git attributes
into account if it was passed no arguments.

For both code paths if the last argument passed is `--disable_git_attribute_checks` filtering based on .gitattributes will be disabled.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: no

### Test plan

- New test cases added

