### PR TITLE
feat: Add Cuda format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ New tools are being added frequently, so check this page again!
 | Language               | Formatter             | Linter(s)        |
 | ---------------------- | --------------------- | ---------------- |
 | C / C++                | [clang-format]        | ([#112])         |
+| Cuda                   | [clang-format]        |                  |
 | CSS, Less, Sass        | [Prettier]            |                  |
 | Go                     | [gofmt] or [gofumpt]  |                  |
 | HCL (Hashicorp Config) | [terraform] fmt       |                  |

--- a/docs/format.md
+++ b/docs/format.md
@@ -47,8 +47,8 @@ format_multirun(
 ## languages
 
 <pre>
-languages(<a href="#languages-name">name</a>, <a href="#languages-cc">cc</a>, <a href="#languages-css">css</a>, <a href="#languages-go">go</a>, <a href="#languages-html">html</a>, <a href="#languages-java">java</a>, <a href="#languages-javascript">javascript</a>, <a href="#languages-jsonnet">jsonnet</a>, <a href="#languages-kotlin">kotlin</a>, <a href="#languages-markdown">markdown</a>, <a href="#languages-protocol_buffer">protocol_buffer</a>,
-          <a href="#languages-python">python</a>, <a href="#languages-rust">rust</a>, <a href="#languages-scala">scala</a>, <a href="#languages-shell">shell</a>, <a href="#languages-sql">sql</a>, <a href="#languages-starlark">starlark</a>, <a href="#languages-swift">swift</a>, <a href="#languages-terraform">terraform</a>, <a href="#languages-yaml">yaml</a>)
+languages(<a href="#languages-name">name</a>, <a href="#languages-cc">cc</a>, <a href="#languages-css">css</a>, <a href="#languages-cuda">cuda</a>, <a href="#languages-go">go</a>, <a href="#languages-html">html</a>, <a href="#languages-java">java</a>, <a href="#languages-javascript">javascript</a>, <a href="#languages-jsonnet">jsonnet</a>, <a href="#languages-kotlin">kotlin</a>, <a href="#languages-markdown">markdown</a>,
+          <a href="#languages-protocol_buffer">protocol_buffer</a>, <a href="#languages-python">python</a>, <a href="#languages-rust">rust</a>, <a href="#languages-scala">scala</a>, <a href="#languages-shell">shell</a>, <a href="#languages-sql">sql</a>, <a href="#languages-starlark">starlark</a>, <a href="#languages-swift">swift</a>, <a href="#languages-terraform">terraform</a>, <a href="#languages-yaml">yaml</a>)
 </pre>
 
 Language attributes that may be passed to [format_multirun](#format_multirun) or [format_test](#format_test).
@@ -72,6 +72,7 @@ Some languages have dialects:
 | <a id="languages-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="languages-cc"></a>cc |  a <code>clang-format</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="languages-css"></a>css |  a <code>prettier</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="languages-cuda"></a>cuda |  a <code>clang-format</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="languages-go"></a>go |  a <code>gofmt</code> binary, or any other tool that has a matching command-line interface. Use <code>@aspect_rules_lint//format:gofumpt</code> to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="languages-html"></a>html |  a <code>prettier</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="languages-java"></a>java |  a <code>java-format</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |

--- a/example/src/hello.cu
+++ b/example/src/hello.cu
@@ -1,0 +1,3 @@
+#include <stdio.h>
+
+int main() { printf("Hello, world!\n"); }

--- a/example/tools/format/BUILD.bazel
+++ b/example/tools/format/BUILD.bazel
@@ -56,6 +56,7 @@ java_binary(
 format_multirun(
     name = "format",
     cc = "@llvm_toolchain_llvm//:bin/clang-format",
+    cuda = "@llvm_toolchain_llvm//:bin/clang-format",
     css = ":prettier",
     go = "@aspect_rules_lint//format:gofumpt",
     html = ":prettier",

--- a/example/tools/format/BUILD.bazel
+++ b/example/tools/format/BUILD.bazel
@@ -56,8 +56,8 @@ java_binary(
 format_multirun(
     name = "format",
     cc = "@llvm_toolchain_llvm//:bin/clang-format",
-    cuda = "@llvm_toolchain_llvm//:bin/clang-format",
     css = ":prettier",
+    cuda = "@llvm_toolchain_llvm//:bin/clang-format",
     go = "@aspect_rules_lint//format:gofumpt",
     html = ":prettier",
     # You can use standard gofmt instead of stricter gofumpt:

--- a/format/private/filter.jq
+++ b/format/private/filter.jq
@@ -2,6 +2,7 @@
 with_entries(select(.key | IN(
     "C++",
     "CSS",
+    "Cuda",
     "Markdown",
     "Go",
     "HCL",

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -62,6 +62,7 @@ function ls-files {
     # using the ./mirror_linguist_languages.sh tool to transform to Bash code
     case "$language" in
       'C++') patterns=('*.cpp' '*.c++' '*.cc' '*.cp' '*.cppm' '*.cxx' '*.h' '*.h++' '*.hh' '*.hpp' '*.hxx' '*.inc' '*.inl' '*.ino' '*.ipp' '*.ixx' '*.re' '*.tcc' '*.tpp' '*.txx') ;;
+      'Cuda') patterns=('*.cu' '*.cuh') ;;
       'CSS') patterns=('*.css') ;;
       'Go') patterns=('*.go') ;;
       'HTML') patterns=('*.html' '*.hta' '*.htm' '*.html.hl' '*.inc' '*.xht' '*.xhtml') ;;

--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -21,6 +21,7 @@ TOOLS = {
     "Shell": "shfmt",
     "Protocol Buffer": "buf",
     "C++": "clang-format",
+    "Cuda": "clang-format",
     "YAML": "yamlfmt",
     "Rust": "rustfmt",
 }

--- a/format/test/BUILD.bazel
+++ b/format/test/BUILD.bazel
@@ -37,6 +37,7 @@ UNIQUE_TOOLS = sets.to_list(sets.make(TOOLS.values()))
 format_multirun(
     name = "format",
     cc = ":mock_clang-format.sh",
+    cuda = ":mock_clang-format.sh",
     css = ":mock_prettier.sh",
     go = ":mock_gofmt.sh",
     html = ":mock_prettier.sh",

--- a/format/test/BUILD.bazel
+++ b/format/test/BUILD.bazel
@@ -37,8 +37,8 @@ UNIQUE_TOOLS = sets.to_list(sets.make(TOOLS.values()))
 format_multirun(
     name = "format",
     cc = ":mock_clang-format.sh",
-    cuda = ":mock_clang-format.sh",
     css = ":mock_prettier.sh",
+    cuda = ":mock_clang-format.sh",
     go = ":mock_gofmt.sh",
     html = ":mock_prettier.sh",
     java = ":mock_java-format.sh",

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -119,6 +119,13 @@ bats_load_library "bats-assert"
     assert_output --partial "+ clang-format -style=file --fallback-style=none -i example/src/hello.cpp"
 }
 
+@test "should run clang-format on Cuda" {
+    run bazel run //format/test:format_Cuda_with_clang-format
+    assert_success
+
+    assert_output --partial "+ clang-format -style=file --fallback-style=none -i example/src/hello.cu"
+}
+
 @test "should run shfmt on Shell" {
     run bazel run //format/test:format_Shell_with_shfmt
     assert_success


### PR DESCRIPTION

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Adds support for formatting cuda files by passing clang_format target to the cuda attribute of format_multirun.

### Test plan

<!-- Delete any which do not apply -->

- New test cases added
