### PR TITLE
Make linter aspect provider and helpers public

### DIFF
--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -187,6 +187,15 @@ bzl_library(
 )
 
 bzl_library(
+    name = "lint_aspect",
+    srcs = ["lint_aspect.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lint/private:lint_aspect",
+    ],
+)
+
+bzl_library(
     name = "ktlint",
     srcs = ["ktlint.bzl"],
     visibility = ["//visibility:public"],

--- a/lint/lint_aspect.bzl
+++ b/lint/lint_aspect.bzl
@@ -1,0 +1,12 @@
+"API for linter aspect providers and helper functions"
+
+load(
+    "//lint/private:lint_aspect.bzl",
+    _LintOptionsInfo = "LintOptionsInfo",
+    _patch_and_report_files = "patch_and_report_files",
+    _report_files = "report_files",
+)
+
+LintOptionsInfo = _LintOptionsInfo
+report_files = _report_files
+patch_and_report_files = _patch_and_report_files


### PR DESCRIPTION
We have implemented a couple of linters in our private repository, and it would be nice if we could import the provider and the helpers without patching rules_lint on our end.

---

### Changes are visible to end-users: yes/no

The functions would now be publicly exposed.
