### PR TITLE
chore: bump example to bazel-lib 2.7.5

### DIFF
--- a/example/MODULE.bazel
+++ b/example/MODULE.bazel
@@ -1,7 +1,7 @@
 "Bazel dependencies"
 
 bazel_dep(name = "aspect_rules_lint", version = "0.0.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.5")
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.6")
 bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc0")
 bazel_dep(name = "aspect_rules_ts", version = "3.0.0-rc0")
 bazel_dep(name = "rules_buf", version = "0.2.0")

--- a/example/MODULE.bazel
+++ b/example/MODULE.bazel
@@ -1,7 +1,7 @@
 "Bazel dependencies"
 
 bazel_dep(name = "aspect_rules_lint", version = "0.0.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.3")
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.5")
 bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc0")
 bazel_dep(name = "aspect_rules_ts", version = "3.0.0-rc0")
 bazel_dep(name = "rules_buf", version = "0.2.0")


### PR DESCRIPTION
bazel-lib 2.7.3 has a bad URL in coreutils for darwin x86