### PR TITLE
refactor: introduce mnemonic convention for rules_lint linters

### DIFF
--- a/example/lint.sh
+++ b/example/lint.sh
@@ -30,7 +30,7 @@ args=(
 	"--norun_validations"
 	"--build_event_json_file=$buildevents"
 	"--output_groups=rules_lint_report"
-	"--remote_download_regex='.*aspect_rules_lint.*'"
+	"--remote_download_regex='.*AspectRulesLint.*'"
 )
 
 # This is a rudimentary flag parser.

--- a/example/test/lint_test.bats
+++ b/example/test/lint_test.bats
@@ -44,7 +44,7 @@ EOF
 	assert_success
 
 	# Check that we created a 'patch -p1' format file that fixes the ESLint violation
-	run cat bazel-bin/src/ts.aspect_rules_lint.ESLint.patch
+	run cat bazel-bin/src/ts.AspectRulesLintESLint.patch
 	assert_success
 	echo <<"EOF" | assert_output --partial
 --- a/src/file.ts
@@ -57,7 +57,7 @@ EOF
 EOF
 
 	# Check that we created a 'patch -p1' format file that fixes the ruff violation
-	run cat bazel-bin/src/unused_import.aspect_rules_lint.ruff.patch
+	run cat bazel-bin/src/unused_import.AspectRulesLintRuff.patch
 	assert_success
 	echo <<"EOF" | assert_output --partial
 --- a/src/unused_import.py

--- a/lint/README.md
+++ b/lint/README.md
@@ -52,8 +52,8 @@ Add these three things:
    It should call the `my_linter_action` function.
    It must always return a `rules_lint_report` output group, which is easiest by using the
    `report_files` helper in `//lint/private:lint_aspect.bzl`.
-   The simple lint.sh also relies on the report output file being named following the convention
-   `*.aspect_rules_lint.report`, though this is a design smell.
+   The simple lint.sh also relies on the report output filenames containing `AspectRulesLint`, which comes from
+   the convention that `AspectRulesLint` is the prefix for all rules_lint linter action mnemonics.
 
 3. A `my_linter_aspect` factory function. This is a higher-order function that returns an aspect.
    This pattern allows us to capture arguments like labels and toolchains which aren't legal

--- a/lint/buf.bzl
+++ b/lint/buf.bzl
@@ -14,7 +14,7 @@ buf = buf_lint_aspect(
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "report_files")
 
-_MNEMONIC = "buf"
+_MNEMONIC = "AspectRulesLintBuf"
 
 def _short_path(file, _):
     return file.path
@@ -80,6 +80,7 @@ def buf_lint_action(ctx, buf, protoc, target, stderr, exit_code = None):
         ),
         arguments = [args],
         mnemonic = _MNEMONIC,
+        progress_message = "Linting %{label} with Buf",
     )
 
 def _buf_lint_aspect_impl(target, ctx):

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -57,7 +57,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "c
 load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "patch_and_report_files", "report_files")
 
-_MNEMONIC = "ESLint"
+_MNEMONIC = "AspectRulesLintESLint"
 
 def _gather_inputs(ctx, srcs):
     inputs = copy_files_to_bin_actions(ctx, srcs)
@@ -118,6 +118,7 @@ def eslint_action(ctx, executable, srcs, report, exit_code = None):
             command = executable._eslint.path + " $@ && touch " + report.path,
             env = env,
             mnemonic = _MNEMONIC,
+            progress_message = "Linting %{label} with ESLint",
         )
     else:
         # Workaround: create an empty report file in case eslint doesn't write one
@@ -134,6 +135,7 @@ def eslint_action(ctx, executable, srcs, report, exit_code = None):
             arguments = [args],
             env = env,
             mnemonic = _MNEMONIC,
+            progress_message = "Linting %{label} with ESLint",
         )
 
 def eslint_fix(ctx, executable, srcs, patch, stdout, exit_code):
@@ -173,6 +175,7 @@ def eslint_fix(ctx, executable, srcs, patch, stdout, exit_code):
         },
         tools = [executable._eslint],
         mnemonic = _MNEMONIC,
+        progress_message = "Linting %{label} with ESLint",
     )
 
 # buildifier: disable=function-docstring

--- a/lint/flake8.bzl
+++ b/lint/flake8.bzl
@@ -28,7 +28,7 @@ flake8 = lint_flake8_aspect(
 
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "report_files")
 
-_MNEMONIC = "flake8"
+_MNEMONIC = "AspectRulesLintFlake8"
 
 def flake8_action(ctx, executable, srcs, config, stdout, exit_code = None):
     """Run flake8 as an action under Bazel.
@@ -67,6 +67,7 @@ def flake8_action(ctx, executable, srcs, config, stdout, exit_code = None):
         command = command.format(flake8 = executable.path, stdout = stdout.path),
         arguments = [args],
         mnemonic = _MNEMONIC,
+        progress_message = "Linting %{label} with Flake8",
     )
 
 # buildifier: disable=function-docstring

--- a/lint/ktlint.bzl
+++ b/lint/ktlint.bzl
@@ -54,7 +54,7 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "report_files")
 
-_MNEMONIC = "ktlint"
+_MNEMONIC = "AspectRulesLintKTLint"
 
 def ktlint_action(ctx, executable, srcs, editorconfig, stdout, baseline_file, java_runtime, ruleset_jar = None, exit_code = None):
     """ Runs ktlint as build action in Bazel.
