### PR TITLE
ruff didn't change the archive format for windows

### DIFF
--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -262,7 +262,7 @@ def fetch_ruff(tag):
                 version = version,
                 ext = "zip" if is_windows else "tar.gz",
             ),
-            strip_prefix = "ruff-" + plat if versions.is_at_least("0.5.0", version) else None,
+            strip_prefix = "ruff-" + plat if versions.is_at_least("0.5.0", version) and not is_windows else None,
             sha256 = sha256,
             build_file_content = """exports_files(["ruff", "ruff.exe"])""",
         )


### PR DESCRIPTION
### Changes are visible to end-users: no
35da1b00c36dd145cd831bf346cf741eb3f84cb5 worked around a change to upstream ruff packaging, but it looks like upstream only changed it for non-windows; the windows zips still just have a single top-level ruff.exe.

### Test plan
- Manual testing; please provide instructions so we can reproduce:

Run ruff on windows.