### PR TITLE
chore: update buildifier pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ default_language_version:
 repos:
   # Check formatting and lint for starlark code
   - repo: https://github.com/keith/pre-commit-buildifier
-    rev: 6.3.3
+    rev: 6.4.0.1
     hooks:
       - id: buildifier
       - id: buildifier-lint


### PR DESCRIPTION
Pick up windows fix in 6.3.3.1

Fixes #293 