### PR TITLE
feat: add GraphQL format support (#319)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ Features:
 New tools are being added frequently, so check this page again!
 
 | Language               | Formatter             | Linter(s)        |
-| ---------------------- | --------------------- | ---------------- |
+|------------------------| --------------------- |------------------|
 | C / C++                | [clang-format]        | ([#112])         |
 | Cuda                   | [clang-format]        |                  |
 | CSS, Less, Sass        | [Prettier]            |                  |
 | Go                     | [gofmt] or [gofumpt]  |                  |
+| GraphQL                | [Prettier]            |                  |
 | HCL (Hashicorp Config) | [terraform] fmt       |                  |
 | HTML                   | [Prettier]            |                  |
 | JSON                   | [Prettier]            |                  |

--- a/docs/format.md
+++ b/docs/format.md
@@ -47,7 +47,7 @@ format_multirun(
 ## languages
 
 <pre>
-languages(<a href="#languages-name">name</a>, <a href="#languages-cc">cc</a>, <a href="#languages-css">css</a>, <a href="#languages-cuda">cuda</a>, <a href="#languages-go">go</a>, <a href="#languages-html">html</a>, <a href="#languages-java">java</a>, <a href="#languages-javascript">javascript</a>, <a href="#languages-jsonnet">jsonnet</a>, <a href="#languages-kotlin">kotlin</a>, <a href="#languages-markdown">markdown</a>,
+languages(<a href="#languages-name">name</a>, <a href="#languages-cc">cc</a>, <a href="#languages-css">css</a>, <a href="#languages-cuda">cuda</a>, <a href="#languages-go">go</a>, <a href="#languages-graphql">graphql</a>, <a href="#languages-html">html</a>, <a href="#languages-java">java</a>, <a href="#languages-javascript">javascript</a>, <a href="#languages-jsonnet">jsonnet</a>, <a href="#languages-kotlin">kotlin</a>, <a href="#languages-markdown">markdown</a>,
           <a href="#languages-protocol_buffer">protocol_buffer</a>, <a href="#languages-python">python</a>, <a href="#languages-rust">rust</a>, <a href="#languages-scala">scala</a>, <a href="#languages-shell">shell</a>, <a href="#languages-sql">sql</a>, <a href="#languages-starlark">starlark</a>, <a href="#languages-swift">swift</a>, <a href="#languages-terraform">terraform</a>, <a href="#languages-yaml">yaml</a>)
 </pre>
 
@@ -74,6 +74,7 @@ Some languages have dialects:
 | <a id="languages-css"></a>css |  a <code>prettier</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="languages-cuda"></a>cuda |  a <code>clang-format</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="languages-go"></a>go |  a <code>gofmt</code> binary, or any other tool that has a matching command-line interface. Use <code>@aspect_rules_lint//format:gofumpt</code> to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="languages-graphql"></a>graphql |  a <code>prettier</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="languages-html"></a>html |  a <code>prettier</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="languages-java"></a>java |  a <code>java-format</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="languages-javascript"></a>javascript |  a <code>prettier</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |

--- a/example/src/hello.graphql
+++ b/example/src/hello.graphql
@@ -1,0 +1,7 @@
+query
+{
+  world(greeting:
+  "hello") {
+    ... on Hello { salutation }
+  }
+}

--- a/example/tools/format/BUILD.bazel
+++ b/example/tools/format/BUILD.bazel
@@ -59,6 +59,7 @@ format_multirun(
     css = ":prettier",
     cuda = "@llvm_toolchain_llvm//:bin/clang-format",
     go = "@aspect_rules_lint//format:gofumpt",
+    graphql = ":prettier",
     html = ":prettier",
     # You can use standard gofmt instead of stricter gofumpt:
     # go = "@go_sdk//:bin/gofmt",

--- a/format/private/filter.jq
+++ b/format/private/filter.jq
@@ -5,6 +5,7 @@ with_entries(select(.key | IN(
     "Cuda",
     "Markdown",
     "Go",
+    "GraphQL",
     "HCL",
     "HTML",
     "Java",

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -67,6 +67,7 @@ function ls-files {
       'Cuda') patterns=('*.cu' '*.cuh') ;;
       'CSS') patterns=('*.css') ;;
       'Go') patterns=('*.go') ;;
+      'GraphQL') patterns=('*.graphql' '*.gql' '*.graphqls') ;;
       'HTML') patterns=('*.html' '*.hta' '*.htm' '*.html.hl' '*.inc' '*.xht' '*.xhtml') ;;
       'JSON') patterns=('.all-contributorsrc' '.arcconfig' '.auto-changelog' '.c8rc' '.htmlhintrc' '.imgbotconfig' '.nycrc' '.tern-config' '.tern-project' '.watchmanconfig' 'Pipfile.lock' 'composer.lock' 'deno.lock' 'flake.lock' 'mcmod.info' '*.json' '*.4DForm' '*.4DProject' '*.avsc' '*.geojson' '*.gltf' '*.har' '*.ice' '*.JSON-tmLanguage' '*.jsonl' '*.mcmeta' '*.tfstate' '*.tfstate.backup' '*.topojson' '*.webapp' '*.webmanifest' '*.yy' '*.yyp') ;;
       'Java') patterns=('*.java' '*.jav' '*.jsh') ;;

--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -7,6 +7,7 @@ TOOLS = {
     "JavaScript": "prettier",
     "Markdown": "prettier",
     "CSS": "prettier",
+    "GraphQL": "prettier",
     "HTML": "prettier",
     "Python": "ruff",
     "Starlark": "buildifier",

--- a/format/test/BUILD.bazel
+++ b/format/test/BUILD.bazel
@@ -40,6 +40,7 @@ format_multirun(
     css = ":mock_prettier.sh",
     cuda = ":mock_clang-format.sh",
     go = ":mock_gofmt.sh",
+    graphql = ":mock_prettier.sh",
     html = ":mock_prettier.sh",
     java = ":mock_java-format.sh",
     javascript = ":mock_prettier.sh",

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -56,6 +56,13 @@ bats_load_library "bats-assert"
     assert_output --partial "+ prettier --write example/src/index.html"
 }
 
+@test "should run prettier on GraphQL" {
+    run bazel run //format/test:format_GraphQL_with_prettier
+    assert_success
+
+    assert_output --partial "+ prettier --write example/src/hello.graphql"
+}
+
 @test "should run prettier on SQL" {
     run bazel run //format/test:format_SQL_with_prettier
     assert_success


### PR DESCRIPTION
Prettier supports GraphQL natively. The file extensions are registered with the formatter and a basic format test is added.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: 

GraphQL is added as a language to `format_multirun` to opt into formatting with prettier.

### Test plan

- New test cases added

An example hello.graphql file was added which is fixed when running `bazel run format` from `examples/`. There is also a unit test that prettier is invoked with graphql files.
