### PR TITLE
fix(format): "File name too long" when using --disable_git_attribute_checks

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -127,7 +127,10 @@ function ls-files {
     fi
 
     if [[ $disable_git_attribute_checks == true ]]; then
-      echo $files
+      # files should be returned newline separated to avoid a "File name too long" error
+      for file in $files; do
+        echo "$file"
+      done
       return
     fi
 
@@ -136,7 +139,7 @@ function ls-files {
         for file in $files; do
             # Check if any of the attributes we ignore are set for this file.
             if ! grep -qE "(^| )$file: (rules-lint-ignored|linguist-generated|gitlab-generated): set($| )" <<< $git_attributes; then
-                echo $file
+                echo "$file"
             fi
         done
     fi

--- a/format/test/ls-files_test.sh
+++ b/format/test/ls-files_test.sh
@@ -2,8 +2,7 @@
 
 set -o nounset -o errexit -o pipefail
 
-BUILD_WORKSPACE_DIRECTORY=$TEST_TMPDIR
-source $TEST_SRCDIR/_main/format/private/format.sh
+BUILD_WORKSPACE_DIRECTORY=$TEST_TMPDIR source "$TEST_SRCDIR/_main/format/private/format.sh"
 
 git init --initial-branch=test
 
@@ -51,7 +50,11 @@ js=$(ls-files JavaScript src.js gen1.js gen2.js gen3.js)
     exit 1
 }
 js=$(ls-files JavaScript src.js gen1.js gen2.js gen3.js --disable_git_attribute_checks)
-[[ "$js" == "src.js gen1.js gen2.js gen3.js" ]] || {
+expected='src.js
+gen1.js
+gen2.js
+gen3.js'
+[[ "$js" == "$expected" ]] || {
     echo >&2 -e "expected ls-files to return src.js gen1.js gen2.js gen3.js, was\n$js"
     exit 1
 }


### PR DESCRIPTION
this fixes #261, which is caused by the branch in this code when `disable_git_attribute_checks` is set returning the full list of files rather than echoing them one at a time as the other branch does:

https://github.com/aspect-build/rules_lint/blob/30c5c399b07f0327b9d4ffaf67370d7be7e79285/format/private/format.sh#L129-L142

### Test plan

- incorrect existing test fixed

- Manual testing; please provide instructions so we can reproduce:

I've created <https://github.com/mattnworb/aspect-lint-rc1-repro> to reproduce #261, and the branch <https://github.com/mattnworb/aspect-lint-rc1-repro/tree/fix-disable_git_attribute_checks> tests this patch.

It would be a good idea to add a test case to this repo for this sort of thing, to prevent it from happening in the first place, but I have not yet done this.
