### PR TITLE
Improve shellcheck aspect

### DIFF
--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -43,12 +43,19 @@ def shellcheck_action(ctx, executable, srcs, config, stdout, exit_code = None, o
     args.add_all(srcs)
     outputs = [stdout]
 
+    # Exit early when srcs is empty. This can happen when all srcs are generated files.
     if exit_code:
-        command = "{shellcheck} $@ >{stdout} 2>&1; echo $? >" + exit_code.path
+        if len(srcs) == 0:
+            command = "touch {stdout} && echo 0 >" + exit_code.path
+        else:
+            command = "{shellcheck} $@ >{stdout} 2>&1; echo $? >" + exit_code.path
         outputs.append(exit_code)
     else:
         # Create empty file on success, as Bazel expects one
-        command = "{shellcheck} $@ && touch {stdout}"
+        if len(srcs) == 0:
+            command = "touch {stdout}"
+        else:
+            command = "{shellcheck} $@ && touch {stdout}"
 
     ctx.actions.run_shell(
         inputs = inputs,

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -44,7 +44,7 @@ def shellcheck_action(ctx, executable, srcs, config, stdout, exit_code = None, o
     outputs = [stdout]
 
     if exit_code:
-        command = "{shellcheck} $@ >{stdout}; echo $? >" + exit_code.path
+        command = "{shellcheck} $@ >{stdout} 2>&1; echo $? >" + exit_code.path
         outputs.append(exit_code)
     else:
         # Create empty file on success, as Bazel expects one


### PR DESCRIPTION
Forward stderr to the report stdout in shellcheck aspect, and exit early when no files provided.

## stderr to report

When calling shellcheck without input files the exitCode is 3, and a message like the following is shown
```
No files specified.

Usage: shellcheck [OPTIONS...] FILES...
  -a                  --check-sourced            Include warnings from sourced files
  -C[WHEN]            --color[=WHEN]             Use color (auto, always, never)
  -i CODE1,CODE2..    --include=CODE1,CODE2..    Consider only given types of warnings
  -e CODE1,CODE2..    --exclude=CODE1,CODE2..    Exclude types of warnings
                      --extended-analysis=bool   Perform dataflow analysis (default true)
  -f FORMAT           --format=FORMAT            Output format (checkstyle, diff, gcc, json, json1, quiet, tty)
                      --list-optional            List checks disabled by default
                      --norc                     Don't look for .shellcheckrc files
                      --rcfile=RCFILE            Prefer the specified configuration file over searching for one
  -o check1,check2..  --enable=check1,check2..   List of optional checks to enable (or 'all')
  -P SOURCEPATHS      --source-path=SOURCEPATHS  Specify path when looking for sourced files ("SCRIPTDIR" for script's dir)
  -s SHELLNAME        --shell=SHELLNAME          Specify dialect (sh, bash, dash, ksh, busybox)
  -S SEVERITY         --severity=SEVERITY        Minimum severity of errors to consider (error, warning, info, style)
  -V                  --version                  Print version information
  -W NUM              --wiki-link-count=NUM      The number of wiki links to show, when applicable
  -x                  --external-sources         Allow 'source' outside of FILES
                      --help                     Show this usage summary and exit
```

When executed through the shellcheck aspect, the output was swallowed, and the reports were empty.

In addition to this, I think we should exit early successfully if no files are provided. This happens when all files in sh_library are generated.

## exit early when no files provided

There is no need to call shellcheck with an empty list of files. When a sh_binary only contains generated files we will hit this, and it should exit successfully. 