### PR TITLE
Add C example and file extension.

### DIFF
--- a/docs/format.md
+++ b/docs/format.md
@@ -47,7 +47,7 @@ format_multirun(
 ## languages
 
 <pre>
-languages(<a href="#languages-name">name</a>, <a href="#languages-cc">cc</a>, <a href="#languages-css">css</a>, <a href="#languages-cuda">cuda</a>, <a href="#languages-go">go</a>, <a href="#languages-graphql">graphql</a>, <a href="#languages-html">html</a>, <a href="#languages-java">java</a>, <a href="#languages-javascript">javascript</a>, <a href="#languages-jsonnet">jsonnet</a>, <a href="#languages-kotlin">kotlin</a>, <a href="#languages-markdown">markdown</a>,
+languages(<a href="#languages-name">name</a>, <a href="#languages-c">c</a>, <a href="#languages-cc">cc</a>, <a href="#languages-css">css</a>, <a href="#languages-cuda">cuda</a>, <a href="#languages-go">go</a>, <a href="#languages-graphql">graphql</a>, <a href="#languages-html">html</a>, <a href="#languages-java">java</a>, <a href="#languages-javascript">javascript</a>, <a href="#languages-jsonnet">jsonnet</a>, <a href="#languages-kotlin">kotlin</a>, <a href="#languages-markdown">markdown</a>,
           <a href="#languages-protocol_buffer">protocol_buffer</a>, <a href="#languages-python">python</a>, <a href="#languages-rust">rust</a>, <a href="#languages-scala">scala</a>, <a href="#languages-shell">shell</a>, <a href="#languages-sql">sql</a>, <a href="#languages-starlark">starlark</a>, <a href="#languages-swift">swift</a>, <a href="#languages-terraform">terraform</a>, <a href="#languages-yaml">yaml</a>)
 </pre>
 
@@ -70,6 +70,7 @@ Some languages have dialects:
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="languages-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="languages-c"></a>c |  a <code>clang-format</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="languages-cc"></a>cc |  a <code>clang-format</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="languages-css"></a>css |  a <code>prettier</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="languages-cuda"></a>cuda |  a <code>clang-format</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |

--- a/example/src/BUILD.bazel
+++ b/example/src/BUILD.bazel
@@ -78,6 +78,11 @@ cc_binary(
     srcs = ["hello.cpp"],
 )
 
+cc_binary(
+    name = "hello_c",
+    srcs = ["hello.c"],
+)
+
 kt_jvm_library(
     name = "hello_kt",
     srcs = ["hello.kt"],

--- a/example/src/hello.c
+++ b/example/src/hello.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// deliberately bad code to trigger clang-tidy warning
+int string_to_int(const char *num) { return atoi(num); }
+
+// deliberately insecure code to trigger clang-tidy warning
+void ls() { system("ls"); }
+
+static int compare(int x, int y) {
+  if (x < y)
+    ;
+  { x++; }
+  return x;
+}
+
+int main() {
+  printf("Hello, world!\n");
+  compare(3, 4);
+  char *a = NULL;
+  char *b = 0;
+}

--- a/example/tools/format/BUILD.bazel
+++ b/example/tools/format/BUILD.bazel
@@ -57,6 +57,7 @@ java_binary(
 
 format_multirun(
     name = "format",
+    c = "@llvm_toolchain_llvm//:bin/clang-format",
     cc = "@llvm_toolchain_llvm//:bin/clang-format",
     css = ":prettier",
     cuda = "@llvm_toolchain_llvm//:bin/clang-format",

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -66,7 +66,8 @@ function ls-files {
     # https://github.com/github-linguist/linguist/blob/559a6426942abcae16b6d6b328147476432bf6cb/lib/linguist/languages.yml
     # using the ./mirror_linguist_languages.sh tool to transform to Bash code
     case "$language" in
-      'C++') patterns=('*.c' '*.cpp' '*.c++' '*.cc' '*.cp' '*.cppm' '*.cxx' '*.h' '*.h++' '*.hh' '*.hpp' '*.hxx' '*.inc' '*.inl' '*.ino' '*.ipp' '*.ixx' '*.re' '*.tcc' '*.tpp' '*.txx') ;;
+      'C') patterns=('*.c' '*.cats' '*.h' '*.idc') ;;
+      'C++') patterns=('*.cpp' '*.c++' '*.cc' '*.cp' '*.cppm' '*.cxx' '*.h' '*.h++' '*.hh' '*.hpp' '*.hxx' '*.inc' '*.inl' '*.ino' '*.ipp' '*.ixx' '*.re' '*.tcc' '*.tpp' '*.txx') ;;
       'Cuda') patterns=('*.cu' '*.cuh') ;;
       'CSS') patterns=('*.css') ;;
       'Go') patterns=('*.go') ;;

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -66,7 +66,7 @@ function ls-files {
     # https://github.com/github-linguist/linguist/blob/559a6426942abcae16b6d6b328147476432bf6cb/lib/linguist/languages.yml
     # using the ./mirror_linguist_languages.sh tool to transform to Bash code
     case "$language" in
-      'C++') patterns=('*.cpp' '*.c++' '*.cc' '*.cp' '*.cppm' '*.cxx' '*.h' '*.h++' '*.hh' '*.hpp' '*.hxx' '*.inc' '*.inl' '*.ino' '*.ipp' '*.ixx' '*.re' '*.tcc' '*.tpp' '*.txx') ;;
+      'C++') patterns=('*.c' '*.cpp' '*.c++' '*.cc' '*.cp' '*.cppm' '*.cxx' '*.h' '*.h++' '*.hh' '*.hpp' '*.hxx' '*.inc' '*.inl' '*.ino' '*.ipp' '*.ixx' '*.re' '*.tcc' '*.tpp' '*.txx') ;;
       'Cuda') patterns=('*.cu' '*.cuh') ;;
       'CSS') patterns=('*.css') ;;
       'Go') patterns=('*.go') ;;

--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -21,6 +21,7 @@ TOOLS = {
     "SQL": "prettier",
     "Shell": "shfmt",
     "Protocol Buffer": "buf",
+    "C": "clang-format",
     "C++": "clang-format",
     "Cuda": "clang-format",
     "YAML": "yamlfmt",


### PR DESCRIPTION
This adds `clang-format` support for C files `*.c`.  `clang-tidy` support already works correctly for `cc_*` targets with C sources.

It wasn't clear the best way to add `*.c` to `format.sh` given how it seems the output of `mirror_linguist_languages.sh` is manually copied over.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
  - Given how `cc_*` targets silently handle C and C++ users likely already expect C support.
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes
  - Add support for formatting C files.

### Test plan

- New test cases added
