### PR TITLE
Correct docstring for eslint (#275)

### DIFF
--- a/docs/eslint.md
+++ b/docs/eslint.md
@@ -16,9 +16,9 @@ eslint_bin.eslint_binary(name = "eslint")
 Finally, create the linter aspect, typically in `tools/lint/linters.bzl`:
 
 ```starlark
-load("@aspect_rules_lint//lint:eslint.bzl", "eslint_aspect")
+load("@aspect_rules_lint//lint:eslint.bzl", "lint_eslint_aspect")
 
-eslint = eslint_aspect(
+eslint = lint_eslint_aspect(
     binary = "@@//tools/lint:eslint",
     # We trust that eslint will locate the correct configuration file for a given source file.
     # See https://eslint.org/docs/latest/use/configure/configuration-files#cascading-and-hierarchy

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -14,9 +14,9 @@ eslint_bin.eslint_binary(name = "eslint")
 Finally, create the linter aspect, typically in `tools/lint/linters.bzl`:
 
 ```starlark
-load("@aspect_rules_lint//lint:eslint.bzl", "eslint_aspect")
+load("@aspect_rules_lint//lint:eslint.bzl", "lint_eslint_aspect")
 
-eslint = eslint_aspect(
+eslint = lint_eslint_aspect(
     binary = "@@//tools/lint:eslint",
     # We trust that eslint will locate the correct configuration file for a given source file.
     # See https://eslint.org/docs/latest/use/configure/configuration-files#cascading-and-hierarchy


### PR DESCRIPTION
<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

Addresses small miss in the documentation. (#275)

Updates to the docstring will assist in setup tasks for new users of `rules_lint`.

---

### Changes are visible to end-users: yes


- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan


- Covered by existing test cases
