### PR TITLE
Fix safe_flag parsing in clang_tidy.bzl

### DIFF
--- a/docs/clang-tidy.md
+++ b/docs/clang-tidy.md
@@ -30,9 +30,9 @@ native_binary(
 Finally, create the linter aspect, typically in `tools/lint/linters.bzl`:
 
 ```starlark
-load("@aspect_rules_lint//lint:clang_tidy.bzl", "clang_tidy_aspect")
+load("@aspect_rules_lint//lint:clang_tidy.bzl", "lint_clang_tidy_aspect")
 
-clang_tidy = clang_tidy_aspect(
+clang_tidy = lint_clang_tidy_aspect(
     binary = "@@//path/to:clang-tidy",
     configs = "@@//path/to:.clang-tidy",
 )


### PR DESCRIPTION
Fixes parameter shadowing in the _safe_flags macro.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Pass C++ toolchain and copt flags to clang-tidy.

### Test plan

- Covered by existing test cases

