### PR TITLE
feat: add tfsec security linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ New tools are being added frequently, so check this page again!
 | Cuda                   | [clang-format]        |                  |
 | CSS, Less, Sass        | [Prettier]            |                  |
 | Go                     | [gofmt] or [gofumpt]  |                  |
-| HCL (Hashicorp Config) | [terraform] fmt       |                  |
+| HCL (Hashicorp Config) | [terraform] fmt       | [tfsec]          |
 | HTML                   | [Prettier]            |                  |
 | JSON                   | [Prettier]            |                  |
 | Java                   | [google-java-format]  | [pmd]            |
@@ -72,6 +72,7 @@ New tools are being added frequently, so check this page again!
 [vale]: https://vale.sh/
 [yamlfmt]: https://github.com/google/yamlfmt
 [rustfmt]: https://rust-lang.github.io/rustfmt
+[tfsec]: https://github.com/aquasecurity/tfsec
 
 1. Non-hermetic: requires that a swift toolchain is installed on the machine.
    See https://github.com/bazelbuild/rules_swift#1-install-swift

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -57,4 +57,9 @@ stardoc_with_diff_test(
     bzl_library_target = "//lint:clang_tidy",
 )
 
+stardoc_with_diff_test(
+    name = "tfsec",
+    bzl_library_target = "//lint:tfsec",
+)
+
 update_docs(name = "update")

