### PR TITLE
feat: linter aspect factories allow customizing rule kinds

### DIFF
--- a/docs/buf.md
+++ b/docs/buf.md
@@ -41,7 +41,7 @@ Runs the buf lint tool as a Bazel action.
 ## lint_buf_aspect
 
 <pre>
-lint_buf_aspect(<a href="#lint_buf_aspect-config">config</a>, <a href="#lint_buf_aspect-toolchain">toolchain</a>)
+lint_buf_aspect(<a href="#lint_buf_aspect-config">config</a>, <a href="#lint_buf_aspect-toolchain">toolchain</a>, <a href="#lint_buf_aspect-rule_kinds">rule_kinds</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -53,5 +53,6 @@ A factory function to create a linter aspect.
 | :------------- | :------------- | :------------- |
 | <a id="lint_buf_aspect-config"></a>config |  label of the the buf.yaml file   |  none |
 | <a id="lint_buf_aspect-toolchain"></a>toolchain |  override the default toolchain of the protoc-gen-buf-lint tool   |  <code>"@rules_buf//tools/protoc-gen-buf-lint:toolchain_type"</code> |
+| <a id="lint_buf_aspect-rule_kinds"></a>rule_kinds |  which [kinds](https://bazel.build/query/language#kind) of rules should be visited by the aspect   |  <code>["proto_library"]</code> |
 
 

--- a/docs/eslint.md
+++ b/docs/eslint.md
@@ -109,7 +109,7 @@ Create a Bazel Action that spawns eslint with --fix.
 ## lint_eslint_aspect
 
 <pre>
-lint_eslint_aspect(<a href="#lint_eslint_aspect-binary">binary</a>, <a href="#lint_eslint_aspect-configs">configs</a>)
+lint_eslint_aspect(<a href="#lint_eslint_aspect-binary">binary</a>, <a href="#lint_eslint_aspect-configs">configs</a>, <a href="#lint_eslint_aspect-rule_kinds">rule_kinds</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -121,5 +121,6 @@ A factory function to create a linter aspect.
 | :------------- | :------------- | :------------- |
 | <a id="lint_eslint_aspect-binary"></a>binary |  the eslint binary, typically a rule like<br><br><pre><code> load("@npm//:eslint/package_json.bzl", eslint_bin = "bin") eslint_bin.eslint_binary(name = "eslint") </code></pre>   |  none |
 | <a id="lint_eslint_aspect-configs"></a>configs |  label(s) of the eslint config file(s)   |  none |
+| <a id="lint_eslint_aspect-rule_kinds"></a>rule_kinds |  which [kinds](https://bazel.build/query/language#kind) of rules should be visited by the aspect   |  <code>["js_library", "ts_project", "ts_project_rule"]</code> |
 
 

--- a/docs/flake8.md
+++ b/docs/flake8.md
@@ -59,7 +59,7 @@ Based on https://flake8.pycqa.org/en/latest/user/invocation.html
 ## lint_flake8_aspect
 
 <pre>
-lint_flake8_aspect(<a href="#lint_flake8_aspect-binary">binary</a>, <a href="#lint_flake8_aspect-config">config</a>)
+lint_flake8_aspect(<a href="#lint_flake8_aspect-binary">binary</a>, <a href="#lint_flake8_aspect-config">config</a>, <a href="#lint_flake8_aspect-rule_kinds">rule_kinds</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -83,5 +83,6 @@ Attrs:
 | :------------- | :------------- | :------------- |
 | <a id="lint_flake8_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
 | <a id="lint_flake8_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
+| <a id="lint_flake8_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  <code>["py_binary", "py_library"]</code> |
 
 

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -100,7 +100,7 @@ https://pinterest.github.io/ktlint/latest/install/cli/
 ## lint_ktlint_aspect
 
 <pre>
-lint_ktlint_aspect(<a href="#lint_ktlint_aspect-binary">binary</a>, <a href="#lint_ktlint_aspect-editorconfig">editorconfig</a>, <a href="#lint_ktlint_aspect-baseline_file">baseline_file</a>, <a href="#lint_ktlint_aspect-ruleset_jar">ruleset_jar</a>)
+lint_ktlint_aspect(<a href="#lint_ktlint_aspect-binary">binary</a>, <a href="#lint_ktlint_aspect-editorconfig">editorconfig</a>, <a href="#lint_ktlint_aspect-baseline_file">baseline_file</a>, <a href="#lint_ktlint_aspect-ruleset_jar">ruleset_jar</a>, <a href="#lint_ktlint_aspect-rule_kinds">rule_kinds</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -114,6 +114,7 @@ A factory function to create a linter aspect.
 | <a id="lint_ktlint_aspect-editorconfig"></a>editorconfig |  The label of the file pointing to the .editorconfig file used by ktlint.   |  none |
 | <a id="lint_ktlint_aspect-baseline_file"></a>baseline_file |  An optional attribute pointing to the label of the baseline file used by ktlint.   |  none |
 | <a id="lint_ktlint_aspect-ruleset_jar"></a>ruleset_jar |  An optional, custom ktlint ruleset provided as a fat jar, and works on top of the standard rules.   |  <code>None</code> |
+| <a id="lint_ktlint_aspect-rule_kinds"></a>rule_kinds |  which [kinds](https://bazel.build/query/language#kind) of rules should be visited by the aspect   |  <code>["kt_jvm_library", "kt_jvm_binary", "kt_js_library"]</code> |
 
 **RETURNS**
 

--- a/docs/pmd.md
+++ b/docs/pmd.md
@@ -46,7 +46,7 @@ fetch_pmd()
 ## lint_pmd_aspect
 
 <pre>
-lint_pmd_aspect(<a href="#lint_pmd_aspect-binary">binary</a>, <a href="#lint_pmd_aspect-rulesets">rulesets</a>)
+lint_pmd_aspect(<a href="#lint_pmd_aspect-binary">binary</a>, <a href="#lint_pmd_aspect-rulesets">rulesets</a>, <a href="#lint_pmd_aspect-rule_kinds">rule_kinds</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -72,6 +72,7 @@ Attrs:
 | :------------- | :------------- | :------------- |
 | <a id="lint_pmd_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
 | <a id="lint_pmd_aspect-rulesets"></a>rulesets |  <p align="center"> - </p>   |  none |
+| <a id="lint_pmd_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  <code>["java_binary", "java_library"]</code> |
 
 
 <a id="pmd_action"></a>

--- a/docs/ruff.md
+++ b/docs/ruff.md
@@ -98,7 +98,7 @@ Allows the user to select a particular ruff version, rather than get whatever is
 ## lint_ruff_aspect
 
 <pre>
-lint_ruff_aspect(<a href="#lint_ruff_aspect-binary">binary</a>, <a href="#lint_ruff_aspect-configs">configs</a>)
+lint_ruff_aspect(<a href="#lint_ruff_aspect-binary">binary</a>, <a href="#lint_ruff_aspect-configs">configs</a>, <a href="#lint_ruff_aspect-rule_kinds">rule_kinds</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -106,6 +106,7 @@ A factory function to create a linter aspect.
 Attrs:
     binary: a ruff executable
     configs: ruff config file(s) (`pyproject.toml`, `ruff.toml`, or `.ruff.toml`)
+    rule_kinds: which [kinds](https://bazel.build/query/language#kind) of rules should be visited by the aspect
 
 **PARAMETERS**
 
@@ -114,6 +115,7 @@ Attrs:
 | :------------- | :------------- | :------------- |
 | <a id="lint_ruff_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
 | <a id="lint_ruff_aspect-configs"></a>configs |  <p align="center"> - </p>   |  none |
+| <a id="lint_ruff_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  <code>["py_binary", "py_library", "py_test"]</code> |
 
 
 <a id="ruff_action"></a>

--- a/docs/shellcheck.md
+++ b/docs/shellcheck.md
@@ -21,7 +21,7 @@ shellcheck = shellcheck_aspect(
 ## lint_shellcheck_aspect
 
 <pre>
-lint_shellcheck_aspect(<a href="#lint_shellcheck_aspect-binary">binary</a>, <a href="#lint_shellcheck_aspect-config">config</a>)
+lint_shellcheck_aspect(<a href="#lint_shellcheck_aspect-binary">binary</a>, <a href="#lint_shellcheck_aspect-config">config</a>, <a href="#lint_shellcheck_aspect-rule_kinds">rule_kinds</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -37,6 +37,7 @@ Attrs:
 | :------------- | :------------- | :------------- |
 | <a id="lint_shellcheck_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
 | <a id="lint_shellcheck_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
+| <a id="lint_shellcheck_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  <code>["sh_binary", "sh_library"]</code> |
 
 
 <a id="shellcheck_action"></a>

--- a/docs/vale.md
+++ b/docs/vale.md
@@ -101,7 +101,7 @@ A factory function to create a linter aspect.
 | <a id="lint_vale_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
 | <a id="lint_vale_aspect-styles"></a>styles |  <p align="center"> - </p>   |  <code>Label("//lint:empty_styles")</code> |
 | <a id="lint_vale_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  <code>["markdown_library"]</code> |
-| <a id="lint_vale_aspect-filegroup_tags"></a>filegroup_tags |  <p align="center"> - </p>   |  <code>["markdown"]</code> |
+| <a id="lint_vale_aspect-filegroup_tags"></a>filegroup_tags |  <p align="center"> - </p>   |  <code>["markdown", "lint-with-vale"]</code> |
 
 
 <a id="vale_action"></a>

--- a/docs/vale.md
+++ b/docs/vale.md
@@ -87,7 +87,7 @@ A repository macro used from WORKSPACE to fetch vale binaries
 ## lint_vale_aspect
 
 <pre>
-lint_vale_aspect(<a href="#lint_vale_aspect-binary">binary</a>, <a href="#lint_vale_aspect-config">config</a>, <a href="#lint_vale_aspect-styles">styles</a>)
+lint_vale_aspect(<a href="#lint_vale_aspect-binary">binary</a>, <a href="#lint_vale_aspect-config">config</a>, <a href="#lint_vale_aspect-styles">styles</a>, <a href="#lint_vale_aspect-rule_kinds">rule_kinds</a>, <a href="#lint_vale_aspect-filegroup_tags">filegroup_tags</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -100,6 +100,8 @@ A factory function to create a linter aspect.
 | <a id="lint_vale_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
 | <a id="lint_vale_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
 | <a id="lint_vale_aspect-styles"></a>styles |  <p align="center"> - </p>   |  <code>Label("//lint:empty_styles")</code> |
+| <a id="lint_vale_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  <code>["markdown_library"]</code> |
+| <a id="lint_vale_aspect-filegroup_tags"></a>filegroup_tags |  <p align="center"> - </p>   |  <code>["markdown"]</code> |
 
 
 <a id="vale_action"></a>

--- a/lint/private/lint_aspect.bzl
+++ b/lint/private/lint_aspect.bzl
@@ -25,6 +25,25 @@ lint_options = rule(
     },
 )
 
+def should_visit(rule, allow_kinds, allow_filegroup_tags = []):
+    """Determine whether a rule is meant to be visited by a linter aspect
+
+    Args:
+        rule: a [rules_attributes](https://bazel.build/rules/lib/builtins/rule_attributes.html) object
+        allow_kinds (list of string): return true if the rule's kind is in the list
+        allow_filegroup_tags (list of string): return true if the rule is a filegroup and has a tag in this list
+
+    Returns:
+        whether to apply the aspect on this rule
+    """
+    if rule.kind in allow_kinds:
+        return True
+    if rule.kind == "filegroup":
+        for allow_tag in allow_filegroup_tags:
+            if allow_tag in rule.attr.tags:
+                return True
+    return False
+
 _OUTFILE_FORMAT = "{label}.{mnemonic}.{suffix}"
 
 # buildifier: disable=function-docstring

--- a/lint/vale.bzl
+++ b/lint/vale.bzl
@@ -140,7 +140,7 @@ def _vale_aspect_impl(target, ctx):
 # Users might want to try https://github.com/dwtj/dwtj_rules_markdown but we expect many won't
 # want to take that dependency.
 # So allow a filegroup(tags=["markdown"]) as an alternative rule to host the srcs.
-def lint_vale_aspect(binary, config, styles = Label("//lint:empty_styles"), rule_kinds = ["markdown_library"], filegroup_tags = ["markdown"]):
+def lint_vale_aspect(binary, config, styles = Label("//lint:empty_styles"), rule_kinds = ["markdown_library"], filegroup_tags = ["markdown", "lint-with-vale"]):
     """A factory function to create a linter aspect."""
     return aspect(
         implementation = _vale_aspect_impl,

--- a/lint/vale.bzl
+++ b/lint/vale.bzl
@@ -64,7 +64,7 @@ vale = vale_aspect(
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "report_files")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "report_files", "should_visit")
 load(":vale_library.bzl", "fetch_styles")
 load(":vale_versions.bzl", "VALE_VERSIONS")
 
@@ -122,11 +122,7 @@ def vale_action(ctx, executable, srcs, styles, config, stdout, exit_code = None)
 
 # buildifier: disable=function-docstring
 def _vale_aspect_impl(target, ctx):
-    # There's no "official" markdown_library rule.
-    # Users might want to try https://github.com/dwtj/dwtj_rules_markdown but we expect many won't
-    # want to take that dependency.
-    # So allow a filegroup(tags=["markdown"]) as an alternative rule to host the srcs.
-    if ctx.rule.kind == "markdown_library" or (ctx.rule.kind == "filegroup" and "markdown" in ctx.rule.attr.tags):
+    if should_visit(ctx.rule, ctx.attr._rule_kinds, ctx.attr._filegroup_tags):
         report, exit_code, info = report_files(_MNEMONIC, target, ctx)
         styles = None
         if ctx.files._styles:
@@ -140,7 +136,11 @@ def _vale_aspect_impl(target, ctx):
 
     return []
 
-def lint_vale_aspect(binary, config, styles = Label("//lint:empty_styles")):
+# There's no "official" markdown_library rule.
+# Users might want to try https://github.com/dwtj/dwtj_rules_markdown but we expect many won't
+# want to take that dependency.
+# So allow a filegroup(tags=["markdown"]) as an alternative rule to host the srcs.
+def lint_vale_aspect(binary, config, styles = Label("//lint:empty_styles"), rule_kinds = ["markdown_library"], filegroup_tags = ["markdown"]):
     """A factory function to create a linter aspect."""
     return aspect(
         implementation = _vale_aspect_impl,
@@ -162,6 +162,12 @@ def lint_vale_aspect(binary, config, styles = Label("//lint:empty_styles")):
             ),
             "_styles": attr.label(
                 default = styles,
+            ),
+            "_filegroup_tags": attr.string_list(
+                default = filegroup_tags,
+            ),
+            "_rule_kinds": attr.string_list(
+                default = rule_kinds,
             ),
         },
     )


### PR DESCRIPTION
This lets users adapt for situations where they have a custom rule, for example.
