### PR TITLE
chore(deps): bump bazel-lib minimum

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -41,9 +41,9 @@ http_archive(
 # aspect_rules_lint depends on aspect_bazel_lib.
 http_archive(
     name = "aspect_bazel_lib",
-    sha256 = "f5ea76682b209cc0bd90d0f5a3b26d2f7a6a2885f0c5f615e72913f4805dbb0d",
-    strip_prefix = "bazel-lib-2.5.0",
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.5.0/bazel-lib-v2.5.0.tar.gz",
+    sha256 = "6d758a8f646ecee7a3e294fbe4386daafbe0e5966723009c290d493f227c390b",
+    strip_prefix = "bazel-lib-2.7.7",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.7.7/bazel-lib-v2.7.7.tar.gz",
 )
 
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.5.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
 
 # Needed in the root because we use js_lib_helpers in our aspect impl
 # Minimum version needs 'chore: bump bazel-lib to 2.0 by @alexeagle in #1311'
@@ -28,12 +28,6 @@ multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitoo
 multitool.hub(lockfile = "//format:multitool.lock.json")
 multitool.hub(lockfile = "//lint:multitool.lock.json")
 use_repo(multitool, "multitool")
-
-# Locally, use newer bazel-lib for stardoc
-single_version_override(
-    module_name = "aspect_bazel_lib",
-    version = "2.7.7",
-)
 
 # 0.5.4 is the first version with bzlmod support
 bazel_dep(name = "stardoc", version = "0.5.4", dev_dependency = True, repo_name = "io_bazel_stardoc")


### PR DESCRIPTION
We used a single_version_override locally which makes it hard to repro what users see. Note that the example was already on 2.7.7, this just lines them up.

Fixes #351
