### PR TITLE
feat: color the human-readable outputs

### DIFF
--- a/docs/eslint.md
+++ b/docs/eslint.md
@@ -80,7 +80,7 @@ https://eslint.org/docs/latest/use/command-line-interface
 | <a id="eslint_action-stdout"></a>stdout |  output file containing the stdout or --output-file of eslint   |  none |
 | <a id="eslint_action-exit_code"></a>exit_code |  output file containing the exit code of eslint. If None, then fail the build when eslint exits non-zero.   |  <code>None</code> |
 | <a id="eslint_action-format"></a>format |  value for eslint <code>--format</code> CLI flag   |  <code>"stylish"</code> |
-| <a id="eslint_action-env"></a>env |  environment variaables for eslint   |  <code>{}</code> |
+| <a id="eslint_action-env"></a>env |  environment variables for eslint   |  <code>{}</code> |
 
 
 <a id="eslint_fix"></a>

--- a/docs/eslint.md
+++ b/docs/eslint.md
@@ -60,7 +60,7 @@ See the [react example](https://github.com/bazelbuild/examples/blob/b498bb106b20
 ## eslint_action
 
 <pre>
-eslint_action(<a href="#eslint_action-ctx">ctx</a>, <a href="#eslint_action-executable">executable</a>, <a href="#eslint_action-srcs">srcs</a>, <a href="#eslint_action-stdout">stdout</a>, <a href="#eslint_action-exit_code">exit_code</a>, <a href="#eslint_action-format">format</a>)
+eslint_action(<a href="#eslint_action-ctx">ctx</a>, <a href="#eslint_action-executable">executable</a>, <a href="#eslint_action-srcs">srcs</a>, <a href="#eslint_action-stdout">stdout</a>, <a href="#eslint_action-exit_code">exit_code</a>, <a href="#eslint_action-format">format</a>, <a href="#eslint_action-env">env</a>)
 </pre>
 
 Create a Bazel Action that spawns an eslint process.
@@ -80,6 +80,7 @@ https://eslint.org/docs/latest/use/command-line-interface
 | <a id="eslint_action-stdout"></a>stdout |  output file containing the stdout or --output-file of eslint   |  none |
 | <a id="eslint_action-exit_code"></a>exit_code |  output file containing the exit code of eslint. If None, then fail the build when eslint exits non-zero.   |  <code>None</code> |
 | <a id="eslint_action-format"></a>format |  value for eslint <code>--format</code> CLI flag   |  <code>"stylish"</code> |
+| <a id="eslint_action-env"></a>env |  environment variaables for eslint   |  <code>{}</code> |
 
 
 <a id="eslint_fix"></a>
@@ -87,7 +88,7 @@ https://eslint.org/docs/latest/use/command-line-interface
 ## eslint_fix
 
 <pre>
-eslint_fix(<a href="#eslint_fix-ctx">ctx</a>, <a href="#eslint_fix-executable">executable</a>, <a href="#eslint_fix-srcs">srcs</a>, <a href="#eslint_fix-patch">patch</a>, <a href="#eslint_fix-stdout">stdout</a>, <a href="#eslint_fix-exit_code">exit_code</a>, <a href="#eslint_fix-format">format</a>)
+eslint_fix(<a href="#eslint_fix-ctx">ctx</a>, <a href="#eslint_fix-executable">executable</a>, <a href="#eslint_fix-srcs">srcs</a>, <a href="#eslint_fix-patch">patch</a>, <a href="#eslint_fix-stdout">stdout</a>, <a href="#eslint_fix-exit_code">exit_code</a>, <a href="#eslint_fix-format">format</a>, <a href="#eslint_fix-env">env</a>)
 </pre>
 
 Create a Bazel Action that spawns eslint with --fix.
@@ -104,6 +105,7 @@ Create a Bazel Action that spawns eslint with --fix.
 | <a id="eslint_fix-stdout"></a>stdout |  output file containing the stdout or --output-file of eslint   |  none |
 | <a id="eslint_fix-exit_code"></a>exit_code |  output file containing the exit code of eslint   |  none |
 | <a id="eslint_fix-format"></a>format |  value for eslint <code>--format</code> CLI flag   |  <code>"stylish"</code> |
+| <a id="eslint_fix-env"></a>env |  environment variaables for eslint   |  <code>{}</code> |
 
 
 <a id="lint_eslint_aspect"></a>

--- a/docs/flake8.md
+++ b/docs/flake8.md
@@ -33,7 +33,7 @@ flake8 = lint_flake8_aspect(
 ## flake8_action
 
 <pre>
-flake8_action(<a href="#flake8_action-ctx">ctx</a>, <a href="#flake8_action-executable">executable</a>, <a href="#flake8_action-srcs">srcs</a>, <a href="#flake8_action-config">config</a>, <a href="#flake8_action-stdout">stdout</a>, <a href="#flake8_action-exit_code">exit_code</a>)
+flake8_action(<a href="#flake8_action-ctx">ctx</a>, <a href="#flake8_action-executable">executable</a>, <a href="#flake8_action-srcs">srcs</a>, <a href="#flake8_action-config">config</a>, <a href="#flake8_action-stdout">stdout</a>, <a href="#flake8_action-exit_code">exit_code</a>, <a href="#flake8_action-options">options</a>)
 </pre>
 
 Run flake8 as an action under Bazel.
@@ -52,6 +52,7 @@ Based on https://flake8.pycqa.org/en/latest/user/invocation.html
 | <a id="flake8_action-config"></a>config |  label of the flake8 config file (setup.cfg, tox.ini, or .flake8)   |  none |
 | <a id="flake8_action-stdout"></a>stdout |  output file containing stdout of flake8   |  none |
 | <a id="flake8_action-exit_code"></a>exit_code |  output file containing exit code of flake8 If None, then fail the build when flake8 exits non-zero.   |  <code>None</code> |
+| <a id="flake8_action-options"></a>options |  additional command-line options, see https://flake8.pycqa.org/en/latest/user/options.html   |  <code>[]</code> |
 
 
 <a id="lint_flake8_aspect"></a>

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -70,7 +70,7 @@ fetch_ktlint()
 
 <pre>
 ktlint_action(<a href="#ktlint_action-ctx">ctx</a>, <a href="#ktlint_action-executable">executable</a>, <a href="#ktlint_action-srcs">srcs</a>, <a href="#ktlint_action-editorconfig">editorconfig</a>, <a href="#ktlint_action-stdout">stdout</a>, <a href="#ktlint_action-baseline_file">baseline_file</a>, <a href="#ktlint_action-java_runtime">java_runtime</a>, <a href="#ktlint_action-ruleset_jar">ruleset_jar</a>,
-              <a href="#ktlint_action-exit_code">exit_code</a>)
+              <a href="#ktlint_action-exit_code">exit_code</a>, <a href="#ktlint_action-options">options</a>)
 </pre>
 
  Runs ktlint as build action in Bazel.
@@ -93,6 +93,7 @@ https://pinterest.github.io/ktlint/latest/install/cli/
 | <a id="ktlint_action-java_runtime"></a>java_runtime |  The Java Runtime configured for this build, pulled from the registered toolchain.   |  none |
 | <a id="ktlint_action-ruleset_jar"></a>ruleset_jar |  An optional, custom ktlint ruleset jar.   |  <code>None</code> |
 | <a id="ktlint_action-exit_code"></a>exit_code |  output file to write the exit code. If None, then fail the build when ktlint exits non-zero.   |  <code>None</code> |
+| <a id="ktlint_action-options"></a>options |  additional command-line arguments to ktlint, see https://pinterest.github.io/ktlint/latest/install/cli/#miscellaneous-flags-and-commands   |  <code>[]</code> |
 
 
 <a id="lint_ktlint_aspect"></a>

--- a/docs/pmd.md
+++ b/docs/pmd.md
@@ -80,7 +80,7 @@ Attrs:
 ## pmd_action
 
 <pre>
-pmd_action(<a href="#pmd_action-ctx">ctx</a>, <a href="#pmd_action-executable">executable</a>, <a href="#pmd_action-srcs">srcs</a>, <a href="#pmd_action-rulesets">rulesets</a>, <a href="#pmd_action-stdout">stdout</a>, <a href="#pmd_action-exit_code">exit_code</a>)
+pmd_action(<a href="#pmd_action-ctx">ctx</a>, <a href="#pmd_action-executable">executable</a>, <a href="#pmd_action-srcs">srcs</a>, <a href="#pmd_action-rulesets">rulesets</a>, <a href="#pmd_action-stdout">stdout</a>, <a href="#pmd_action-exit_code">exit_code</a>, <a href="#pmd_action-options">options</a>)
 </pre>
 
 Run PMD as an action under Bazel.
@@ -99,5 +99,6 @@ Based on https://docs.pmd-code.org/latest/pmd_userdocs_installation.html#running
 | <a id="pmd_action-rulesets"></a>rulesets |  list of labels of the PMD ruleset files   |  none |
 | <a id="pmd_action-stdout"></a>stdout |  output file to generate   |  none |
 | <a id="pmd_action-exit_code"></a>exit_code |  output file to write the exit code. If None, then fail the build when PMD exits non-zero.   |  <code>None</code> |
+| <a id="pmd_action-options"></a>options |  additional command-line options, see https://pmd.github.io/pmd/pmd_userdocs_cli_reference.html   |  <code>[]</code> |
 
 

--- a/docs/ruff.md
+++ b/docs/ruff.md
@@ -123,7 +123,7 @@ Attrs:
 ## ruff_action
 
 <pre>
-ruff_action(<a href="#ruff_action-ctx">ctx</a>, <a href="#ruff_action-executable">executable</a>, <a href="#ruff_action-srcs">srcs</a>, <a href="#ruff_action-config">config</a>, <a href="#ruff_action-stdout">stdout</a>, <a href="#ruff_action-exit_code">exit_code</a>)
+ruff_action(<a href="#ruff_action-ctx">ctx</a>, <a href="#ruff_action-executable">executable</a>, <a href="#ruff_action-srcs">srcs</a>, <a href="#ruff_action-config">config</a>, <a href="#ruff_action-stdout">stdout</a>, <a href="#ruff_action-exit_code">exit_code</a>, <a href="#ruff_action-env">env</a>)
 </pre>
 
 Run ruff as an action under Bazel.
@@ -153,6 +153,7 @@ However this is needed because:
 | <a id="ruff_action-config"></a>config |  labels of ruff config files (pyproject.toml, ruff.toml, or .ruff.toml)   |  none |
 | <a id="ruff_action-stdout"></a>stdout |  output file of linter results to generate   |  none |
 | <a id="ruff_action-exit_code"></a>exit_code |  output file to write the exit code. If None, then fail the build when ruff exits non-zero. See https://github.com/astral-sh/ruff/blob/dfe4291c0b7249ae892f5f1d513e6f1404436c13/docs/linter.md#exit-codes   |  <code>None</code> |
+| <a id="ruff_action-env"></a>env |  environment variaables for ruff   |  <code>{}</code> |
 
 
 <a id="ruff_fix"></a>
@@ -160,7 +161,7 @@ However this is needed because:
 ## ruff_fix
 
 <pre>
-ruff_fix(<a href="#ruff_fix-ctx">ctx</a>, <a href="#ruff_fix-executable">executable</a>, <a href="#ruff_fix-srcs">srcs</a>, <a href="#ruff_fix-config">config</a>, <a href="#ruff_fix-patch">patch</a>, <a href="#ruff_fix-stdout">stdout</a>, <a href="#ruff_fix-exit_code">exit_code</a>)
+ruff_fix(<a href="#ruff_fix-ctx">ctx</a>, <a href="#ruff_fix-executable">executable</a>, <a href="#ruff_fix-srcs">srcs</a>, <a href="#ruff_fix-config">config</a>, <a href="#ruff_fix-patch">patch</a>, <a href="#ruff_fix-stdout">stdout</a>, <a href="#ruff_fix-exit_code">exit_code</a>, <a href="#ruff_fix-env">env</a>)
 </pre>
 
 Create a Bazel Action that spawns ruff with --fix.
@@ -177,5 +178,6 @@ Create a Bazel Action that spawns ruff with --fix.
 | <a id="ruff_fix-patch"></a>patch |  output file containing the applied fixes that can be applied with the patch(1) command.   |  none |
 | <a id="ruff_fix-stdout"></a>stdout |  output file of linter results to generate   |  none |
 | <a id="ruff_fix-exit_code"></a>exit_code |  output file to write the exit code   |  none |
+| <a id="ruff_fix-env"></a>env |  environment variaables for ruff   |  <code>{}</code> |
 
 

--- a/docs/vale.md
+++ b/docs/vale.md
@@ -109,7 +109,7 @@ A factory function to create a linter aspect.
 ## vale_action
 
 <pre>
-vale_action(<a href="#vale_action-ctx">ctx</a>, <a href="#vale_action-executable">executable</a>, <a href="#vale_action-srcs">srcs</a>, <a href="#vale_action-styles">styles</a>, <a href="#vale_action-config">config</a>, <a href="#vale_action-stdout">stdout</a>, <a href="#vale_action-exit_code">exit_code</a>, <a href="#vale_action-output">output</a>)
+vale_action(<a href="#vale_action-ctx">ctx</a>, <a href="#vale_action-executable">executable</a>, <a href="#vale_action-srcs">srcs</a>, <a href="#vale_action-styles">styles</a>, <a href="#vale_action-config">config</a>, <a href="#vale_action-stdout">stdout</a>, <a href="#vale_action-exit_code">exit_code</a>, <a href="#vale_action-output">output</a>, <a href="#vale_action-env">env</a>)
 </pre>
 
 Run Vale as an action under Bazel.
@@ -127,5 +127,6 @@ Run Vale as an action under Bazel.
 | <a id="vale_action-stdout"></a>stdout |  output file containing stdout of Vale   |  none |
 | <a id="vale_action-exit_code"></a>exit_code |  output file containing Vale exit code. If None, then fail the build when Vale exits non-zero.   |  <code>None</code> |
 | <a id="vale_action-output"></a>output |  the value for the --output flag   |  <code>"CLI"</code> |
+| <a id="vale_action-env"></a>env |  environment variables for vale   |  <code>{}</code> |
 
 

--- a/example/test/lint_test.bats
+++ b/example/test/lint_test.bats
@@ -20,7 +20,13 @@ EOF
 	assert_output --partial "src/unused_import.py:13:1: F401 'os' imported but unused"
 
 	# PMD
-	assert_output --partial 'src/Foo.java:9:	FinalizeOverloaded:	Finalize methods should not be overloaded'
+	echo <<"EOF" | assert_output --partial
+* file: src/Foo.java
+    src:  Foo.java:9:9
+    rule: FinalizeOverloaded
+    msg:  Finalize methods should not be overloaded
+    code: protected void finalize(int a) {}
+EOF
 
 	# ktlint
 	assert_output --partial "src/hello.kt:1:1: File name 'hello.kt' should conform PascalCase (standard:filename)"

--- a/example/test/lint_test.bats
+++ b/example/test/lint_test.bats
@@ -42,7 +42,7 @@ EOF
 }
 
 @test "should produce reports" {
-	run $BATS_TEST_DIRNAME/../lint.sh //src:all
+	run $BATS_TEST_DIRNAME/../lint.sh //src:all --@aspect_rules_lint//lint:color=false
 	assert_success
 	assert_lints
 

--- a/example/test/lint_test.bats
+++ b/example/test/lint_test.bats
@@ -48,7 +48,7 @@ EOF
 }
 
 @test "should produce reports" {
-	run $BATS_TEST_DIRNAME/../lint.sh //src:all --@aspect_rules_lint//lint:color=false
+	run $BATS_TEST_DIRNAME/../lint.sh //src:all --no@aspect_rules_lint//lint:color
 	assert_success
 	assert_lints
 

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -69,8 +69,23 @@ config_setting(
     flag_values = {":fix": "true"},
 )
 
+bool_flag(
+    name = "color",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "color.enabled",
+    flag_values = {":color": "true"},
+)
+
 lint_options(
     name = "options",
+    color = select({
+        ":color.enabled": True,
+        "//conditions:default": False,
+    }),
     debug = select({
         ":debug.enabled": True,
         "//conditions:default": False,

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -98,7 +98,7 @@ def eslint_action(ctx, executable, srcs, stdout, exit_code = None, format = "sty
         exit_code: output file containing the exit code of eslint.
             If None, then fail the build when eslint exits non-zero.
         format: value for eslint `--format` CLI flag
-        env: environment variaables for eslint
+        env: environment variables for eslint
     """
 
     args = ctx.actions.args()

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -59,6 +59,12 @@ load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "output
 
 _MNEMONIC = "AspectRulesLintESLint"
 
+# https://www.npmjs.com/package/chalk#chalklevel
+_FORCE_COLOR_ENV = {
+    # Force 256 color support even when a tty isn't detected
+    "FORCE_COLOR": "2",
+}
+
 def _gather_inputs(ctx, srcs, files):
     inputs = copy_files_to_bin_actions(ctx, srcs)
 
@@ -84,7 +90,7 @@ def _gather_inputs(ctx, srcs, files):
     inputs.extend(js_inputs.to_list())
     return inputs
 
-def eslint_action(ctx, executable, srcs, stdout, exit_code = None, format = "stylish"):
+def eslint_action(ctx, executable, srcs, stdout, exit_code = None, format = "stylish", env = {}):
     """Create a Bazel Action that spawns an eslint process.
 
     Adapter for wrapping Bazel around
@@ -98,6 +104,7 @@ def eslint_action(ctx, executable, srcs, stdout, exit_code = None, format = "sty
         exit_code: output file containing the exit code of eslint.
             If None, then fail the build when eslint exits non-zero.
         format: value for eslint `--format` CLI flag
+        env: environment variaables for eslint
     """
 
     args = ctx.actions.args()
@@ -120,9 +127,9 @@ def eslint_action(ctx, executable, srcs, stdout, exit_code = None, format = "sty
             tools = [executable._eslint],
             arguments = [args],
             command = executable._eslint.path + " $@ && touch " + stdout.path,
-            env = {
+            env = dict(env, **{
                 "BAZEL_BINDIR": ctx.bin_dir.path,
-            },
+            }),
             mnemonic = _MNEMONIC,
             progress_message = "Linting %{label} with ESLint",
         )
@@ -138,15 +145,15 @@ def eslint_action(ctx, executable, srcs, stdout, exit_code = None, format = "sty
             outputs = [stdout, exit_code],
             executable = executable._eslint,
             arguments = [args],
-            env = {
+            env = dict(env, **{
                 "BAZEL_BINDIR": ctx.bin_dir.path,
                 "JS_BINARY__EXIT_CODE_OUTPUT_FILE": exit_code.path,
-            },
+            }),
             mnemonic = _MNEMONIC,
             progress_message = "Linting %{label} with ESLint",
         )
 
-def eslint_fix(ctx, executable, srcs, patch, stdout, exit_code, format = "stylish"):
+def eslint_fix(ctx, executable, srcs, patch, stdout, exit_code, format = "stylish", env = {}):
     """Create a Bazel Action that spawns eslint with --fix.
 
     Args:
@@ -157,6 +164,7 @@ def eslint_fix(ctx, executable, srcs, patch, stdout, exit_code, format = "stylis
         stdout: output file containing the stdout or --output-file of eslint
         exit_code: output file containing the exit code of eslint
         format: value for eslint `--format` CLI flag
+        env: environment variaables for eslint
     """
     patch_cfg = ctx.actions.declare_file("_{}.patch_cfg".format(ctx.label.name))
 
@@ -165,7 +173,7 @@ def eslint_fix(ctx, executable, srcs, patch, stdout, exit_code, format = "stylis
         content = json.encode({
             "linter": executable._eslint.path,
             "args": ["--fix", "--format", format] + [s.short_path for s in srcs],
-            "env": {"BAZEL_BINDIR": ctx.bin_dir.path},
+            "env": dict(env, **{"BAZEL_BINDIR": ctx.bin_dir.path}),
             "files_to_diff": [s.path for s in srcs],
             "output": patch.path,
         }),
@@ -176,12 +184,12 @@ def eslint_fix(ctx, executable, srcs, patch, stdout, exit_code, format = "stylis
         outputs = [patch, stdout, exit_code],
         executable = executable._patcher,
         arguments = [patch_cfg.path],
-        env = {
+        env = dict(env, **{
             "BAZEL_BINDIR": ".",
             "JS_BINARY__EXIT_CODE_OUTPUT_FILE": exit_code.path,
             "JS_BINARY__STDOUT_OUTPUT_FILE": stdout.path,
             "JS_BINARY__SILENT_ON_SUCCESS": "1",
-        },
+        }),
         tools = [executable._eslint],
         mnemonic = _MNEMONIC,
         progress_message = "Linting %{label} with ESLint",
@@ -198,11 +206,13 @@ def _eslint_aspect_impl(target, ctx):
     else:
         outputs, info = output_files(_MNEMONIC, target, ctx)
 
+    human_env = _FORCE_COLOR_ENV if ctx.attr._options[LintOptionsInfo].color else {}
+
     # eslint can produce a patch file at the same time it reports the unpatched violations
     if hasattr(outputs, "patch"):
-        eslint_fix(ctx, ctx.executable, files_to_lint, outputs.patch, outputs.human.out, outputs.human.exit_code)
+        eslint_fix(ctx, ctx.executable, files_to_lint, outputs.patch, outputs.human.out, outputs.human.exit_code, env = human_env)
     else:
-        eslint_action(ctx, ctx.executable, files_to_lint, outputs.human.out, outputs.human.exit_code)
+        eslint_action(ctx, ctx.executable, files_to_lint, outputs.human.out, outputs.human.exit_code, env = human_env)
 
     # TODO(alex): if we run with --fix, this will report the issues that were fixed. Does a machine reader want to know about them?
     eslint_action(ctx, ctx.executable, files_to_lint, outputs.machine.out, outputs.machine.exit_code, format = ctx.attr._formatter)

--- a/lint/flake8.bzl
+++ b/lint/flake8.bzl
@@ -86,8 +86,8 @@ def _flake8_aspect_impl(target, ctx):
         noop_lint_action(ctx, outputs)
         return [info]
 
-    color_args = ["--color=always"] if ctx.attr._options[LintOptionsInfo].color else []
-    flake8_action(ctx, ctx.executable._flake8, files_to_lint, ctx.file._config_file, outputs.human.out, outputs.human.exit_code, color_args)
+    color_options = ["--color=always"] if ctx.attr._options[LintOptionsInfo].color else []
+    flake8_action(ctx, ctx.executable._flake8, files_to_lint, ctx.file._config_file, outputs.human.out, outputs.human.exit_code, color_options)
     flake8_action(ctx, ctx.executable._flake8, files_to_lint, ctx.file._config_file, outputs.machine.out, outputs.machine.exit_code)
     return [info]
 

--- a/lint/ktlint.bzl
+++ b/lint/ktlint.bzl
@@ -56,7 +56,7 @@ load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "noop_l
 
 _MNEMONIC = "AspectRulesLintKTLint"
 
-def ktlint_action(ctx, executable, srcs, editorconfig, stdout, baseline_file, java_runtime, ruleset_jar = None, exit_code = None):
+def ktlint_action(ctx, executable, srcs, editorconfig, stdout, baseline_file, java_runtime, ruleset_jar = None, exit_code = None, options = []):
     """ Runs ktlint as build action in Bazel.
 
     Adapter for wrapping Bazel around
@@ -73,9 +73,11 @@ def ktlint_action(ctx, executable, srcs, editorconfig, stdout, baseline_file, ja
         ruleset_jar: An optional, custom ktlint ruleset jar.
         exit_code: output file to write the exit code.
             If None, then fail the build when ktlint exits non-zero.
+        options: additional command-line arguments to ktlint, see https://pinterest.github.io/ktlint/latest/install/cli/#miscellaneous-flags-and-commands
     """
 
     args = ctx.actions.args()
+    args.add_all(options)
     inputs = srcs
     outputs = [stdout]
 
@@ -141,8 +143,8 @@ def _ktlint_aspect_impl(target, ctx):
         noop_lint_action(ctx, outputs)
         return [info]
 
-    # TODO(#332): colorize the human output
-    ktlint_action(ctx, ctx.executable._ktlint, files_to_lint, ctx.file._editorconfig, outputs.human.out, ctx.file._baseline_file, ctx.attr._java_runtime, ruleset_jar, outputs.human.exit_code)
+    color_args = ["--color"] if ctx.attr._options[LintOptionsInfo].color else []
+    ktlint_action(ctx, ctx.executable._ktlint, files_to_lint, ctx.file._editorconfig, outputs.human.out, ctx.file._baseline_file, ctx.attr._java_runtime, ruleset_jar, outputs.human.exit_code, color_args)
     ktlint_action(ctx, ctx.executable._ktlint, files_to_lint, ctx.file._editorconfig, outputs.machine.out, ctx.file._baseline_file, ctx.attr._java_runtime, ruleset_jar, outputs.machine.exit_code)
     return [info]
 

--- a/lint/ktlint.bzl
+++ b/lint/ktlint.bzl
@@ -143,8 +143,8 @@ def _ktlint_aspect_impl(target, ctx):
         noop_lint_action(ctx, outputs)
         return [info]
 
-    color_args = ["--color"] if ctx.attr._options[LintOptionsInfo].color else []
-    ktlint_action(ctx, ctx.executable._ktlint, files_to_lint, ctx.file._editorconfig, outputs.human.out, ctx.file._baseline_file, ctx.attr._java_runtime, ruleset_jar, outputs.human.exit_code, color_args)
+    color_options = ["--color"] if ctx.attr._options[LintOptionsInfo].color else []
+    ktlint_action(ctx, ctx.executable._ktlint, files_to_lint, ctx.file._editorconfig, outputs.human.out, ctx.file._baseline_file, ctx.attr._java_runtime, ruleset_jar, outputs.human.exit_code, color_options)
     ktlint_action(ctx, ctx.executable._ktlint, files_to_lint, ctx.file._editorconfig, outputs.machine.out, ctx.file._baseline_file, ctx.attr._java_runtime, ruleset_jar, outputs.machine.exit_code)
     return [info]
 

--- a/lint/pmd.bzl
+++ b/lint/pmd.bzl
@@ -32,7 +32,7 @@ load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "noop_l
 
 _MNEMONIC = "AspectRulesLintPMD"
 
-def pmd_action(ctx, executable, srcs, rulesets, stdout, exit_code = None):
+def pmd_action(ctx, executable, srcs, rulesets, stdout, exit_code = None, options = []):
     """Run PMD as an action under Bazel.
 
     Based on https://docs.pmd-code.org/latest/pmd_userdocs_installation.html#running-pmd-via-command-line
@@ -45,6 +45,7 @@ def pmd_action(ctx, executable, srcs, rulesets, stdout, exit_code = None):
         stdout: output file to generate
         exit_code: output file to write the exit code.
             If None, then fail the build when PMD exits non-zero.
+        options: additional command-line options, see https://pmd.github.io/pmd/pmd_userdocs_cli_reference.html
     """
     inputs = srcs + rulesets
     outputs = [stdout]
@@ -52,6 +53,7 @@ def pmd_action(ctx, executable, srcs, rulesets, stdout, exit_code = None):
     # Wire command-line options, see
     # https://docs.pmd-code.org/latest/pmd_userdocs_cli_reference.html
     args = ctx.actions.args()
+    args.add_all(options)
     args.add("--rulesets")
     args.add_joined(rulesets, join_with = ",")
 
@@ -87,8 +89,9 @@ def _pmd_aspect_impl(target, ctx):
         noop_lint_action(ctx, outputs)
         return [info]
 
-    # TODO(#332): colorize the human output
-    pmd_action(ctx, ctx.executable._pmd, files_to_lint, ctx.files._rulesets, outputs.human.out, outputs.human.exit_code)
+    # https://github.com/pmd/pmd/blob/master/docs/pages/pmd/userdocs/pmd_report_formats.md
+    format_args = ["--format", "textcolor" if ctx.attr._options[LintOptionsInfo].color else "text"]
+    pmd_action(ctx, ctx.executable._pmd, files_to_lint, ctx.files._rulesets, outputs.human.out, outputs.human.exit_code, format_args)
     pmd_action(ctx, ctx.executable._pmd, files_to_lint, ctx.files._rulesets, outputs.machine.out, outputs.machine.exit_code)
     return [info]
 

--- a/lint/pmd.bzl
+++ b/lint/pmd.bzl
@@ -90,8 +90,8 @@ def _pmd_aspect_impl(target, ctx):
         return [info]
 
     # https://github.com/pmd/pmd/blob/master/docs/pages/pmd/userdocs/pmd_report_formats.md
-    format_args = ["--format", "textcolor" if ctx.attr._options[LintOptionsInfo].color else "text"]
-    pmd_action(ctx, ctx.executable._pmd, files_to_lint, ctx.files._rulesets, outputs.human.out, outputs.human.exit_code, format_args)
+    format_options = ["--format", "textcolor" if ctx.attr._options[LintOptionsInfo].color else "text"]
+    pmd_action(ctx, ctx.executable._pmd, files_to_lint, ctx.files._rulesets, outputs.human.out, outputs.human.exit_code, format_options)
     pmd_action(ctx, ctx.executable._pmd, files_to_lint, ctx.files._rulesets, outputs.machine.out, outputs.machine.exit_code)
     return [info]
 

--- a/lint/private/lint_aspect.bzl
+++ b/lint/private/lint_aspect.bzl
@@ -3,6 +3,7 @@
 LintOptionsInfo = provider(
     doc = "Global options for running linters",
     fields = {
+        "color": "whether ANSI color escape codes are desired in the human-readable stdout",
         "debug": "print additional information for rules_lint developers",
         "fail_on_violation": "whether to honor the exit code of linter tools run as actions",
         "fix": "whether to run linters in their --fix mode. Fixes are collected into patch files.",
@@ -11,6 +12,7 @@ LintOptionsInfo = provider(
 
 def _lint_options_impl(ctx):
     return LintOptionsInfo(
+        color = ctx.attr.color,
         debug = ctx.attr.debug,
         fail_on_violation = ctx.attr.fail_on_violation,
         fix = ctx.attr.fix,
@@ -19,6 +21,7 @@ def _lint_options_impl(ctx):
 lint_options = rule(
     implementation = _lint_options_impl,
     attrs = {
+        "color": attr.bool(),
         "debug": attr.bool(),
         "fix": attr.bool(),
         "fail_on_violation": attr.bool(),

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -79,7 +79,7 @@ def _shellcheck_aspect_impl(target, ctx):
         noop_lint_action(ctx, outputs)
         return [info]
 
-    color_args = ["--color"] if ctx.attr._options[LintOptionsInfo].color else {}
+    color_args = ["--color"] if ctx.attr._options[LintOptionsInfo].color else []
 
     # shellcheck does not have a --fix mode that applies fixes for some violations while reporting others.
     # So we must run an action to generate the report separately from an action that writes the human-readable report.

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -79,14 +79,15 @@ def _shellcheck_aspect_impl(target, ctx):
         noop_lint_action(ctx, outputs)
         return [info]
 
+    color_args = ["--color"] if ctx.attr._options[LintOptionsInfo].color else {}
+
     # shellcheck does not have a --fix mode that applies fixes for some violations while reporting others.
     # So we must run an action to generate the report separately from an action that writes the human-readable report.
     if hasattr(outputs, "patch"):
         discard_exit_code = ctx.actions.declare_file(_OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "patch_exit_code"))
         shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, outputs.patch, discard_exit_code, ["--format", "diff"])
 
-    # TODO(#332): the human action should run with color enabled
-    shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, outputs.human.out, outputs.human.exit_code)
+    shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, outputs.human.out, outputs.human.exit_code, color_args)
     shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, outputs.machine.out, outputs.machine.exit_code)
 
     return [info]

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -79,7 +79,7 @@ def _shellcheck_aspect_impl(target, ctx):
         noop_lint_action(ctx, outputs)
         return [info]
 
-    color_args = ["--color"] if ctx.attr._options[LintOptionsInfo].color else []
+    color_options = ["--color"] if ctx.attr._options[LintOptionsInfo].color else []
 
     # shellcheck does not have a --fix mode that applies fixes for some violations while reporting others.
     # So we must run an action to generate the report separately from an action that writes the human-readable report.
@@ -87,7 +87,7 @@ def _shellcheck_aspect_impl(target, ctx):
         discard_exit_code = ctx.actions.declare_file(_OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "patch_exit_code"))
         shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, outputs.patch, discard_exit_code, ["--format", "diff"])
 
-    shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, outputs.human.out, outputs.human.exit_code, color_args)
+    shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, outputs.human.out, outputs.human.exit_code, color_options)
     shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, outputs.machine.out, outputs.machine.exit_code)
 
     return [info]


### PR DESCRIPTION
Demo with

```shell
example % ./lint.sh src:ts src:hello_kt src:md src:hello_shell src:unused_import src:foo
```

![Screenshot 2024-07-17 at 12 05 41 PM](https://github.com/user-attachments/assets/ec40a329-8f22-4e6e-9068-28368bb9654d)

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

The human-readable report now includes colored output. Set `--no@aspect_rules_lint//lint:color` to inhibit this.
