### PR TITLE
chore: fix ruff mirroring

### DIFF
--- a/docs/ruff.md
+++ b/docs/ruff.md
@@ -19,7 +19,7 @@ ruff = ruff_aspect(
 ## ruff_workaround_20269
 
 <pre>
-ruff_workaround_20269(<a href="#ruff_workaround_20269-name">name</a>, <a href="#ruff_workaround_20269-build_file_content">build_file_content</a>, <a href="#ruff_workaround_20269-repo_mapping">repo_mapping</a>, <a href="#ruff_workaround_20269-sha256">sha256</a>, <a href="#ruff_workaround_20269-url">url</a>)
+ruff_workaround_20269(<a href="#ruff_workaround_20269-name">name</a>, <a href="#ruff_workaround_20269-build_file_content">build_file_content</a>, <a href="#ruff_workaround_20269-repo_mapping">repo_mapping</a>, <a href="#ruff_workaround_20269-sha256">sha256</a>, <a href="#ruff_workaround_20269-strip_prefix">strip_prefix</a>, <a href="#ruff_workaround_20269-url">url</a>)
 </pre>
 
 Workaround for https://github.com/bazelbuild/bazel/issues/20269
@@ -33,6 +33,7 @@ Workaround for https://github.com/bazelbuild/bazel/issues/20269
 | <a id="ruff_workaround_20269-build_file_content"></a>build_file_content |  -   | String | optional | <code>""</code> |
 | <a id="ruff_workaround_20269-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | required |  |
 | <a id="ruff_workaround_20269-sha256"></a>sha256 |  -   | String | optional | <code>""</code> |
+| <a id="ruff_workaround_20269-strip_prefix"></a>strip_prefix |  unlike http_archive, any value causes us to pass --strip-components=1 to tar   | String | optional | <code>""</code> |
 | <a id="ruff_workaround_20269-url"></a>url |  -   | String | optional | <code>""</code> |
 
 

--- a/docs/ruff.md
+++ b/docs/ruff.md
@@ -51,7 +51,7 @@ A repository macro used from WORKSPACE to fetch ruff binaries
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="fetch_ruff-tag"></a>tag |  a tag of ruff that we have mirrored, e.g. <code>v0.1.0</code>   |  <code>"v0.4.10"</code> |
+| <a id="fetch_ruff-tag"></a>tag |  a tag of ruff that we have mirrored, e.g. <code>v0.1.0</code>   |  <code>"0.5.0"</code> |
 
 
 <a id="lint_ruff_aspect"></a>

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -149,6 +149,7 @@ bzl_library(
     deps = _BAZEL_TOOLS + [
         ":ruff_versions",
         "//lint/private:lint_aspect",
+        "@bazel_skylib//lib:versions",
     ],
 )
 

--- a/lint/mirror_ruff.sh
+++ b/lint/mirror_ruff.sh
@@ -14,7 +14,7 @@ JQ_FILTER=\
     "value": .assets
         | map(select((.name | contains("ruff-")) and (.name | contains("sha256") | not) ))
         | map({
-            "key": .name | capture("ruff-[0-9\\.]+-(?<platform>.*)\\.(tar\\.gz|zip)") | .platform,
+            "key": .name | capture("ruff-(?<platform>.*)\\.(tar\\.gz|zip)") | .platform,
             "value": (.browser_download_url + ".sha256"),
         })
         | from_entries

--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -12,6 +12,7 @@ ruff = ruff_aspect(
 ```
 """
 
+load("@bazel_skylib//lib:versions.bzl", "versions")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "dummy_successful_lint_action", "filter_srcs", "patch_and_report_files", "report_files")
@@ -199,7 +200,11 @@ def fetch_ruff(tag = RUFF_VERSIONS.keys()[0]):
     version = tag.lstrip("v")
 
     # ruff changed their release artifact naming starting with v0.1.8, so that's the minimum version we support
-    url = "https://github.com/astral-sh/ruff/releases/download/{tag}/ruff-{version}-{plat}.{ext}"
+    # they changed it again in 0.5.0, removing the version from the filename.
+    if versions.is_at_least("0.5.0", version):
+        url = "https://github.com/astral-sh/ruff/releases/download/{tag}/ruff-{plat}.{ext}"
+    else:
+        url = "https://github.com/astral-sh/ruff/releases/download/{tag}/ruff-{version}-{plat}.{ext}"
 
     for plat, sha256 in RUFF_VERSIONS[tag].items():
         fetch_rule = http_archive

--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -176,7 +176,10 @@ def _ruff_workaround_20269_impl(rctx):
     # To workaround, we fetch the file and then use the BSD tar on the system to extract it.
     # TODO: remove for users on Bazel 8 (or maybe sooner if that fix is cherry-picked)
     rctx.download(sha256 = rctx.attr.sha256, url = rctx.attr.url, output = "ruff.tar.gz")
-    result = rctx.execute([rctx.which("tar"), "xzf", "ruff.tar.gz"])
+    tar_cmd = [rctx.which("tar"), "xzf", "ruff.tar.gz"]
+    if rctx.attr.strip_prefix:
+        tar_cmd.append("--strip-components=1")
+    result = rctx.execute(tar_cmd)
     if result.return_code:
         fail("Couldn't extract ruff: \nSTDOUT:\n{}\nSTDERR:\n{}".format(result.stdout, result.stderr))
     rctx.file("BUILD", rctx.attr.build_file_content)
@@ -187,6 +190,7 @@ ruff_workaround_20269 = repository_rule(
     attrs = {
         "build_file_content": attr.string(),
         "sha256": attr.string(),
+        "strip_prefix": attr.string(doc = "unlike http_archive, any value causes us to pass --strip-components=1 to tar"),
         "url": attr.string(),
     },
 )
@@ -208,7 +212,7 @@ def fetch_ruff(tag = RUFF_VERSIONS.keys()[0]):
 
     for plat, sha256 in RUFF_VERSIONS[tag].items():
         fetch_rule = http_archive
-        if plat.endswith("darwin"):
+        if plat.endswith("darwin") and not versions.is_at_least("7.2.0", versions.get()):
             fetch_rule = ruff_workaround_20269
         is_windows = plat.endswith("windows-msvc")
 
@@ -221,6 +225,7 @@ def fetch_ruff(tag = RUFF_VERSIONS.keys()[0]):
                 version = version,
                 ext = "zip" if is_windows else "tar.gz",
             ),
+            strip_prefix = "ruff-" + plat if versions.is_at_least("0.5.0", version) else None,
             sha256 = sha256,
             build_file_content = """exports_files(["ruff", "ruff.exe"])""",
         )

--- a/lint/ruff_versions.bzl
+++ b/lint/ruff_versions.bzl
@@ -1,5 +1,24 @@
 "This file is automatically updated by mirror_ruff.sh"
 RUFF_VERSIONS = {
+    "0.5.0": {
+        "aarch64-apple-darwin": "a9203ee067703ef9589cae0d78e3def76e855650d721f77057a3b60638302b36",
+        "aarch64-pc-windows-msvc": "bb1fc1540ac591b0f0405c472291a98697ccbd4c31f7d2af371943008a890ec4",
+        "aarch64-unknown-linux-gnu": "6348b52aa618cb24bebab733da923ac4289cd04bbf32e6557b3b0f75ecf2e885",
+        "aarch64-unknown-linux-musl": "bc47a3ecff865b38385774fd6191347ecebc201b3a5c0fb56b6e75bc67757ff0",
+        "arm-unknown-linux-musleabihf": "c1490b68ead60c44c870fb944e2099e7f01446b3327fb8b16e5ae079b83b3029",
+        "armv7-unknown-linux-gnueabihf": "741ea90fa58471c84be92e75d97e13510722adabfc5160838f228fca444b0b97",
+        "armv7-unknown-linux-musleabihf": "d39bda906724f0c9b9c07055a37b0fbf156a637a2b42967578c8f6c7e655d460",
+        "i686-pc-windows-msvc": "757430f6bac31b8d4ec08a6ca600cd4afb0dda0a2e78cb48054380895e70b8de",
+        "i686-unknown-linux-gnu": "57863fad533914bb0a90e3ea29d861d5665c8b44cb5e97c79713b1139b1f7d7b",
+        "i686-unknown-linux-musl": "bb28233b18db28b4e65c387c3a4ba195c44425154f8d1f900b1599005531be3a",
+        "powerpc64-unknown-linux-gnu": "97d19ada60f37763437c41d8bd3b47a1d560841634abecd435438b89bce978a6",
+        "powerpc64le-unknown-linux-gnu": "b9c0d1465a494db8babcafe1a4f31046d3af26b83ded6693d7c60fd0bc6ae806",
+        "s390x-unknown-linux-gnu": "552efa4f0577622fb377f54c8dfd49adf9be316f59c199b60cda38ea2725ef89",
+        "x86_64-apple-darwin": "283a2d23af7d3b05173e34aade53c4d04694e44ca240b61e5b95c887a379eaf1",
+        "x86_64-pc-windows-msvc": "3c5305938a44803ea5b2aafe896c1edbbd721d648a768dbd061bc66a18caee98",
+        "x86_64-unknown-linux-gnu": "f8a054683586cb3edc3ba072d4916d7c3962910b0d46bc6d4e70b4894d70f6cc",
+        "x86_64-unknown-linux-musl": "32f4dce258b73f350dd4aab46e7ab54ff74ffb31f3ab2c46e7168f2afd624c78",
+    },
     "v0.4.10": {
         "aarch64-apple-darwin": "5a4ff81270eee1efa7901566719aca705a3e8d0f1abead96c01caa4678a7762e",
         "aarch64-pc-windows-msvc": "6b526e4da0d45589dc1247615e418d5e82490e25f8234b45551b2737f14ca5a1",


### PR DESCRIPTION
they made breaking changes to their tagging and artifact naming schemes:

https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#050
https://github.com/astral-sh/ruff/discussions/12078
