### PR TITLE
feat: add format_multirun() attribute to disable slow gitattribute checks

### DIFF
--- a/docs/format.md
+++ b/docs/format.md
@@ -52,7 +52,7 @@ languages(<a href="#languages-name">name</a>, <a href="#languages-cc">cc</a>, <a
 </pre>
 
 Language attributes that may be passed to [format_multirun](#format_multirun) or [format_test](#format_test).
-    
+
 Files with matching extensions from [GitHub Linguist] will be formatted for the given language.
 
 Some languages have dialects:
@@ -96,7 +96,7 @@ Some languages have dialects:
 ## format_multirun
 
 <pre>
-format_multirun(<a href="#format_multirun-name">name</a>, <a href="#format_multirun-jobs">jobs</a>, <a href="#format_multirun-print_command">print_command</a>, <a href="#format_multirun-kwargs">kwargs</a>)
+format_multirun(<a href="#format_multirun-name">name</a>, <a href="#format_multirun-jobs">jobs</a>, <a href="#format_multirun-print_command">print_command</a>, <a href="#format_multirun-disable_git_attribute_checks">disable_git_attribute_checks</a>, <a href="#format_multirun-kwargs">kwargs</a>)
 </pre>
 
 Create a [multirun] binary for the given languages.
@@ -119,6 +119,7 @@ Not recommended: to check formatting with `bazel test`, use [format_test](#forma
 | <a id="format_multirun-name"></a>name |  name of the resulting target, typically "format"   |  none |
 | <a id="format_multirun-jobs"></a>jobs |  how many language formatters to spawn in parallel, ideally matching how many CPUs are available   |  <code>4</code> |
 | <a id="format_multirun-print_command"></a>print_command |  whether to print a progress message before calling the formatter of each language. Note that a line is printed for a formatter even if no files of that language are to be formatted.   |  <code>False</code> |
+| <a id="format_multirun-disable_git_attribute_checks"></a>disable_git_attribute_checks |  set to True to disable the checking of each file's git attributes to check if it should be excluding from formatting. This check can be slow for large codebases.   |  <code>False</code> |
 | <a id="format_multirun-kwargs"></a>kwargs |  attributes named for each language; see [languages](#languages)   |  none |
 
 

--- a/docs/format.md
+++ b/docs/format.md
@@ -119,7 +119,7 @@ Not recommended: to check formatting with `bazel test`, use [format_test](#forma
 | <a id="format_multirun-name"></a>name |  name of the resulting target, typically "format"   |  none |
 | <a id="format_multirun-jobs"></a>jobs |  how many language formatters to spawn in parallel, ideally matching how many CPUs are available   |  <code>4</code> |
 | <a id="format_multirun-print_command"></a>print_command |  whether to print a progress message before calling the formatter of each language. Note that a line is printed for a formatter even if no files of that language are to be formatted.   |  <code>False</code> |
-| <a id="format_multirun-disable_git_attribute_checks"></a>disable_git_attribute_checks |  set to True to disable the checking of each file's git attributes to check if it should be excluding from formatting. This check can be slow for large codebases.   |  <code>False</code> |
+| <a id="format_multirun-disable_git_attribute_checks"></a>disable_git_attribute_checks |  Set to True to disable honoring .gitattributes filters   |  <code>False</code> |
 | <a id="format_multirun-kwargs"></a>kwargs |  attributes named for each language; see [languages](#languages)   |  none |
 
 

--- a/format/defs.bzl
+++ b/format/defs.bzl
@@ -115,8 +115,7 @@ def format_multirun(name, jobs = 4, print_command = False, disable_git_attribute
         jobs: how many language formatters to spawn in parallel, ideally matching how many CPUs are available
         print_command: whether to print a progress message before calling the formatter of each language.
             Note that a line is printed for a formatter even if no files of that language are to be formatted.
-        disable_git_attribute_checks: set to True to disable the checking of each file's git attributes to check
-            if it should be excluding from formatting. This check can be slow for large codebases.
+        disable_git_attribute_checks: Set to True to disable honoring .gitattributes filters
         **kwargs: attributes named for each language; see [languages](#languages)
     """
     commands = []

--- a/format/defs.bzl
+++ b/format/defs.bzl
@@ -45,10 +45,18 @@ load("@aspect_bazel_lib//lib:utils.bzl", "propagate_common_rule_attributes", "pr
 load("@rules_multirun//:defs.bzl", "command", "multirun")
 load("//format/private:formatter_binary.bzl", "BUILTIN_TOOL_LABELS", "CHECK_FLAGS", "FIX_FLAGS", "TOOLS", "to_attribute_name")
 
-def _format_attr_factory(target_name, lang, toolname, tool_label, mode):
+def _format_attr_factory(target_name, lang, toolname, tool_label, mode, disable_git_attribute_checks):
     if mode not in ["check", "fix", "test"]:
         fail("Invalid mode", mode)
 
+    args = []
+    if disable_git_attribute_checks:
+        args.append("--disable_git_attribute_checks")
+
+    # this dict is used to create the attributes both to pass to command() (for
+    # format_multirun) and to sh_test() (for format_test, so it has to toggle
+    # between different attr names ("env" vs "environment", "args" vs
+    # "arguments")
     return {
         "name": target_name + (".check" if mode in "check" else ""),
         ("env" if mode == "test" else "environment"): {
@@ -61,13 +69,14 @@ def _format_attr_factory(target_name, lang, toolname, tool_label, mode):
             "mode": "check" if mode == "test" else mode,
         },
         "data": [tool_label],
+        ("args" if mode == "test" else "arguments"): args,
     }
 
 languages = rule(
     implementation = lambda ctx: fail("languages rule is documentation-only; do not call it"),
     doc = """\
 Language attributes that may be passed to [format_multirun](#format_multirun) or [format_test](#format_test).
-    
+
 Files with matching extensions from [GitHub Linguist] will be formatted for the given language.
 
 Some languages have dialects:
@@ -89,7 +98,7 @@ Some languages have dialects:
     },
 )
 
-def format_multirun(name, jobs = 4, print_command = False, **kwargs):
+def format_multirun(name, jobs = 4, print_command = False, disable_git_attribute_checks = False, **kwargs):
     """Create a [multirun] binary for the given languages.
 
     Intended to be used with `bazel run` to update source files in-place.
@@ -106,6 +115,8 @@ def format_multirun(name, jobs = 4, print_command = False, **kwargs):
         jobs: how many language formatters to spawn in parallel, ideally matching how many CPUs are available
         print_command: whether to print a progress message before calling the formatter of each language.
             Note that a line is printed for a formatter even if no files of that language are to be formatted.
+        disable_git_attribute_checks: set to True to disable the checking of each file's git attributes to check
+            if it should be excluding from formatting. This check can be slow for large codebases.
         **kwargs: attributes named for each language; see [languages](#languages)
     """
     commands = []
@@ -119,7 +130,7 @@ def format_multirun(name, jobs = 4, print_command = False, **kwargs):
             command(
                 command = Label("@aspect_rules_lint//format/private:format"),
                 description = "Formatting {} with {}...".format(lang, toolname),
-                **_format_attr_factory(target_name, lang, toolname, tool_label, mode)
+                **_format_attr_factory(target_name, lang, toolname, tool_label, mode, disable_git_attribute_checks)
             )
         commands.append(target_name)
 
@@ -176,16 +187,13 @@ def format_test(name, srcs = None, workspace = None, no_sandbox = False, disable
         kwargs.pop(k)
 
     for lang, toolname, tool_label, target_name in _tools_loop(name, kwargs):
-        attrs = _format_attr_factory(target_name, lang, toolname, tool_label, "test")
+        attrs = _format_attr_factory(target_name, lang, toolname, tool_label, "test", disable_git_attribute_checks)
         if srcs:
             attrs["data"] = [tool_label] + srcs
             attrs["args"] = ["$(location {})".format(i) for i in srcs]
         else:
             attrs["data"] = [tool_label, workspace]
             attrs["env"]["WORKSPACE"] = "$(location {})".format(workspace)
-
-        if disable_git_attribute_checks:
-            attrs["args"].push("--disable_git_attribute_checks")
 
         native.sh_test(
             srcs = [Label("@aspect_rules_lint//format/private:format.sh")],

--- a/format/test/BUILD.bazel
+++ b/format/test/BUILD.bazel
@@ -6,7 +6,7 @@ load("//format/private:formatter_binary.bzl", "TOOLS")
 sh_test(
     name = "ls-files_test",
     srcs = ["ls-files_test.sh"],
-    deps = ["//format/private:format"],
+    data = ["//format/private:format"],
 )
 
 UNIQUE_TOOLS = sets.to_list(sets.make(TOOLS.values()))


### PR DESCRIPTION
We recently upgraded a repo containing ~1500 Java source files from `0.21.0` to `v1.0.0-rc1` and noticed that running `format_multirun()` over the whole codebase without any arguments (e.g. `bazel run format`) was significantly slower than before.

For example, we would see execution times like

```
> time bazel run //:format
...
Formatted Python in 0m0.062s
Formatted Starlark in 0m0.087s
Formatted Java in 0m3.535s
Formatted Go in 0m0.039s
Formatted Shell in 0m0.051s
Formatted Protocol Buffer in 0m1.878s
Formatted YAML in 0m0.154s

real    0m22.364s
user    0m41.983s
sys     0m6.982s
```

note that these numbers don't add up - in particular, a large amount of the 22s `real` time was waiting for the Java formatter.
 
Before the upgrade, we'd see Java formatter times like:

```
> time bazel run //:format_Java_with_java-format
...
Formatted Java in 0m3.195s

real    0m6.734s
user    0m25.887s
sys     0m2.578s
```

Investigating a bit more, we traced it down to the addition to `format/private/format.sh` to check the git attributes of each and every file (when the script is run with no arguments / specific source files) to find which files should not be formatted, which was added in #210 and

The git attributes check can be skipped by passing `--disable_git_attribute_checks` as an argument to the format target, but we don't want to have to instruct every engineer working in this repo to set this (or set it always in everyone's pre-commit hook, CI, etc.). Note that this flag is actually broken at the moment for large repos, which is fixed in #262.

This commits adds the ability to always disable these checks by setting an attribute on `format_multirun`, for anyone who does not have any use case to ignore individual files via gitattributes.

Arguably the default behavior should be reversed, since checking the attributes of each file individually does not scale well, or perhaps there are more performant ways to ignore formatting in specific files (such as listing files in an attr on `format_multirun`?).


### Changes are visible to end-users: yes/no

- Suggested release notes appear below: yes

    ```
     added `disable_git_attributes_check` to `format_multirun()` to disable checking the git attributes of each file-to-be-formatted to see if the formatting the file should be skipped, which can be excessively slow with a large number of files
    ```

### Test plan

tested in <https://github.com/mattnworb/aspect-lint-rc1-repro/tree/attribute-for-disable_git_attribute_checks>, any advice on how to add tests here for this?