### PR TITLE
feat: parameterise clang-tidy aspect

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,10 @@
 # https://bazelbuild.slack.com/archives/C014RARENH0/p1691158021917459?thread_ts=1691156601.420349&cid=C014RARENH0
 common --check_direct_dependencies=off
 
+# Provide more output on error in CI
+common --verbose_failures
+common --test_output=errors
+
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members
 # This needs to be last statement in this

--- a/docs/clang-tidy.md
+++ b/docs/clang-tidy.md
@@ -115,7 +115,7 @@ is_parent_in_list(<a href="#is_parent_in_list-dir">dir</a>, <a href="#is_parent_
 
 <pre>
 lint_clang_tidy_aspect(<a href="#lint_clang_tidy_aspect-binary">binary</a>, <a href="#lint_clang_tidy_aspect-configs">configs</a>, <a href="#lint_clang_tidy_aspect-global_config">global_config</a>, <a href="#lint_clang_tidy_aspect-header_filter">header_filter</a>, <a href="#lint_clang_tidy_aspect-lint_target_headers">lint_target_headers</a>,
-                       <a href="#lint_clang_tidy_aspect-angle_includes_are_system">angle_includes_are_system</a>, <a href="#lint_clang_tidy_aspect-verbose">verbose</a>)
+                       <a href="#lint_clang_tidy_aspect-angle_includes_are_system">angle_includes_are_system</a>, <a href="#lint_clang_tidy_aspect-verbose">verbose</a>, <a href="#lint_clang_tidy_aspect-mnemonic_suffix">mnemonic_suffix</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -132,5 +132,6 @@ A factory function to create a linter aspect.
 | <a id="lint_clang_tidy_aspect-lint_target_headers"></a>lint_target_headers |  optional, set to True to pass a pattern that includes all headers with the target's directory prefix. This crude control may include headers from the linted target in the results. If supplied, overrides the header_filter option.   |  <code>False</code> |
 | <a id="lint_clang_tidy_aspect-angle_includes_are_system"></a>angle_includes_are_system |  controls how angle includes are passed to clang-tidy. By default, Bazel passes these as -isystem. Change this to False to pass these as -I, which allows clang-tidy to regard them as regular header files.   |  <code>True</code> |
 | <a id="lint_clang_tidy_aspect-verbose"></a>verbose |  print debug messages including clang-tidy command lines being invoked.   |  <code>False</code> |
+| <a id="lint_clang_tidy_aspect-mnemonic_suffix"></a>mnemonic_suffix |  suffix of mneomnic to be used. A prefix of AspectRulesLint is always used.   |  <code>"ClangTidy"</code> |
 
 

--- a/docs/clang-tidy.md
+++ b/docs/clang-tidy.md
@@ -114,7 +114,7 @@ is_parent_in_list(<a href="#is_parent_in_list-dir">dir</a>, <a href="#is_parent_
 ## lint_clang_tidy_aspect
 
 <pre>
-lint_clang_tidy_aspect(<a href="#lint_clang_tidy_aspect-binary">binary</a>, <a href="#lint_clang_tidy_aspect-configs">configs</a>, <a href="#lint_clang_tidy_aspect-global_config">global_config</a>, <a href="#lint_clang_tidy_aspect-header_filter">header_filter</a>, <a href="#lint_clang_tidy_aspect-lint_target_headers">lint_target_headers</a>,
+lint_clang_tidy_aspect(<a href="#lint_clang_tidy_aspect-binary">binary</a>, <a href="#lint_clang_tidy_aspect-name">name</a>, <a href="#lint_clang_tidy_aspect-configs">configs</a>, <a href="#lint_clang_tidy_aspect-global_config">global_config</a>, <a href="#lint_clang_tidy_aspect-header_filter">header_filter</a>, <a href="#lint_clang_tidy_aspect-lint_target_headers">lint_target_headers</a>,
                        <a href="#lint_clang_tidy_aspect-angle_includes_are_system">angle_includes_are_system</a>, <a href="#lint_clang_tidy_aspect-verbose">verbose</a>, <a href="#lint_clang_tidy_aspect-mnemonic_suffix">mnemonic_suffix</a>)
 </pre>
 
@@ -126,12 +126,13 @@ A factory function to create a linter aspect.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="lint_clang_tidy_aspect-binary"></a>binary |  the clang-tidy binary, typically a rule like<br><br><pre><code>starlark native_binary(     name = "clang_tidy",     src = "clang-tidy.exe"     out = "clang_tidy", ) </code></pre>   |  none |
+| <a id="lint_clang_tidy_aspect-name"></a>name |  name of the aspect.   |  <code>"clang-tidy"</code> |
 | <a id="lint_clang_tidy_aspect-configs"></a>configs |  labels of the .clang-tidy files to make available to clang-tidy's config search. These may be in subdirectories and clang-tidy will apply them if appropriate. This may also include .clang-format files which may be used for formatting fixes.   |  <code>[]</code> |
 | <a id="lint_clang_tidy_aspect-global_config"></a>global_config |  label of a single global .clang-tidy file to pass to clang-tidy on the command line. This will cause clang-tidy to ignore any other config files in the source directories.   |  <code>[]</code> |
 | <a id="lint_clang_tidy_aspect-header_filter"></a>header_filter |  optional, set to a posix regex to supply to clang-tidy with the -header-filter option   |  <code>""</code> |
 | <a id="lint_clang_tidy_aspect-lint_target_headers"></a>lint_target_headers |  optional, set to True to pass a pattern that includes all headers with the target's directory prefix. This crude control may include headers from the linted target in the results. If supplied, overrides the header_filter option.   |  <code>False</code> |
 | <a id="lint_clang_tidy_aspect-angle_includes_are_system"></a>angle_includes_are_system |  controls how angle includes are passed to clang-tidy. By default, Bazel passes these as -isystem. Change this to False to pass these as -I, which allows clang-tidy to regard them as regular header files.   |  <code>True</code> |
 | <a id="lint_clang_tidy_aspect-verbose"></a>verbose |  print debug messages including clang-tidy command lines being invoked.   |  <code>False</code> |
-| <a id="lint_clang_tidy_aspect-mnemonic_suffix"></a>mnemonic_suffix |  suffix of mneomnic to be used. A prefix of AspectRulesLint is always used.   |  <code>"ClangTidy"</code> |
+| <a id="lint_clang_tidy_aspect-mnemonic_suffix"></a>mnemonic_suffix |  suffix of mnemonic to be used. A prefix of AspectRulesLint is always used.   |  <code>"ClangTidy"</code> |
 
 

--- a/lint/clang_tidy.bzl
+++ b/lint/clang_tidy.bzl
@@ -363,6 +363,9 @@ def lint_clang_tidy_aspect(binary, name = "clang-tidy", configs = [], global_con
     return aspect(
         implementation = _clang_tidy_aspect_impl,
         attrs = {
+            "name": attr.string(
+                default = name,                
+            ),
             "_options": attr.label(
                 default = "//lint:options",
                 providers = [LintOptionsInfo],

--- a/lint/clang_tidy.bzl
+++ b/lint/clang_tidy.bzl
@@ -354,7 +354,7 @@ def lint_clang_tidy_aspect(binary, name = "clang-tidy", configs = [], global_con
             passes these as -isystem. Change this to False to pass these as -I, which allows clang-tidy to regard
             them as regular header files.
         verbose: print debug messages including clang-tidy command lines being invoked.
-        mnemonic_suffix: suffix of mneomnic to be used. A prefix of AspectRulesLint is always used.
+        mnemonic_suffix: suffix of mnemonic to be used. A prefix of AspectRulesLint is always used.
     """
 
     if type(global_config) == "string":


### PR DESCRIPTION
Parameterize clang-tidy aspect name and mnemonic. We have a custom clang-tidy extension, and with this change we can create an extra aspect that runs it, and also have a default aspect that runs the OOTB clang-tidy.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no
