### PR TITLE
chore(example): enable proto toolchain resolution

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v6
     with:
       folders: '[".", "example"]'
-      # Only test with Bazel 6. And we don't try for Windows support yet.
+      # Root module is bzlmod-only, and don't try for Windows support yet.
       exclude: |
         [
           {"bzlmodEnabled": false, "folder": "."},

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,11 +21,14 @@ jobs:
     uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v6
     with:
       folders: '[".", "example"]'
-      # Root module is bzlmod-only, and don't try for Windows support yet.
+      # Root module is bzlmod-only.
+      # Don't try for Windows support yet.
+      # Example uses a bazel7-only flag.
       exclude: |
         [
           {"bzlmodEnabled": false, "folder": "."},
-          {"os": "windows-latest"}
+          {"os": "windows-latest"},
+          {"bazelversion": "6.4.0", "folder": "example"}
         ]
 
   integration-test:

--- a/example/.bazelrc
+++ b/example/.bazelrc
@@ -2,9 +2,5 @@
 # see https://github.com/bazelbuild/rules_jvm_external/issues/445
 build --repo_env=JAVA_HOME=../bazel_tools/jdk
 
-# Let's not use the bzlmod lockfile yet.
-# It has some stability issues and causes a ton of merge conflicts.
-# We also don't have a reproducibility problem that necessitates it.
-common --lockfile_mode=off
+common --incompatible_enable_proto_toolchain_resolution
 common --@aspect_rules_ts//ts:skipLibCheck=always
-startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1

--- a/example/MODULE.bazel
+++ b/example/MODULE.bazel
@@ -7,22 +7,16 @@ bazel_dep(name = "aspect_rules_ts", version = "3.0.0-rc0")
 bazel_dep(name = "rules_buf", version = "0.2.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "toolchains_llvm", version = "0.10.3")
+bazel_dep(name = "toolchains_protoc", version = "0.3.0")
 bazel_dep(name = "rules_java", version = "5.5.0")
 bazel_dep(name = "rules_jvm_external", version = "4.5")
 bazel_dep(name = "rules_go", version = "0.42.0", repo_name = "io_bazel_rules_go")
-bazel_dep(name = "rules_proto", version = "6.0.0-rc2")
+bazel_dep(name = "rules_proto", version = "6.0.0")
 bazel_dep(name = "rules_python", version = "0.26.0")
-bazel_dep(name = "rules_rust", version = "0.42.1")
+bazel_dep(name = "rules_rust", version = "0.45.1")
 bazel_dep(name = "buildifier_prebuilt", version = "6.3.3")
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_kotlin", version = "1.9.0")
-
-# TODO(alex): remove and upgrade to rules_rust 0.44.0 or later
-git_override(
-    module_name = "rules_rust",
-    commit = "4a3ffcb1e89b3f20b12a37b55595682f4bc866b7",
-    remote = "https://github.com/bazelbuild/rules_rust.git",
-)
 
 local_path_override(
     module_name = "aspect_rules_lint",

--- a/example/WORKSPACE.bazel
+++ b/example/WORKSPACE.bazel
@@ -57,6 +57,13 @@ http_archive(
     url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.0/bazel_features-v1.9.0.tar.gz",
 )
 
+http_archive(
+    name = "rules_proto",
+    sha256 = "303e86e722a520f6f326a50b41cfc16b98fe6d1955ce46642a5b7a67c11c0f5d",
+    strip_prefix = "rules_proto-6.0.0",
+    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz",
+)
+
 load("@bazel_features//:deps.bzl", "bazel_features_deps")
 
 bazel_features_deps()
@@ -172,15 +179,18 @@ http_archive(
 )
 
 http_archive(
-    name = "com_google_protobuf",
-    sha256 = "d7d204a59fd0d2d2387bd362c2155289d5060f32122c4d1d922041b61191d522",
-    strip_prefix = "protobuf-3.21.5",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.21.5.tar.gz"],
+    name = "toolchains_protoc",
+    sha256 = "117af61ee2f1b9b014dcac7c9146f374875551abb8a30e51d1b3c5946d25b142",
+    strip_prefix = "toolchains_protoc-0.3.0",
+    url = "https://github.com/aspect-build/toolchains_protoc/releases/download/v0.3.0/toolchains_protoc-v0.3.0.tar.gz",
 )
 
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("@toolchains_protoc//protoc:toolchain.bzl", "protoc_toolchains")
 
-protobuf_deps()
+protoc_toolchains(
+    name = "protoc_toolchains",
+    version = "v25.3",
+)
 
 http_archive(
     name = "rules_buf",
@@ -196,6 +206,17 @@ load("@rules_buf//buf:repositories.bzl", "rules_buf_dependencies", "rules_buf_to
 rules_buf_dependencies()
 
 rules_buf_toolchains(version = "v1.5.0")
+
+RULES_JVM_EXTERNAL_TAG = "5.3"
+
+RULES_JVM_EXTERNAL_SHA = "d31e369b854322ca5098ea12c69d7175ded971435e55c18dd9dd5f29cc5249ac"
+
+http_archive(
+    name = "rules_jvm_external",
+    sha256 = RULES_JVM_EXTERNAL_SHA,
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+    url = "https://github.com/bazelbuild/rules_jvm_external/releases/download/%s/rules_jvm_external-%s.tar.gz" % (RULES_JVM_EXTERNAL_TAG, RULES_JVM_EXTERNAL_TAG),
+)
 
 load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
 


### PR DESCRIPTION
Avoids compiling protoc from source in the example. Also cleanup other BCR dependency versions.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