--- a/docs/tfsec.md
+++ b/docs/tfsec.md
@@ -1,0 +1,42 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+API for declaring a tfsec lint aspect that visits filegroup rules.
+
+Typical usage:
+
+Use [tfsec_aspect](#tfsec_aspect) to declare the tfsec linter aspect, typically in in `tools/lint/linters.bzl`:
+
+```
+load("@aspect_rules_lint//lint:tfsec.bzl", "tfsec_aspect")
+
+tfsec = tfsec_aspect(
+    binary = "@multitool//tools/tfsec",
+)
+```
+
+Note that tfsec has noted they are migrating its abilities to [Trivy](https://github.com/aquasecurity/trivy).
+
+
+<a id="tfsec_aspect"></a>
+
+## tfsec_aspect
+
+<pre>
+tfsec_aspect(<a href="#tfsec_aspect-binary">binary</a>, <a href="#tfsec_aspect-filegroup_tags">filegroup_tags</a>)
+</pre>
+
+A factory function to create a linter aspect.
+
+Attrs:
+    binary: a tfsec executable
+    filegroup_tags: which tags on filegroups should be visited by the aspect
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="tfsec_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
+| <a id="tfsec_aspect-filegroup_tags"></a>filegroup_tags |  <p align="center"> - </p>   |  <code>["terraform", "scan-with-tfsec"]</code> |
+
+

--- a/example/.aspect/cli/config.yaml
+++ b/example/.aspect/cli/config.yaml
@@ -7,3 +7,4 @@ lint:
     - //tools/lint:linters.bzl%pmd
     - //tools/lint:linters.bzl%ruff
     - //tools/lint:linters.bzl%vale
+    - //tools/lint:linters.bzl%tfsec

--- a/example/lint.sh
+++ b/example/lint.sh
@@ -37,7 +37,7 @@ if [ $machine == "Windows" ]; then
     # avoid missing linters on windows platform
     args=("--aspects=$(echo //tools/lint:linters.bzl%{flake8,pmd,ruff,vale,clang_tidy} | tr ' ' ',')")
 else
-    args=("--aspects=$(echo //tools/lint:linters.bzl%{buf,eslint,flake8,ktlint,pmd,ruff,shellcheck,vale,clang_tidy} | tr ' ' ',')")
+    args=("--aspects=$(echo //tools/lint:linters.bzl%{buf,eslint,flake8,ktlint,pmd,ruff,shellcheck,vale,clang_tidy,tfsec} | tr ' ' ',')")
 fi
 
 # NB: perhaps --remote_download_toplevel is needed as well with remote execution?

--- a/example/src/BUILD.bazel
+++ b/example/src/BUILD.bazel
@@ -17,6 +17,14 @@ filegroup(
     tags = ["markdown"],
 )
 
+filegroup(
+    name = "tf",
+    srcs = ["hello.tf"],
+    # The tfsec linter will look for this `terraform` tag by default
+    # on filegroups, and include them in the targets to be linted.
+    tags = ["terraform"],
+)
+
 ts_project(
     name = "ts",
     srcs = ["file.ts"],

--- a/example/src/hello.tf
+++ b/example/src/hello.tf
@@ -6,3 +6,45 @@ resource "aws_subnet" "private_subnet_us_east_2a" {
     Name = "aspect-ci-subnet-private1-us-east-2a"
   }
 }
+
+# These show the tfsec warning regarding permissive access policies and access grants:
+#
+# Result #1 HIGH IAM policy document uses wildcarded action 's3:Get*'
+# ────────────────────────────────────────────────────────────────────────────────
+#   hello.tf:13-15
+# ────────────────────────────────────────────────────────────────────────────────
+#    10    data "aws_iam_policy_document" "bucket" {
+#    11      statement {
+#    12        effect = "Allow"
+#    13  ┌     actions = [
+#    14  │       "s3:Get*",
+#    15  └     ]
+#    16        resources = [
+#    17          "*",
+#    18        ]
+#    ..
+# ────────────────────────────────────────────────────────────────────────────────
+#           ID aws-iam-no-policy-wildcards
+#       Impact Overly permissive policies may grant access to sensitive resources
+#   Resolution Specify the exact permissions required, and to which resources they should apply instead of using wildcards.
+#
+#   More Information
+#   - https://aquasecurity.github.io/tfsec/v1.28.10/checks/aws/iam/no-policy-wildcards/
+#   - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document
+#
+data "aws_iam_policy_document" "bucket" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:Get*",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "policy" {
+  name        = "policy"
+  policy      = data.aws_iam_policy_document.bucket.json
+}

--- a/example/test/lint_test.bats
+++ b/example/test/lint_test.bats
@@ -33,6 +33,9 @@ EOF
 
 	# Vale
 	assert_output --partial "src/README.md:3:47:Google.We:Try to avoid using first-person plural like 'We'."
+	
+	# Tfsec
+	assert_output --partial "Overly permissive policies may grant access to sensitive resources"
 }
 
 @test "should produce reports" {

--- a/example/tools/lint/linters.bzl
+++ b/example/tools/lint/linters.bzl
@@ -9,6 +9,7 @@ load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
 load("@aspect_rules_lint//lint:pmd.bzl", "lint_pmd_aspect")
 load("@aspect_rules_lint//lint:ruff.bzl", "lint_ruff_aspect")
 load("@aspect_rules_lint//lint:shellcheck.bzl", "lint_shellcheck_aspect")
+load("@aspect_rules_lint//lint:tfsec.bzl", "tfsec_aspect")
 load("@aspect_rules_lint//lint:vale.bzl", "lint_vale_aspect")
 
 buf = lint_buf_aspect(
@@ -94,4 +95,8 @@ clang_tidy_global_config = lint_clang_tidy_aspect(
     lint_target_headers = True,
     angle_includes_are_system = False,
     verbose = False,
+)
+
+tfsec = tfsec_aspect(
+    binary = "@multitool//tools/tfsec",
 )

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -211,6 +211,15 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "tfsec",
+    srcs = ["tfsec.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lint/private:lint_aspect",
+    ],
+)
+
 sh_binary(
     name = "clang_tidy_wrapper",
     srcs = ["clang_tidy_wrapper.bash"],

--- a/lint/multitool.lock.json
+++ b/lint/multitool.lock.json
@@ -71,5 +71,37 @@
         "cpu": "x86_64"
       }
     ]
