### PR TITLE
feat: print better command to fix format check fails

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -30,6 +30,7 @@ fi
 
 set -u
 
+FIX_CMD="bazel run ${FIX_TARGET:-} $@"
 function on_exit {
   code=$?
   case "$code" in
@@ -39,7 +40,7 @@ function on_exit {
       ;;
     *)
       echo >&2 "FAILED: A formatter tool exited with code $code"
-      echo >&2 "Try running 'bazel run $FIX_TARGET' to fix this."
+      echo >&2 "Try running '$FIX_CMD' to fix this."
       ;;
   esac
 }


### PR DESCRIPTION
Fixes #230

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

When `format.check` fails, it now prints a command that includes the arguments it was passed.

### Test plan

- Manual testing; please provide instructions so we can reproduce:

```
alexeagle@MacBook-Pro-79 example % bazel run tools/format:format.check src/hello.scss src/hello.rs              
Checking formatting...
[warn] src/hello.scss
[warn] Code style issues found in the above file. Forgot to run Prettier?
FAILED: A formatter tool exited with code 1
Try running 'bazel run //tools/format:format_CSS_with_prettier src/hello.scss src/hello.rs' to fix this.
Formatted Rust in 0m0.029s
Error: bazel exited with exit code: 1

alexeagle@MacBook-Pro-79 example % bazel run //tools/format:format_CSS_with_prettier src/hello.scss src/hello.rs
INFO: Running command line: bazel-bin/tools/format/format_CSS_with_prettier.bash src/hello.scss src/hello.rs
src/hello.scss 21ms
Formatted SCSS in 0m0.279s

alexeagle@MacBook-Pro-79 example % bazel run tools/format:format.check src/hello.scss src/hello.rs              
Checking formatting...
All matched files use Prettier code style!
Formatted SCSS in 0m0.266s
Formatted Rust in 0m0.030s
```