### PR TITLE
Only run aspect actions when input files provided

### DIFF
--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -29,7 +29,7 @@ ktlint = ktlint_aspect(
 )
 ```
 
-If you plan on using Ktlint [custom rulesets](https://pinterest.github.io/ktlint/1.2.1/install/cli/#rule-sets), you can also declare 
+If you plan on using Ktlint [custom rulesets](https://pinterest.github.io/ktlint/1.2.1/install/cli/#rule-sets), you can also declare
 an additional `ruleset_jar` attribute pointing to your custom ruleset jar like this
 
 ```

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -55,7 +55,7 @@ See the [react example](https://github.com/bazelbuild/examples/blob/b498bb106b20
 
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "copy_files_to_bin_actions")
 load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
-load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "patch_and_report_files", "report_files")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "dummy_successful_lint_action", "filter_srcs", "patch_and_report_files", "report_files")
 
 _MNEMONIC = "AspectRulesLintESLint"
 
@@ -184,15 +184,19 @@ def _eslint_aspect_impl(target, ctx):
         return []
 
     files_to_lint = filter_srcs(ctx.rule)
-    if len(files_to_lint) == 0:
-        return []
 
     if ctx.attr._options[LintOptionsInfo].fix:
         patch, report, exit_code, info = patch_and_report_files(_MNEMONIC, target, ctx)
-        eslint_fix(ctx, ctx.executable, files_to_lint, patch, report, exit_code)
+        if len(files_to_lint) == 0:
+            dummy_successful_lint_action(ctx, report, exit_code, patch)
+        else:
+            eslint_fix(ctx, ctx.executable, files_to_lint, patch, report, exit_code)
     else:
         report, exit_code, info = report_files(_MNEMONIC, target, ctx)
-        eslint_action(ctx, ctx.executable, files_to_lint, report, exit_code)
+        if len(files_to_lint) == 0:
+            dummy_successful_lint_action(ctx, report, exit_code)
+        else:
+            eslint_action(ctx, ctx.executable, files_to_lint, report, exit_code)
 
     return [info]
 

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -184,6 +184,9 @@ def _eslint_aspect_impl(target, ctx):
         return []
 
     files_to_lint = filter_srcs(ctx.rule)
+    if len(files_to_lint) == 0:
+        return []
+
     if ctx.attr._options[LintOptionsInfo].fix:
         patch, report, exit_code, info = patch_and_report_files(_MNEMONIC, target, ctx)
         eslint_fix(ctx, ctx.executable, files_to_lint, patch, report, exit_code)