@@ -122,6 +122,7 @@ def ktlint_action(ctx, executable, srcs, editorconfig, stdout, baseline_file, ja
         command = command.format(ktlint = executable.path, stdout = stdout.path),
         arguments = [args],
         mnemonic = _MNEMONIC,
+        progress_message = "Linting %{label} with Ktlint",
         env = env,
     )
 

--- a/lint/pmd.bzl
+++ b/lint/pmd.bzl
@@ -30,7 +30,7 @@ pmd = pmd_aspect(
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "report_files")
 
-_MNEMONIC = "PMD"
+_MNEMONIC = "AspectRulesLintPMD"
 
 def pmd_action(ctx, executable, srcs, rulesets, stdout, exit_code = None):
     """Run PMD as an action under Bazel.
@@ -73,6 +73,7 @@ def pmd_action(ctx, executable, srcs, rulesets, stdout, exit_code = None):
         arguments = [args, "--file-list", src_args],
         mnemonic = _MNEMONIC,
         tools = [executable],
+        progress_message = "Linting %{label} with PMD",
     )
 
 # buildifier: disable=function-docstring

--- a/lint/private/lint_aspect.bzl
+++ b/lint/private/lint_aspect.bzl
@@ -25,7 +25,7 @@ lint_options = rule(
     },
 )
 
-_OUTFILE_FORMAT = "{label}.aspect_rules_lint.{mnemonic}.{suffix}"
+_OUTFILE_FORMAT = "{label}.{mnemonic}.{suffix}"
 
 # buildifier: disable=function-docstring
 def report_files(mnemonic, target, ctx):

--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -17,7 +17,7 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "patch_and_report_files", "report_files")
 load(":ruff_versions.bzl", "RUFF_VERSIONS")
 
-_MNEMONIC = "ruff"
+_MNEMONIC = "AspectRulesLintRuff"
 
 def ruff_action(ctx, executable, srcs, config, stdout, exit_code = None):
     """Run ruff as an action under Bazel.
@@ -67,6 +67,7 @@ def ruff_action(ctx, executable, srcs, config, stdout, exit_code = None):
         command = command.format(ruff = executable.path, stdout = stdout.path),
         arguments = [args],
         mnemonic = _MNEMONIC,
+        progress_message = "Linting %{label} with Ruff",
         tools = [executable],
     )
 
@@ -107,6 +108,7 @@ def ruff_fix(ctx, executable, srcs, config, patch, stdout, exit_code):
         },
         tools = [executable._ruff],
         mnemonic = _MNEMONIC,
+        progress_message = "Linting %{label} with Ruff",
     )
 
 # buildifier: disable=function-docstring

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -16,7 +16,8 @@ shellcheck = shellcheck_aspect(
 
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "patch_and_report_files", "report_files")
 
-_MNEMONIC = "shellcheck"
+_MNEMONIC = "AspectRulesLintShellCheck"
+_OUTFILE_FORMAT = "{label}.{mnemonic}.{suffix}"
 
 def shellcheck_action(ctx, executable, srcs, config, stdout, exit_code = None, options = []):
     """Run shellcheck as an action under Bazel.
@@ -59,6 +60,7 @@ def shellcheck_action(ctx, executable, srcs, config, stdout, exit_code = None, o
         ),
         arguments = [args],
         mnemonic = _MNEMONIC,
+        progress_message = "Linting %{label} with ShellCheck",
         tools = [executable],
     )
 
@@ -70,7 +72,7 @@ def _shellcheck_aspect_impl(target, ctx):
     files_to_lint = filter_srcs(ctx.rule)
     if ctx.attr._options[LintOptionsInfo].fix:
         patch, report, exit_code, info = patch_and_report_files(_MNEMONIC, target, ctx)
-        discard_exit_code = ctx.actions.declare_file("{}.{}.aspect_rules_lint.patch_exit_code".format(_MNEMONIC, target.label.name))
+        discard_exit_code = ctx.actions.declare_file(_OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "patch_exit_code"))
         shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, patch, discard_exit_code, ["--format", "diff"])
     else:
         report, exit_code, info = report_files(_MNEMONIC, target, ctx)

--- a/lint/vale.bzl
+++ b/lint/vale.bzl
@@ -68,7 +68,7 @@ load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "report_files")
 load(":vale_library.bzl", "fetch_styles")
 load(":vale_versions.bzl", "VALE_VERSIONS")
 
-_MNEMONIC = "Vale"
+_MNEMONIC = "AspectRulesLintVale"
 
 def vale_action(ctx, executable, srcs, styles, config, stdout, exit_code = None):
     """Run Vale as an action under Bazel.
@@ -116,6 +116,7 @@ def vale_action(ctx, executable, srcs, styles, config, stdout, exit_code = None)
         env = env,
         arguments = [args],
         mnemonic = _MNEMONIC,
+        progress_message = "Linting %{label} with Vale",
         tools = [executable],
     )
 


### PR DESCRIPTION
Standardize the mnemonic for linters in this repository to `AspectRulesLintFoobar` so that we don't collide with other mnemonics and so that downstream tools that post-process generated report, patch and exit_code files can reliably determine the linter type using this convention.