+  },
+  "tfsec": {
+    "binaries": [
+      {
+        "kind": "file",
+        "url": "https://github.com/aquasecurity/tfsec/releases/download/v1.28.10/tfsec-darwin-arm64",
+        "sha256": "c2952bbfbd85e557cbd6e82a7fc8cd47c8936d34d0f023792063367addcdc333",
+        "os": "macos",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "file",
+        "url": "https://github.com/aquasecurity/tfsec/releases/download/v1.28.10/tfsec-darwin-amd64",
+        "sha256": "cf313f4da777f26858437dfc3f5713b3ac02bd362139d594554091dc1176b2fb",
+        "os": "macos",
+        "cpu": "x86_64"
+      },
+      {
+        "kind": "file",
+        "url": "https://github.com/aquasecurity/tfsec/releases/download/v1.28.10/tfsec-linux-amd64",
+        "sha256": "8584ac659e1bc8b183eae73228345cc76f5baafa8b00768357da807a5bd84b03",
+        "os": "linux",
+        "cpu": "x86_64"
+      },
+      {
+        "kind": "file",
+        "url": "https://github.com/aquasecurity/tfsec/releases/download/v1.28.10/tfsec-linux-arm64",
+        "sha256": "ff2095df50a757d937d0fc868c708389b325f53ee8d30b856f93b7aa9f68d743",
+        "os": "linux",
+        "cpu": "arm64"
+      }
+    ]
   }
 }

--- a/lint/tfsec.bzl
+++ b/lint/tfsec.bzl
@@ -1,0 +1,90 @@
+"""API for declaring a tfsec lint aspect that visits filegroup rules.
+
+Typical usage:
+
+Use [tfsec_aspect](#tfsec_aspect) to declare the tfsec linter aspect, typically in in `tools/lint/linters.bzl`:
+
+```
+load("@aspect_rules_lint//lint:tfsec.bzl", "tfsec_aspect")
+
+tfsec = tfsec_aspect(
+    binary = "@multitool//tools/tfsec",
+)
+```
+
+Note that tfsec has noted they are migrating its abilities to [Trivy](https://github.com/aquasecurity/trivy).
+"""
+
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "report_files", "should_visit")
+
+_MNEMONIC = "AspectRulesLintTfsec"
+
+def _tfsec_action(ctx, executable, srcs, stdout, exit_code = None):
+    args = ctx.actions.args()
+    args.add_all([
+        ctx.label.package,
+        "--exclude-downloaded-modules",
+        "--minimum-severity=HIGH",
+    ])
+    outputs = [stdout]
+
+    # Tfsec is deprecated, and tells us to use Trivy, ignore it for now until
+    # Trivy has fixed some more issues, such as coloured output, as it's output
+    # without colours is very hard to parse.
+    if exit_code:
+        command = "{tfsec} $@ 2>/dev/null >{stdout}; echo $? > " + exit_code.path
+        outputs.append(exit_code)
+    else:
+        command = "{tfsec} $@ 2>/dev/null && touch {stdout}"
+
+    ctx.actions.run_shell(
+        inputs = srcs,
+        outputs = outputs,
+        command = command.format(
+            tfsec = executable.path,
+            stdout = stdout.path,
+        ),
+        use_default_shell_env = True,
+        arguments = [args],
+        mnemonic = _MNEMONIC,
+        progress_message = "Scanning %{label} with tfsec",
+        tools = [executable],
+        execution_requirements = {
+            # tfsec does not support symlinks, and finds 0 files when presented with the symlink forest.
+            "no-sandbox": "1",
+        },
+    )
+
+def _tfsec_aspect_impl(target, ctx):
+    if should_visit(ctx.rule, [], ctx.attr._filegroup_tags):
+        report, exit_code, info = report_files(_MNEMONIC, target, ctx)
+        _tfsec_action(ctx, ctx.executable._tfsec, ctx.rule.files.srcs, report, exit_code)
+        return [info]
+
+    return []
+
+def tfsec_aspect(binary, filegroup_tags = ["terraform", "scan-with-tfsec"]):
+    """A factory function to create a linter aspect.
+
+    Attrs:
+        binary: a tfsec executable
+        filegroup_tags: which tags on filegroups should be visited by the aspect
+    """
+
+    return aspect(
+        implementation = _tfsec_aspect_impl,
+        attrs = {
+            "_options": attr.label(
+                default = "@aspect_rules_lint//lint:options",
+                providers = [LintOptionsInfo],
+            ),
+            "_tfsec": attr.label(
+                default = binary,
+                executable = True,
+                cfg = "exec",
+            ),
+            "_filegroup_tags": attr.string_list(
+                default = filegroup_tags,
+            ),
+        },
+    )


### PR DESCRIPTION
Adds the tfsec Terraform security linter.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Add the `tfsec` Terraform security linter.

### Test plan

- New test cases added