### PR TITLE
Fix crash caused by fail-on-violation and no lintable files in target

### DIFF
--- a/lint/private/lint_aspect.bzl
+++ b/lint/private/lint_aspect.bzl
@@ -140,11 +140,17 @@ def noop_lint_action(ctx, outputs):
     commands.append("touch {}".format(outputs.human.out.path))
     commands.append("touch {}".format(outputs.machine.out.path))
 
-    # NB: if we write JSON machine-readable outputs, then an empty file won't be appropriate
-    commands.append("echo 0 > {}".format(outputs.human.exit_code.path))
-    commands.append("echo 0 > {}".format(outputs.machine.exit_code.path))
+    outs = [outputs.human.out, outputs.machine.out]
 
-    outs = [outputs.human.out, outputs.human.exit_code, outputs.machine.out, outputs.machine.exit_code]
+    # NB: if we write JSON machine-readable outputs, then an empty file won't be appropriate
+    if outputs.human.exit_code:
+      commands.append("echo 0 > {}".format(outputs.human.exit_code.path))
+      outs += [outputs.human.exit_code]
+
+    if outputs.machine.exit_code:
+      commands.append("echo 0 > {}".format(outputs.machine.exit_code.path))
+      outs += [outputs.machine.exit_code]
+
     if hasattr(outputs, "patch"):
         commands.append("touch {}".format(outputs.patch.path))
         outs.append(outputs.patch)


### PR DESCRIPTION
#331 introduced a bug where the noop lint fails if running with fail on validation. 

If we have a lint aspect that has no files to lint and run with fail-on-validation the exit_code file will be set to None. Which is why we need to check that its not None before trying to access its path.

Relevant error
```
Traceback (most recent call last):
        File "/home/tokongs/.cache/bazel/_bazel_tokongs/51d0d670cf09bb319bf1151bdc73a969/external/aspect_rules_lint~/lint/ruff.bzl", line 165, column 25, in _ruff_aspect_impl
                noop_lint_action(ctx, outputs)
        File "/home/tokongs/.cache/bazel/_bazel_tokongs/51d0d670cf09bb319bf1151bdc73a969/external/aspect_rules_lint~/lint/private/lint_aspect.bzl", line 144, column 65, in noop_lint_action
                commands.append("echo 0 > {}".format(outputs.human.exit_code.path))
Error: 'NoneType' value has no field or method 'path'
```

---

### Changes are visible to end-users: yes
- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Suggested release notes:  fix crash caused by noop lints running with fail-on-validation
