### PR TITLE
feat: Optimize the git ignore checks

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -135,14 +135,35 @@ function ls-files {
     fi
 
     if [[ $files != "" ]]; then
-        git_attributes=$(git check-attr rules-lint-ignored linguist-generated gitlab-generated -- $files)
-        for file in $files; do
-            # Check if any of the attributes we ignore are set for this file.
-            if ! grep -qE "(^| )$file: (rules-lint-ignored|linguist-generated|gitlab-generated): set($| )" <<< $git_attributes; then
-                echo "$file"
-            fi
-        done
-    fi
+      git_attributes=$(git check-attr rules-lint-ignored linguist-generated gitlab-generated --stdin <<<"$files")
+
+      # Iterate over each line of the output, files will be reported multiple times, once per attribute checked. To keep from formatting a file twice, we keep track of when the file has changed.
+      last_file=""
+      attribute_set=false
+      while IFS= read -r line; do
+          # Extract the file name and attribute values
+          file=$(echo "$line" | cut -d ':' -f 1)
+
+          if [[ "$file" != "$last_file" ]]; then
+              # If no attribute is set for the previous file, add it to the output
+              if [[ "$attribute_set" == false && "$last_file" != "" ]]; then
+                  echo "$last_file"
+              fi
+              last_file="$file"
+              attribute_set=false
+          fi
+
+          # Check if the attribute is set
+          if [[ "$line" == *"set" ]]; then
+              attribute_set=true
+          fi
+      done <<< "$git_attributes"
+
+      # Handle the last file
+      if [[ "$attribute_set" == false && "$last_file" != "" ]]; then
+          echo "$last_file"
+      fi
+  fi
 }
 
 function time-run {

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -142,7 +142,7 @@ function ls-files {
       attribute_set=false
       while IFS= read -r line; do
           # Extract the file name and attribute values
-          file=$(echo "$line" | cut -d ':' -f 1)
+          file="${line%%:*}"
 
           if [[ "$file" != "$last_file" ]]; then
               # If no attribute is set for the previous file, add it to the output

--- a/format/test/ls-files_test.sh
+++ b/format/test/ls-files_test.sh
@@ -36,6 +36,7 @@ kt=$(ls-files Kotlin)
 # .gitattributes should allow more excludes
 cat >.gitattributes <<EOF
 gen1.js rules-lint-ignored
+gen2.js rules-lint-ignored
 gen2.js gitlab-generated
 gen3.js linguist-generated
 EOF
@@ -45,6 +46,11 @@ js=$(ls-files JavaScript)
     exit 1
 }
 js=$(ls-files JavaScript src.js gen1.js gen2.js gen3.js)
+[[ "$js" == "src.js" ]] || {
+    echo >&2 -e "expected ls-files to return src.js, was\n$js"
+    exit 1
+}
+js=$(ls-files JavaScript  gen1.js gen2.js gen3.js src.js)
 [[ "$js" == "src.js" ]] || {
     echo >&2 -e "expected ls-files to return src.js, was\n$js"
     exit 1


### PR DESCRIPTION
Now rather than calling grep N times where N is
the number of files to be formatted, we call grep
0 times and simply iterate through the array of
lines outputted by git check-attr

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases

Git attribute based ignoring files performance increase!