### PR TITLE
chore: update bazel-lib version in WORKSPACE snippet

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -38,13 +38,14 @@ http_archive(
     url = "https://github.com/aspect-build/rules_lint/releases/download/${TAG}/${ARCHIVE}",
 )
 
-# aspect_rules_lint depends on aspect_bazel_lib. Either 1.x or 2.x works.
+# aspect_rules_lint depends on aspect_bazel_lib.
 http_archive(
     name = "aspect_bazel_lib",
-    sha256 = "979667bb7276ee8fcf2c114c9be9932b9a3052a64a647e0dcaacfb9c0016f0a3",
-    strip_prefix = "bazel-lib-2.4.1",
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.4.1/bazel-lib-v2.4.1.tar.gz",
+    sha256 = "f5ea76682b209cc0bd90d0f5a3b26d2f7a6a2885f0c5f615e72913f4805dbb0d",
+    strip_prefix = "bazel-lib-2.5.0",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.5.0/bazel-lib-v2.5.0.tar.gz",
 )
+
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
 
 # aspect_bazel_lib depends on bazel_skylib


### PR DESCRIPTION
Now it matches the version in MODULE.bazel.

Fixes #351