--- a/lint/flake8.bzl
+++ b/lint/flake8.bzl
@@ -26,7 +26,7 @@ flake8 = lint_flake8_aspect(
 ```
 """
 
-load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "report_files")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "dummy_successful_lint_action", "filter_srcs", "report_files")
 
 _MNEMONIC = "AspectRulesLintFlake8"
 
@@ -75,12 +75,14 @@ def _flake8_aspect_impl(target, ctx):
     if ctx.rule.kind not in ["py_binary", "py_library"]:
         return []
 
-    files_to_lint = filter_srcs(ctx.rule)
-    if len(files_to_lint) == 0:
-        return []
-
     report, exit_code, info = report_files(_MNEMONIC, target, ctx)
-    flake8_action(ctx, ctx.executable._flake8, files_to_lint, ctx.file._config_file, report, exit_code)
+
+    files_to_lint = filter_srcs(ctx.rule)
+
+    if len(files_to_lint) == 0:
+        dummy_successful_lint_action(ctx, report, exit_code)
+    else:
+        flake8_action(ctx, ctx.executable._flake8, files_to_lint, ctx.file._config_file, report, exit_code)
     return [info]
 
 def lint_flake8_aspect(binary, config):

--- a/lint/flake8.bzl
+++ b/lint/flake8.bzl
@@ -75,8 +75,12 @@ def _flake8_aspect_impl(target, ctx):
     if ctx.rule.kind not in ["py_binary", "py_library"]:
         return []
 
+    files_to_lint = filter_srcs(ctx.rule)
+    if len(files_to_lint) == 0:
+        return []
+
     report, exit_code, info = report_files(_MNEMONIC, target, ctx)
-    flake8_action(ctx, ctx.executable._flake8, filter_srcs(ctx.rule), ctx.file._config_file, report, exit_code)
+    flake8_action(ctx, ctx.executable._flake8, files_to_lint, ctx.file._config_file, report, exit_code)
     return [info]
 
 def lint_flake8_aspect(binary, config):

--- a/lint/ktlint.bzl
+++ b/lint/ktlint.bzl
@@ -27,7 +27,7 @@ ktlint = ktlint_aspect(
 )
 ```
 
-If you plan on using Ktlint [custom rulesets](https://pinterest.github.io/ktlint/1.2.1/install/cli/#rule-sets), you can also declare 
+If you plan on using Ktlint [custom rulesets](https://pinterest.github.io/ktlint/1.2.1/install/cli/#rule-sets), you can also declare
 an additional `ruleset_jar` attribute pointing to your custom ruleset jar like this
 
 ```
@@ -135,7 +135,11 @@ def _ktlint_aspect_impl(target, ctx):
     if hasattr(ctx.attr, "_ruleset_jar"):
         ruleset_jar = ctx.file._ruleset_jar
 
-    ktlint_action(ctx, ctx.executable._ktlint, filter_srcs(ctx.rule), ctx.file._editorconfig, report, ctx.file._baseline_file, ctx.attr._java_runtime, ruleset_jar, exit_code)
+    files_to_lint = filter_srcs(ctx.rule)
+    if len(files_to_lint) == 0:
+        return []
+
+    ktlint_action(ctx, ctx.executable._ktlint, files_to_lint, ctx.file._editorconfig, report, ctx.file._baseline_file, ctx.attr._java_runtime, ruleset_jar, exit_code)
     return [info]
 
 def lint_ktlint_aspect(binary, editorconfig, baseline_file, ruleset_jar = None):

--- a/lint/ktlint.bzl
+++ b/lint/ktlint.bzl
@@ -52,7 +52,7 @@ If your custom ruleset is a third-party dependency and not a first-party depende
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
-load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "report_files")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "dummy_successful_lint_action", "filter_srcs", "report_files")
 
 _MNEMONIC = "AspectRulesLintKTLint"
 
@@ -136,10 +136,11 @@ def _ktlint_aspect_impl(target, ctx):
         ruleset_jar = ctx.file._ruleset_jar
 
     files_to_lint = filter_srcs(ctx.rule)
-    if len(files_to_lint) == 0:
-        return []
 
-    ktlint_action(ctx, ctx.executable._ktlint, files_to_lint, ctx.file._editorconfig, report, ctx.file._baseline_file, ctx.attr._java_runtime, ruleset_jar, exit_code)
+    if len(files_to_lint) == 0:
+        dummy_successful_lint_action(ctx, report, exit_code)
+    else:
+        ktlint_action(ctx, ctx.executable._ktlint, files_to_lint, ctx.file._editorconfig, report, ctx.file._baseline_file, ctx.attr._java_runtime, ruleset_jar, exit_code)
     return [info]
 
 def lint_ktlint_aspect(binary, editorconfig, baseline_file, ruleset_jar = None):

--- a/lint/pmd.bzl
+++ b/lint/pmd.bzl
@@ -28,7 +28,7 @@ pmd = pmd_aspect(
 """
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "report_files")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "dummy_successful_lint_action", "filter_srcs", "report_files")
 
 _MNEMONIC = "AspectRulesLintPMD"
 
@@ -82,11 +82,12 @@ def _pmd_aspect_impl(target, ctx):
         return []
 
     files_to_lint = filter_srcs(ctx.rule)
-    if len(files_to_lint) == 0:
-        return []
 
     report, exit_code, info = report_files(_MNEMONIC, target, ctx)
-    pmd_action(ctx, ctx.executable._pmd, files_to_lint, ctx.files._rulesets, report, exit_code)
+    if len(files_to_lint) == 0:
+        dummy_successful_lint_action(ctx, report, exit_code)
+    else:
+        pmd_action(ctx, ctx.executable._pmd, files_to_lint, ctx.files._rulesets, report, exit_code)
     return [info]
 
 def lint_pmd_aspect(binary, rulesets):

--- a/lint/pmd.bzl
+++ b/lint/pmd.bzl
@@ -81,8 +81,12 @@ def _pmd_aspect_impl(target, ctx):
     if ctx.rule.kind not in ["java_binary", "java_library"]:
         return []
 
+    files_to_lint = filter_srcs(ctx.rule)
+    if len(files_to_lint) == 0:
+        return []
+
     report, exit_code, info = report_files(_MNEMONIC, target, ctx)
-    pmd_action(ctx, ctx.executable._pmd, filter_srcs(ctx.rule), ctx.files._rulesets, report, exit_code)
+    pmd_action(ctx, ctx.executable._pmd, files_to_lint, ctx.files._rulesets, report, exit_code)
     return [info]
 
 def lint_pmd_aspect(binary, rulesets):

--- a/lint/private/lint_aspect.bzl
+++ b/lint/private/lint_aspect.bzl
@@ -61,3 +61,33 @@ def filter_srcs(rule):
         return rule.files.srcs
     else:
         return [s for s in rule.files.srcs if s.is_source]
+
+def dummy_successful_lint_action(ctx, stdout, exit_code = None, patch = None):
+    """Dummy action for creating expected outputs when no files are provided to a lint action.
+
+    Args:
+        ctx: Bazel Rule or Aspect evaluation context
+        stdout: output file that will be empty
+        exit_code: output file containing 0 exit code.
+            If None, continue successfully
+        patch: output file for the patch
+            If None, continue successfully
+    """
+    inputs = []
+    outputs = [stdout]
+
+    command = "touch {stdout}".format(stdout = stdout.path)
+
+    if exit_code:
+        command += " && echo 0 > {exit_code}".format(exit_code = exit_code.path)
+        outputs.append(exit_code)
+
+    if patch:
+        command += " && touch {patch}".format(patch = patch.path)
+        outputs.append(patch)
+
+    ctx.actions.run_shell(
+        inputs = inputs,
+        outputs = outputs,
+        command = command,
+    )

--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -117,6 +117,9 @@ def _ruff_aspect_impl(target, ctx):
         return []
 
     files_to_lint = filter_srcs(ctx.rule)
+    if len(files_to_lint) == 0:
+        return []
+
     if ctx.attr._options[LintOptionsInfo].fix:
         patch, report, exit_code, info = patch_and_report_files(_MNEMONIC, target, ctx)
         ruff_fix(ctx, ctx.executable, files_to_lint, ctx.files._config_files, patch, report, exit_code)

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -70,6 +70,9 @@ def _shellcheck_aspect_impl(target, ctx):
         return []
 
     files_to_lint = filter_srcs(ctx.rule)
+    if len(files_to_lint) == 0:
+        return []
+
     if ctx.attr._options[LintOptionsInfo].fix:
         patch, report, exit_code, info = patch_and_report_files(_MNEMONIC, target, ctx)
         discard_exit_code = ctx.actions.declare_file(_OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "patch_exit_code"))

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -14,7 +14,7 @@ shellcheck = shellcheck_aspect(
 ```
 """
 
-load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "patch_and_report_files", "report_files")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "dummy_successful_lint_action", "filter_srcs", "patch_and_report_files", "report_files")
 
 _MNEMONIC = "AspectRulesLintShellCheck"
 _OUTFILE_FORMAT = "{label}.{mnemonic}.{suffix}"
@@ -70,19 +70,23 @@ def _shellcheck_aspect_impl(target, ctx):
         return []
 
     files_to_lint = filter_srcs(ctx.rule)
-    if len(files_to_lint) == 0:
-        return []
 
     if ctx.attr._options[LintOptionsInfo].fix:
         patch, report, exit_code, info = patch_and_report_files(_MNEMONIC, target, ctx)
         discard_exit_code = ctx.actions.declare_file(_OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "patch_exit_code"))
-        shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, patch, discard_exit_code, ["--format", "diff"])
+        if len(files_to_lint) == 0:
+            dummy_successful_lint_action(ctx, patch, discard_exit_code)
+        else:
+            shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, patch, discard_exit_code, ["--format", "diff"])
     else:
         report, exit_code, info = report_files(_MNEMONIC, target, ctx)
 
-    # shellcheck does not have a --fix mode that applies fixes for some violations while reporting others.
-    # So we must run a second action to populate the human-readable report.
-    shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, report, exit_code)
+    if len(files_to_lint) == 0:
+        dummy_successful_lint_action(ctx, report, exit_code)
+    else:
+        # shellcheck does not have a --fix mode that applies fixes for some violations while reporting others.
+        # So we must run a second action to populate the human-readable report.
+        shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, report, exit_code)
     return [info]
 
 def lint_shellcheck_aspect(binary, config):


### PR DESCRIPTION
Many tools fail if we don't provide any input files. Skipping the actions seems like the cleanest solution.

The other alternative is to always generate an empty report and a status code file with 0, but that seems unnecessary. On the other hand, it would make the tests cleaner. 

@alexeagle what do you think?

---

### Changes are visible to end-users: yes


- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Test plan

I am planning to update the tests in lint_tests, but I wanna make sure this is the right approach first.


