### PR TITLE
fix: connect eslint --debug

### DIFF
--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -104,8 +104,8 @@ def eslint_action(ctx, executable, srcs, stdout, exit_code = None, format = "sty
     args.add("--no-warn-ignored")
     file_inputs = [ctx.attr._workaround_17660]
 
-    # TODO: enable if debug config, similar to rules_ts
-    # args.add("--debug")
+    if ctx.attr._options[LintOptionsInfo].debug:
+        args.add("--debug")
     if type(format) == "string":
         args.add_all(["--format", format])
     else:


### PR DESCRIPTION
The LintOptionsInfo provider tracks a debug setting that should enable debug level logging for linters that support it. A TODO was left in the eslint.bzl noting the missing integration. This is now added by conditionally adding the --debug flag to the eslint args.

---

### Changes are visible to end-users: yes

This fixes integration via `--@aspect_rules_lint//lint:debug`

### Test plan

I don't believe any existing automated cases check the debug bool. I did confirm that when enabled in examples it writes the logs out to STDOUT. 