### PR TITLE
fix: lint.sh script --fix flag

### DIFF
--- a/example/lint.sh
+++ b/example/lint.sh
@@ -81,12 +81,8 @@ fi
 bazel build ${args[@]} $@
 
 # TODO: Maybe this could be hermetic with bazel run @aspect_bazel_lib//tools:jq or sth
-if [ $machine == "Windows" ]; then
-    # jq on windows outputs CRLF which breaks this script. https://github.com/jqlang/jq/issues/92
-    valid_reports=$(jq --arg ext .out --raw-output "$filter" "$buildevents" | tr -d '\r')
-else
-    valid_reports=$(jq --arg ext .out --raw-output "$filter" "$buildevents")
-fi
+# jq on windows outputs CRLF which breaks this script. https://github.com/jqlang/jq/issues/92
+valid_reports=$(jq --arg ext .out --raw-output "$filter" "$buildevents" | tr -d '\r')
 
 # Show the results.
 while IFS= read -r report; do
@@ -101,7 +97,7 @@ while IFS= read -r report; do
 done <<<"$valid_reports"
 
 if [ -n "$fix" ]; then
-	valid_patches=$valid_reports
+	valid_patches=$(jq --arg ext .patch --raw-output "$filter" "$buildevents" | tr -d '\r')
 	while IFS= read -r patch; do
 		# Exclude coverage, and check if the patch is empty.
 		if [[ "$patch" == *coverage.dat ]] || [[ ! -s "$patch" ]]; then


### PR DESCRIPTION
It was broken because it used the wrong file as the patch. See https://github.com/aspect-build/rules_lint/commit/7a14cfdee5f97ae6ad9f3fda66fa83f4094b79a6#r144358642

Note, this might mean we should add some automated testing for `lint.sh` - but I'd rather spend time on the `aspect lint` command.

---

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:

```
example % ./lint.sh --fix --dry-run src:ts     
From bazel-out/darwin_arm64-fastbuild/bin/src/ts.AspectRulesLintESLint.out:

/private/var/folders/8n/7cfngjb106sgwb8mr1tytx700000gn/T/rules_lint_patcher-pgLeXz/_main/bazel-out/darwin_arm64-fastbuild/bin/src/file.ts
  7:1  error  Unnecessary try/catch wrapper  no-useless-catch

✖ 1 problem (1 error, 0 warnings)


From bazel-out/darwin_arm64-fastbuild/bin/src/ts.AspectRulesLintESLint.patch:
--- a/src/file.ts
+++ b/src/file.ts
@@ -1,5 +1,5 @@
 // this is a linting violation, and is auto-fixed under `--fix`
-const a: string = "a";
+const a = "a";
 console.log(a);
 
 // linting violation; not auto-fixable
```