### PR TITLE
fix: filter out 'external' sources from linting

### DIFF
--- a/lint/private/lint_aspect.bzl
+++ b/lint/private/lint_aspect.bzl
@@ -124,7 +124,7 @@ def filter_srcs(rule):
     if "lint-genfiles" in rule.attr.tags:
         return rule.files.srcs
     else:
-        return [s for s in rule.files.srcs if s.is_source]
+        return [s for s in rule.files.srcs if s.is_source and s.owner.workspace_name == ""]
 
 def noop_lint_action(ctx, outputs):
     """Action that creates expected outputs when no files are provided to a lint action.


### PR DESCRIPTION
Fixes #346

Note, I haven't added a test here since I didn't figure out how to repro yet. Would take a few brain cycles, maybe worth doing if the reviewer wants it.