### PR TITLE
chore: update stardoc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,10 +24,11 @@ jobs:
       # Don't try for Windows support yet.
       exclude_windows: true
       # Root module is bzlmod-only and uses newer stardoc that requires Bazel 7.
+      # Example uses incompatible_enable_proto_toolchain_resolution
       exclude: |
         [
           {"bzlmodEnabled": false, "folder": "."},
-          {"bazelversion": "6.4.0", "folder": "."}
+          {"bazelversion": "6.4.0"}
         ]
 
   integration-test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,14 +21,13 @@ jobs:
     uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v6
     with:
       folders: '[".", "example"]'
-      # Root module is bzlmod-only.
       # Don't try for Windows support yet.
-      # Example uses a bazel7-only flag.
+      exclude_windows: true
+      # Root module is bzlmod-only and uses newer stardoc that requires Bazel 7.
       exclude: |
         [
           {"bzlmodEnabled": false, "folder": "."},
-          {"os": "windows-latest"},
-          {"bazelversion": "6.4.0", "folder": "example"}
+          {"bazelversion": "6.4.0", "folder": "."}
         ]
 
   integration-test:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,5 +29,4 @@ multitool.hub(lockfile = "//format:multitool.lock.json")
 multitool.hub(lockfile = "//lint:multitool.lock.json")
 use_repo(multitool, "multitool")
 
-# 0.5.4 is the first version with bzlmod support
-bazel_dep(name = "stardoc", version = "0.5.4", dev_dependency = True, repo_name = "io_bazel_stardoc")
+bazel_dep(name = "stardoc", version = "0.7.0", dev_dependency = True, repo_name = "io_bazel_stardoc")

--- a/docs/buf.md
+++ b/docs/buf.md
@@ -12,12 +12,13 @@ buf = buf_lint_aspect(
 )
 ```
 
-
 <a id="buf_lint_action"></a>
 
 ## buf_lint_action
 
 <pre>
+load("@aspect_rules_lint//lint:buf.bzl", "buf_lint_action")
+
 buf_lint_action(<a href="#buf_lint_action-ctx">ctx</a>, <a href="#buf_lint_action-buf">buf</a>, <a href="#buf_lint_action-protoc">protoc</a>, <a href="#buf_lint_action-target">target</a>, <a href="#buf_lint_action-stderr">stderr</a>, <a href="#buf_lint_action-exit_code">exit_code</a>)
 </pre>
 
@@ -33,7 +34,7 @@ Runs the buf lint tool as a Bazel action.
 | <a id="buf_lint_action-protoc"></a>protoc |  the protoc executable   |  none |
 | <a id="buf_lint_action-target"></a>target |  the proto_library target to run on   |  none |
 | <a id="buf_lint_action-stderr"></a>stderr |  output file containing the stderr of protoc   |  none |
-| <a id="buf_lint_action-exit_code"></a>exit_code |  output file to write the exit code. If None, then fail the build when protoc exits non-zero.   |  <code>None</code> |
+| <a id="buf_lint_action-exit_code"></a>exit_code |  output file to write the exit code. If None, then fail the build when protoc exits non-zero.   |  `None` |
 
 
 <a id="lint_buf_aspect"></a>
@@ -41,6 +42,8 @@ Runs the buf lint tool as a Bazel action.
 ## lint_buf_aspect
 
 <pre>
+load("@aspect_rules_lint//lint:buf.bzl", "lint_buf_aspect")
+
 lint_buf_aspect(<a href="#lint_buf_aspect-config">config</a>, <a href="#lint_buf_aspect-toolchain">toolchain</a>, <a href="#lint_buf_aspect-rule_kinds">rule_kinds</a>)
 </pre>
 
@@ -52,7 +55,7 @@ A factory function to create a linter aspect.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="lint_buf_aspect-config"></a>config |  label of the the buf.yaml file   |  none |
-| <a id="lint_buf_aspect-toolchain"></a>toolchain |  override the default toolchain of the protoc-gen-buf-lint tool   |  <code>"@rules_buf//tools/protoc-gen-buf-lint:toolchain_type"</code> |
-| <a id="lint_buf_aspect-rule_kinds"></a>rule_kinds |  which [kinds](https://bazel.build/query/language#kind) of rules should be visited by the aspect   |  <code>["proto_library"]</code> |
+| <a id="lint_buf_aspect-toolchain"></a>toolchain |  override the default toolchain of the protoc-gen-buf-lint tool   |  `"@rules_buf//tools/protoc-gen-buf-lint:toolchain_type"` |
+| <a id="lint_buf_aspect-rule_kinds"></a>rule_kinds |  which [kinds](https://bazel.build/query/language#kind) of rules should be visited by the aspect   |  `["proto_library"]` |
 
 

--- a/docs/clang-tidy.md
+++ b/docs/clang-tidy.md
@@ -38,12 +38,13 @@ clang_tidy = lint_clang_tidy_aspect(
 )
 ```
 
-
 <a id="clang_tidy_action"></a>
 
 ## clang_tidy_action
 
 <pre>
+load("@aspect_rules_lint//lint:clang_tidy.bzl", "clang_tidy_action")
+
 clang_tidy_action(<a href="#clang_tidy_action-ctx">ctx</a>, <a href="#clang_tidy_action-compilation_context">compilation_context</a>, <a href="#clang_tidy_action-executable">executable</a>, <a href="#clang_tidy_action-srcs">srcs</a>, <a href="#clang_tidy_action-stdout">stdout</a>, <a href="#clang_tidy_action-exit_code">exit_code</a>)
 </pre>
 
@@ -71,6 +72,8 @@ https://clang.llvm.org/extra/clang-tidy/
 ## clang_tidy_fix
 
 <pre>
+load("@aspect_rules_lint//lint:clang_tidy.bzl", "clang_tidy_fix")
+
 clang_tidy_fix(<a href="#clang_tidy_fix-ctx">ctx</a>, <a href="#clang_tidy_fix-compilation_context">compilation_context</a>, <a href="#clang_tidy_fix-executable">executable</a>, <a href="#clang_tidy_fix-srcs">srcs</a>, <a href="#clang_tidy_fix-patch">patch</a>, <a href="#clang_tidy_fix-stdout">stdout</a>, <a href="#clang_tidy_fix-exit_code">exit_code</a>)
 </pre>
 
@@ -95,6 +98,8 @@ Create a Bazel Action that spawns clang-tidy with --fix.
 ## is_parent_in_list
 
 <pre>
+load("@aspect_rules_lint//lint:clang_tidy.bzl", "is_parent_in_list")
+
 is_parent_in_list(<a href="#is_parent_in_list-dir">dir</a>, <a href="#is_parent_in_list-list">list</a>)
 </pre>
 
@@ -114,6 +119,8 @@ is_parent_in_list(<a href="#is_parent_in_list-dir">dir</a>, <a href="#is_parent_
 ## lint_clang_tidy_aspect
 
 <pre>
+load("@aspect_rules_lint//lint:clang_tidy.bzl", "lint_clang_tidy_aspect")
+
 lint_clang_tidy_aspect(<a href="#lint_clang_tidy_aspect-binary">binary</a>, <a href="#lint_clang_tidy_aspect-configs">configs</a>, <a href="#lint_clang_tidy_aspect-global_config">global_config</a>, <a href="#lint_clang_tidy_aspect-header_filter">header_filter</a>, <a href="#lint_clang_tidy_aspect-lint_target_headers">lint_target_headers</a>,
                        <a href="#lint_clang_tidy_aspect-angle_includes_are_system">angle_includes_are_system</a>, <a href="#lint_clang_tidy_aspect-verbose">verbose</a>)
 </pre>
@@ -125,12 +132,12 @@ A factory function to create a linter aspect.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="lint_clang_tidy_aspect-binary"></a>binary |  the clang-tidy binary, typically a rule like<br><br><pre><code>starlark native_binary(     name = "clang_tidy",     src = "clang-tidy.exe"     out = "clang_tidy", ) </code></pre>   |  none |
-| <a id="lint_clang_tidy_aspect-configs"></a>configs |  labels of the .clang-tidy files to make available to clang-tidy's config search. These may be in subdirectories and clang-tidy will apply them if appropriate. This may also include .clang-format files which may be used for formatting fixes.   |  <code>[]</code> |
-| <a id="lint_clang_tidy_aspect-global_config"></a>global_config |  label of a single global .clang-tidy file to pass to clang-tidy on the command line. This will cause clang-tidy to ignore any other config files in the source directories.   |  <code>[]</code> |
-| <a id="lint_clang_tidy_aspect-header_filter"></a>header_filter |  optional, set to a posix regex to supply to clang-tidy with the -header-filter option   |  <code>""</code> |
-| <a id="lint_clang_tidy_aspect-lint_target_headers"></a>lint_target_headers |  optional, set to True to pass a pattern that includes all headers with the target's directory prefix. This crude control may include headers from the linted target in the results. If supplied, overrides the header_filter option.   |  <code>False</code> |
-| <a id="lint_clang_tidy_aspect-angle_includes_are_system"></a>angle_includes_are_system |  controls how angle includes are passed to clang-tidy. By default, Bazel passes these as -isystem. Change this to False to pass these as -I, which allows clang-tidy to regard them as regular header files.   |  <code>True</code> |
-| <a id="lint_clang_tidy_aspect-verbose"></a>verbose |  print debug messages including clang-tidy command lines being invoked.   |  <code>False</code> |
+| <a id="lint_clang_tidy_aspect-binary"></a>binary |  the clang-tidy binary, typically a rule like<br><br><pre><code class="language-starlark">native_binary(&#10;    name = "clang_tidy",&#10;    src = "clang-tidy.exe"&#10;    out = "clang_tidy",&#10;)</code></pre>   |  none |
+| <a id="lint_clang_tidy_aspect-configs"></a>configs |  labels of the .clang-tidy files to make available to clang-tidy's config search. These may be in subdirectories and clang-tidy will apply them if appropriate. This may also include .clang-format files which may be used for formatting fixes.   |  `[]` |
+| <a id="lint_clang_tidy_aspect-global_config"></a>global_config |  label of a single global .clang-tidy file to pass to clang-tidy on the command line. This will cause clang-tidy to ignore any other config files in the source directories.   |  `[]` |
+| <a id="lint_clang_tidy_aspect-header_filter"></a>header_filter |  optional, set to a posix regex to supply to clang-tidy with the -header-filter option   |  `""` |
+| <a id="lint_clang_tidy_aspect-lint_target_headers"></a>lint_target_headers |  optional, set to True to pass a pattern that includes all headers with the target's directory prefix. This crude control may include headers from the linted target in the results. If supplied, overrides the header_filter option.   |  `False` |
+| <a id="lint_clang_tidy_aspect-angle_includes_are_system"></a>angle_includes_are_system |  controls how angle includes are passed to clang-tidy. By default, Bazel passes these as -isystem. Change this to False to pass these as -I, which allows clang-tidy to regard them as regular header files.   |  `True` |
+| <a id="lint_clang_tidy_aspect-verbose"></a>verbose |  print debug messages including clang-tidy command lines being invoked.   |  `False` |
 
 

--- a/docs/eslint.md
+++ b/docs/eslint.md
@@ -54,12 +54,13 @@ eslint_test(
 
 See the [react example](https://github.com/bazelbuild/examples/blob/b498bb106b2028b531ceffbd10cc89530814a177/frontend/react/src/BUILD.bazel#L86-L92)
 
-
 <a id="eslint_action"></a>
 
 ## eslint_action
 
 <pre>
+load("@aspect_rules_lint//lint:eslint.bzl", "eslint_action")
+
 eslint_action(<a href="#eslint_action-ctx">ctx</a>, <a href="#eslint_action-executable">executable</a>, <a href="#eslint_action-srcs">srcs</a>, <a href="#eslint_action-stdout">stdout</a>, <a href="#eslint_action-exit_code">exit_code</a>, <a href="#eslint_action-format">format</a>, <a href="#eslint_action-env">env</a>)
 </pre>
 
@@ -78,9 +79,9 @@ https://eslint.org/docs/latest/use/command-line-interface
 | <a id="eslint_action-executable"></a>executable |  struct with an eslint field   |  none |
 | <a id="eslint_action-srcs"></a>srcs |  list of file objects to lint   |  none |
 | <a id="eslint_action-stdout"></a>stdout |  output file containing the stdout or --output-file of eslint   |  none |
-| <a id="eslint_action-exit_code"></a>exit_code |  output file containing the exit code of eslint. If None, then fail the build when eslint exits non-zero.   |  <code>None</code> |
-| <a id="eslint_action-format"></a>format |  value for eslint <code>--format</code> CLI flag   |  <code>"stylish"</code> |
-| <a id="eslint_action-env"></a>env |  environment variables for eslint   |  <code>{}</code> |
+| <a id="eslint_action-exit_code"></a>exit_code |  output file containing the exit code of eslint. If None, then fail the build when eslint exits non-zero.   |  `None` |
+| <a id="eslint_action-format"></a>format |  value for eslint `--format` CLI flag   |  `"stylish"` |
+| <a id="eslint_action-env"></a>env |  environment variables for eslint   |  `{}` |
 
 
 <a id="eslint_fix"></a>
@@ -88,6 +89,8 @@ https://eslint.org/docs/latest/use/command-line-interface
 ## eslint_fix
 
 <pre>
+load("@aspect_rules_lint//lint:eslint.bzl", "eslint_fix")
+
 eslint_fix(<a href="#eslint_fix-ctx">ctx</a>, <a href="#eslint_fix-executable">executable</a>, <a href="#eslint_fix-srcs">srcs</a>, <a href="#eslint_fix-patch">patch</a>, <a href="#eslint_fix-stdout">stdout</a>, <a href="#eslint_fix-exit_code">exit_code</a>, <a href="#eslint_fix-format">format</a>, <a href="#eslint_fix-env">env</a>)
 </pre>
 
@@ -104,8 +107,8 @@ Create a Bazel Action that spawns eslint with --fix.
 | <a id="eslint_fix-patch"></a>patch |  output file containing the applied fixes that can be applied with the patch(1) command.   |  none |
 | <a id="eslint_fix-stdout"></a>stdout |  output file containing the stdout or --output-file of eslint   |  none |
 | <a id="eslint_fix-exit_code"></a>exit_code |  output file containing the exit code of eslint   |  none |
-| <a id="eslint_fix-format"></a>format |  value for eslint <code>--format</code> CLI flag   |  <code>"stylish"</code> |
-| <a id="eslint_fix-env"></a>env |  environment variaables for eslint   |  <code>{}</code> |
+| <a id="eslint_fix-format"></a>format |  value for eslint `--format` CLI flag   |  `"stylish"` |
+| <a id="eslint_fix-env"></a>env |  environment variaables for eslint   |  `{}` |
 
 
 <a id="lint_eslint_aspect"></a>
@@ -113,6 +116,8 @@ Create a Bazel Action that spawns eslint with --fix.
 ## lint_eslint_aspect
 
 <pre>
+load("@aspect_rules_lint//lint:eslint.bzl", "lint_eslint_aspect")
+
 lint_eslint_aspect(<a href="#lint_eslint_aspect-binary">binary</a>, <a href="#lint_eslint_aspect-configs">configs</a>, <a href="#lint_eslint_aspect-rule_kinds">rule_kinds</a>)
 </pre>
 
@@ -123,8 +128,8 @@ A factory function to create a linter aspect.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="lint_eslint_aspect-binary"></a>binary |  the eslint binary, typically a rule like<br><br><pre><code> load("@npm//:eslint/package_json.bzl", eslint_bin = "bin") eslint_bin.eslint_binary(name = "eslint") </code></pre>   |  none |
+| <a id="lint_eslint_aspect-binary"></a>binary |  the eslint binary, typically a rule like<br><br><pre><code>load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")&#10;eslint_bin.eslint_binary(name = "eslint")</code></pre>   |  none |
 | <a id="lint_eslint_aspect-configs"></a>configs |  label(s) of the eslint config file(s)   |  none |
-| <a id="lint_eslint_aspect-rule_kinds"></a>rule_kinds |  which [kinds](https://bazel.build/query/language#kind) of rules should be visited by the aspect   |  <code>["js_library", "ts_project", "ts_project_rule"]</code> |
+| <a id="lint_eslint_aspect-rule_kinds"></a>rule_kinds |  which [kinds](https://bazel.build/query/language#kind) of rules should be visited by the aspect   |  `["js_library", "ts_project", "ts_project_rule"]` |
 
 

--- a/docs/flake8.md
+++ b/docs/flake8.md
@@ -27,12 +27,13 @@ flake8 = lint_flake8_aspect(
 )
 ```
 
-
 <a id="flake8_action"></a>
 
 ## flake8_action
 
 <pre>
+load("@aspect_rules_lint//lint:flake8.bzl", "flake8_action")
+
 flake8_action(<a href="#flake8_action-ctx">ctx</a>, <a href="#flake8_action-executable">executable</a>, <a href="#flake8_action-srcs">srcs</a>, <a href="#flake8_action-config">config</a>, <a href="#flake8_action-stdout">stdout</a>, <a href="#flake8_action-exit_code">exit_code</a>, <a href="#flake8_action-options">options</a>)
 </pre>
 
@@ -51,8 +52,8 @@ Based on https://flake8.pycqa.org/en/latest/user/invocation.html
 | <a id="flake8_action-srcs"></a>srcs |  python files to be linted   |  none |
 | <a id="flake8_action-config"></a>config |  label of the flake8 config file (setup.cfg, tox.ini, or .flake8)   |  none |
 | <a id="flake8_action-stdout"></a>stdout |  output file containing stdout of flake8   |  none |
-| <a id="flake8_action-exit_code"></a>exit_code |  output file containing exit code of flake8 If None, then fail the build when flake8 exits non-zero.   |  <code>None</code> |
-| <a id="flake8_action-options"></a>options |  additional command-line options, see https://flake8.pycqa.org/en/latest/user/options.html   |  <code>[]</code> |
+| <a id="flake8_action-exit_code"></a>exit_code |  output file containing exit code of flake8 If None, then fail the build when flake8 exits non-zero.   |  `None` |
+| <a id="flake8_action-options"></a>options |  additional command-line options, see https://flake8.pycqa.org/en/latest/user/options.html   |  `[]` |
 
 
 <a id="lint_flake8_aspect"></a>
@@ -60,6 +61,8 @@ Based on https://flake8.pycqa.org/en/latest/user/invocation.html
 ## lint_flake8_aspect
 
 <pre>
+load("@aspect_rules_lint//lint:flake8.bzl", "lint_flake8_aspect")
+
 lint_flake8_aspect(<a href="#lint_flake8_aspect-binary">binary</a>, <a href="#lint_flake8_aspect-config">config</a>, <a href="#lint_flake8_aspect-rule_kinds">rule_kinds</a>)
 </pre>
 
@@ -84,6 +87,6 @@ Attrs:
 | :------------- | :------------- | :------------- |
 | <a id="lint_flake8_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
 | <a id="lint_flake8_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
-| <a id="lint_flake8_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  <code>["py_binary", "py_library"]</code> |
+| <a id="lint_flake8_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  `["py_binary", "py_library"]` |
 
 

--- a/docs/format.md
+++ b/docs/format.md
@@ -41,12 +41,13 @@ format_multirun(
 [Prettier]: https://prettier.io/
 [multitool]: https://registry.bazel.build/modules/rules_multitool
 
-
 <a id="languages"></a>
 
 ## languages
 
 <pre>
+load("@aspect_rules_lint//format:defs.bzl", "languages")
+
 languages(<a href="#languages-name">name</a>, <a href="#languages-c">c</a>, <a href="#languages-cc">cc</a>, <a href="#languages-css">css</a>, <a href="#languages-cuda">cuda</a>, <a href="#languages-go">go</a>, <a href="#languages-graphql">graphql</a>, <a href="#languages-html">html</a>, <a href="#languages-java">java</a>, <a href="#languages-javascript">javascript</a>, <a href="#languages-jsonnet">jsonnet</a>, <a href="#languages-kotlin">kotlin</a>, <a href="#languages-markdown">markdown</a>,
           <a href="#languages-protocol_buffer">protocol_buffer</a>, <a href="#languages-python">python</a>, <a href="#languages-rust">rust</a>, <a href="#languages-scala">scala</a>, <a href="#languages-shell">shell</a>, <a href="#languages-sql">sql</a>, <a href="#languages-starlark">starlark</a>, <a href="#languages-swift">swift</a>, <a href="#languages-terraform">terraform</a>, <a href="#languages-yaml">yaml</a>)
 </pre>
@@ -63,35 +64,34 @@ Some languages have dialects:
 
 [GitHub Linguist]: https://github.com/github-linguist/linguist/blob/559a6426942abcae16b6d6b328147476432bf6cb/lib/linguist/languages.yml
 
-
 **ATTRIBUTES**
 
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="languages-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="languages-c"></a>c |  a <code>clang-format</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-cc"></a>cc |  a <code>clang-format</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-css"></a>css |  a <code>prettier</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-cuda"></a>cuda |  a <code>clang-format</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-go"></a>go |  a <code>gofmt</code> binary, or any other tool that has a matching command-line interface. Use <code>@aspect_rules_lint//format:gofumpt</code> to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-graphql"></a>graphql |  a <code>prettier</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-html"></a>html |  a <code>prettier</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-java"></a>java |  a <code>java-format</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-javascript"></a>javascript |  a <code>prettier</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-jsonnet"></a>jsonnet |  a <code>jsonnetfmt</code> binary, or any other tool that has a matching command-line interface. Use <code>@aspect_rules_lint//format:jsonnetfmt</code> to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-kotlin"></a>kotlin |  a <code>ktfmt</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-markdown"></a>markdown |  a <code>prettier</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-protocol_buffer"></a>protocol_buffer |  a <code>buf</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-python"></a>python |  a <code>ruff</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-rust"></a>rust |  a <code>rustfmt</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-scala"></a>scala |  a <code>scalafmt</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-shell"></a>shell |  a <code>shfmt</code> binary, or any other tool that has a matching command-line interface. Use <code>@aspect_rules_lint//format:shfmt</code> to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-sql"></a>sql |  a <code>prettier</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-starlark"></a>starlark |  a <code>buildifier</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-swift"></a>swift |  a <code>swiftformat</code> binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-terraform"></a>terraform |  a <code>terraform-fmt</code> binary, or any other tool that has a matching command-line interface. Use <code>@aspect_rules_lint//format:terraform</code> to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="languages-yaml"></a>yaml |  a <code>yamlfmt</code> binary, or any other tool that has a matching command-line interface. Use <code>@aspect_rules_lint//format:yamlfmt</code> to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="languages-c"></a>c |  a `clang-format` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-cc"></a>cc |  a `clang-format` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-css"></a>css |  a `prettier` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-cuda"></a>cuda |  a `clang-format` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-go"></a>go |  a `gofmt` binary, or any other tool that has a matching command-line interface. Use `@aspect_rules_lint//format:gofumpt` to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-graphql"></a>graphql |  a `prettier` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-html"></a>html |  a `prettier` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-java"></a>java |  a `java-format` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-javascript"></a>javascript |  a `prettier` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-jsonnet"></a>jsonnet |  a `jsonnetfmt` binary, or any other tool that has a matching command-line interface. Use `@aspect_rules_lint//format:jsonnetfmt` to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-kotlin"></a>kotlin |  a `ktfmt` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-markdown"></a>markdown |  a `prettier` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-protocol_buffer"></a>protocol_buffer |  a `buf` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-python"></a>python |  a `ruff` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-rust"></a>rust |  a `rustfmt` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-scala"></a>scala |  a `scalafmt` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-shell"></a>shell |  a `shfmt` binary, or any other tool that has a matching command-line interface. Use `@aspect_rules_lint//format:shfmt` to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-sql"></a>sql |  a `prettier` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-starlark"></a>starlark |  a `buildifier` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-swift"></a>swift |  a `swiftformat` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-terraform"></a>terraform |  a `terraform-fmt` binary, or any other tool that has a matching command-line interface. Use `@aspect_rules_lint//format:terraform` to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-yaml"></a>yaml |  a `yamlfmt` binary, or any other tool that has a matching command-line interface. Use `@aspect_rules_lint//format:yamlfmt` to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 
 
 <a id="format_multirun"></a>
@@ -99,6 +99,8 @@ Some languages have dialects:
 ## format_multirun
 
 <pre>
+load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
+
 format_multirun(<a href="#format_multirun-name">name</a>, <a href="#format_multirun-jobs">jobs</a>, <a href="#format_multirun-print_command">print_command</a>, <a href="#format_multirun-disable_git_attribute_checks">disable_git_attribute_checks</a>, <a href="#format_multirun-kwargs">kwargs</a>)
 </pre>
 
@@ -120,9 +122,9 @@ To check formatting with `bazel test`, use [format_test](#format_test) instead.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="format_multirun-name"></a>name |  name of the resulting target, typically "format"   |  none |
-| <a id="format_multirun-jobs"></a>jobs |  how many language formatters to spawn in parallel, ideally matching how many CPUs are available   |  <code>4</code> |
-| <a id="format_multirun-print_command"></a>print_command |  whether to print a progress message before calling the formatter of each language. Note that a line is printed for a formatter even if no files of that language are to be formatted.   |  <code>False</code> |
-| <a id="format_multirun-disable_git_attribute_checks"></a>disable_git_attribute_checks |  Set to True to disable honoring .gitattributes filters   |  <code>False</code> |
+| <a id="format_multirun-jobs"></a>jobs |  how many language formatters to spawn in parallel, ideally matching how many CPUs are available   |  `4` |
+| <a id="format_multirun-print_command"></a>print_command |  whether to print a progress message before calling the formatter of each language. Note that a line is printed for a formatter even if no files of that language are to be formatted.   |  `False` |
+| <a id="format_multirun-disable_git_attribute_checks"></a>disable_git_attribute_checks |  Set to True to disable honoring .gitattributes filters   |  `False` |
 | <a id="format_multirun-kwargs"></a>kwargs |  attributes named for each language; see [languages](#languages)   |  none |
 
 
@@ -131,6 +133,8 @@ To check formatting with `bazel test`, use [format_test](#format_test) instead.
 ## format_test
 
 <pre>
+load("@aspect_rules_lint//format:defs.bzl", "format_test")
+
 format_test(<a href="#format_test-name">name</a>, <a href="#format_test-srcs">srcs</a>, <a href="#format_test-workspace">workspace</a>, <a href="#format_test-no_sandbox">no_sandbox</a>, <a href="#format_test-disable_git_attribute_checks">disable_git_attribute_checks</a>, <a href="#format_test-tags">tags</a>, <a href="#format_test-kwargs">kwargs</a>)
 </pre>
 
@@ -148,11 +152,11 @@ To format with `bazel run`, see [format_multirun](#format_multirun).
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="format_test-name"></a>name |  name of the resulting target, typically "format"   |  none |
-| <a id="format_test-srcs"></a>srcs |  list of files to verify formatting. Required when no_sandbox is False.   |  <code>None</code> |
-| <a id="format_test-workspace"></a>workspace |  a file in the root directory to verify formatting. Required when no_sandbox is True. Typically <code>//:WORKSPACE</code> or <code>//:MODULE.bazel</code> may be used.   |  <code>None</code> |
-| <a id="format_test-no_sandbox"></a>no_sandbox |  Set to True to enable formatting all files in the workspace. This mode causes the test to be non-hermetic and it cannot be cached. Read the documentation in /docs/formatting.md.   |  <code>False</code> |
-| <a id="format_test-disable_git_attribute_checks"></a>disable_git_attribute_checks |  Set to True to disable honoring .gitattributes filters   |  <code>False</code> |
-| <a id="format_test-tags"></a>tags |  tags to apply to generated targets. In 'no_sandbox' mode, <code>["no-sandbox", "no-cache", "external"]</code> are added to the tags.   |  <code>[]</code> |
+| <a id="format_test-srcs"></a>srcs |  list of files to verify formatting. Required when no_sandbox is False.   |  `None` |
+| <a id="format_test-workspace"></a>workspace |  a file in the root directory to verify formatting. Required when no_sandbox is True. Typically `//:WORKSPACE` or `//:MODULE.bazel` may be used.   |  `None` |
+| <a id="format_test-no_sandbox"></a>no_sandbox |  Set to True to enable formatting all files in the workspace. This mode causes the test to be non-hermetic and it cannot be cached. Read the documentation in /docs/formatting.md.   |  `False` |
+| <a id="format_test-disable_git_attribute_checks"></a>disable_git_attribute_checks |  Set to True to disable honoring .gitattributes filters   |  `False` |
+| <a id="format_test-tags"></a>tags |  tags to apply to generated targets. In 'no_sandbox' mode, `["no-sandbox", "no-cache", "external"]` are added to the tags.   |  `[]` |
 | <a id="format_test-kwargs"></a>kwargs |  attributes named for each language; see [languages](#languages)   |  none |
 
 

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -51,12 +51,13 @@ ktlint = ktlint_aspect(
 
 If your custom ruleset is a third-party dependency and not a first-party dependency, you can also fetch it using `http_file` and use it instead.
 
-
 <a id="fetch_ktlint"></a>
 
 ## fetch_ktlint
 
 <pre>
+load("@aspect_rules_lint//lint:ktlint.bzl", "fetch_ktlint")
+
 fetch_ktlint()
 </pre>
 
@@ -69,11 +70,13 @@ fetch_ktlint()
 ## ktlint_action
 
 <pre>
+load("@aspect_rules_lint//lint:ktlint.bzl", "ktlint_action")
+
 ktlint_action(<a href="#ktlint_action-ctx">ctx</a>, <a href="#ktlint_action-executable">executable</a>, <a href="#ktlint_action-srcs">srcs</a>, <a href="#ktlint_action-editorconfig">editorconfig</a>, <a href="#ktlint_action-stdout">stdout</a>, <a href="#ktlint_action-baseline_file">baseline_file</a>, <a href="#ktlint_action-java_runtime">java_runtime</a>, <a href="#ktlint_action-ruleset_jar">ruleset_jar</a>,
               <a href="#ktlint_action-exit_code">exit_code</a>, <a href="#ktlint_action-options">options</a>)
 </pre>
 
- Runs ktlint as build action in Bazel.
+Runs ktlint as build action in Bazel.
 
 Adapter for wrapping Bazel around
 https://pinterest.github.io/ktlint/latest/install/cli/
@@ -91,9 +94,9 @@ https://pinterest.github.io/ktlint/latest/install/cli/
 | <a id="ktlint_action-stdout"></a>stdout |  :output:  the stdout of ktlint containing any violations found   |  none |
 | <a id="ktlint_action-baseline_file"></a>baseline_file |  The file object pointing to the baseline file used by ktlint.   |  none |
 | <a id="ktlint_action-java_runtime"></a>java_runtime |  The Java Runtime configured for this build, pulled from the registered toolchain.   |  none |
-| <a id="ktlint_action-ruleset_jar"></a>ruleset_jar |  An optional, custom ktlint ruleset jar.   |  <code>None</code> |
-| <a id="ktlint_action-exit_code"></a>exit_code |  output file to write the exit code. If None, then fail the build when ktlint exits non-zero.   |  <code>None</code> |
-| <a id="ktlint_action-options"></a>options |  additional command-line arguments to ktlint, see https://pinterest.github.io/ktlint/latest/install/cli/#miscellaneous-flags-and-commands   |  <code>[]</code> |
+| <a id="ktlint_action-ruleset_jar"></a>ruleset_jar |  An optional, custom ktlint ruleset jar.   |  `None` |
+| <a id="ktlint_action-exit_code"></a>exit_code |  output file to write the exit code. If None, then fail the build when ktlint exits non-zero.   |  `None` |
+| <a id="ktlint_action-options"></a>options |  additional command-line arguments to ktlint, see https://pinterest.github.io/ktlint/latest/install/cli/#miscellaneous-flags-and-commands   |  `[]` |
 
 
 <a id="lint_ktlint_aspect"></a>
@@ -101,6 +104,8 @@ https://pinterest.github.io/ktlint/latest/install/cli/
 ## lint_ktlint_aspect
 
 <pre>
+load("@aspect_rules_lint//lint:ktlint.bzl", "lint_ktlint_aspect")
+
 lint_ktlint_aspect(<a href="#lint_ktlint_aspect-binary">binary</a>, <a href="#lint_ktlint_aspect-editorconfig">editorconfig</a>, <a href="#lint_ktlint_aspect-baseline_file">baseline_file</a>, <a href="#lint_ktlint_aspect-ruleset_jar">ruleset_jar</a>, <a href="#lint_ktlint_aspect-rule_kinds">rule_kinds</a>)
 </pre>
 
@@ -114,8 +119,8 @@ A factory function to create a linter aspect.
 | <a id="lint_ktlint_aspect-binary"></a>binary |  a ktlint executable, provided as file typically through http_file declaration or using fetch_ktlint in your WORKSPACE.   |  none |
 | <a id="lint_ktlint_aspect-editorconfig"></a>editorconfig |  The label of the file pointing to the .editorconfig file used by ktlint.   |  none |
 | <a id="lint_ktlint_aspect-baseline_file"></a>baseline_file |  An optional attribute pointing to the label of the baseline file used by ktlint.   |  none |
-| <a id="lint_ktlint_aspect-ruleset_jar"></a>ruleset_jar |  An optional, custom ktlint ruleset provided as a fat jar, and works on top of the standard rules.   |  <code>None</code> |
-| <a id="lint_ktlint_aspect-rule_kinds"></a>rule_kinds |  which [kinds](https://bazel.build/query/language#kind) of rules should be visited by the aspect   |  <code>["kt_jvm_library", "kt_jvm_binary", "kt_js_library"]</code> |
+| <a id="lint_ktlint_aspect-ruleset_jar"></a>ruleset_jar |  An optional, custom ktlint ruleset provided as a fat jar, and works on top of the standard rules.   |  `None` |
+| <a id="lint_ktlint_aspect-rule_kinds"></a>rule_kinds |  which [kinds](https://bazel.build/query/language#kind) of rules should be visited by the aspect   |  `["kt_jvm_library", "kt_jvm_binary", "kt_js_library"]` |
 
 **RETURNS**
 

--- a/docs/lint_test.md
+++ b/docs/lint_test.md
@@ -36,12 +36,13 @@ flake8_test(
 )
 ```
 
-
 <a id="lint_test"></a>
 
 ## lint_test
 
 <pre>
+load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
+
 lint_test(<a href="#lint_test-aspect">aspect</a>)
 </pre>
 

--- a/docs/pmd.md
+++ b/docs/pmd.md
@@ -28,12 +28,13 @@ pmd = pmd_aspect(
 )
 ```
 
-
 <a id="fetch_pmd"></a>
 
 ## fetch_pmd
 
 <pre>
+load("@aspect_rules_lint//lint:pmd.bzl", "fetch_pmd")
+
 fetch_pmd()
 </pre>
 
@@ -46,6 +47,8 @@ fetch_pmd()
 ## lint_pmd_aspect
 
 <pre>
+load("@aspect_rules_lint//lint:pmd.bzl", "lint_pmd_aspect")
+
 lint_pmd_aspect(<a href="#lint_pmd_aspect-binary">binary</a>, <a href="#lint_pmd_aspect-rulesets">rulesets</a>, <a href="#lint_pmd_aspect-rule_kinds">rule_kinds</a>)
 </pre>
 
@@ -72,7 +75,7 @@ Attrs:
 | :------------- | :------------- | :------------- |
 | <a id="lint_pmd_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
 | <a id="lint_pmd_aspect-rulesets"></a>rulesets |  <p align="center"> - </p>   |  none |
-| <a id="lint_pmd_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  <code>["java_binary", "java_library"]</code> |
+| <a id="lint_pmd_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  `["java_binary", "java_library"]` |
 
 
 <a id="pmd_action"></a>
@@ -80,6 +83,8 @@ Attrs:
 ## pmd_action
 
 <pre>
+load("@aspect_rules_lint//lint:pmd.bzl", "pmd_action")
+
 pmd_action(<a href="#pmd_action-ctx">ctx</a>, <a href="#pmd_action-executable">executable</a>, <a href="#pmd_action-srcs">srcs</a>, <a href="#pmd_action-rulesets">rulesets</a>, <a href="#pmd_action-stdout">stdout</a>, <a href="#pmd_action-exit_code">exit_code</a>, <a href="#pmd_action-options">options</a>)
 </pre>
 
@@ -98,7 +103,7 @@ Based on https://docs.pmd-code.org/latest/pmd_userdocs_installation.html#running
 | <a id="pmd_action-srcs"></a>srcs |  java files to be linted   |  none |
 | <a id="pmd_action-rulesets"></a>rulesets |  list of labels of the PMD ruleset files   |  none |
 | <a id="pmd_action-stdout"></a>stdout |  output file to generate   |  none |
-| <a id="pmd_action-exit_code"></a>exit_code |  output file to write the exit code. If None, then fail the build when PMD exits non-zero.   |  <code>None</code> |
-| <a id="pmd_action-options"></a>options |  additional command-line options, see https://pmd.github.io/pmd/pmd_userdocs_cli_reference.html   |  <code>[]</code> |
+| <a id="pmd_action-exit_code"></a>exit_code |  output file to write the exit code. If None, then fail the build when PMD exits non-zero.   |  `None` |
+| <a id="pmd_action-options"></a>options |  additional command-line options, see https://pmd.github.io/pmd/pmd_userdocs_cli_reference.html   |  `[]` |
 
 

--- a/docs/ruff.md
+++ b/docs/ruff.md
@@ -48,35 +48,13 @@ ruff = lint_ruff_aspect(
 )
 ```
 
-
-<a id="ruff_workaround_20269"></a>
-
-## ruff_workaround_20269
-
-<pre>
-ruff_workaround_20269(<a href="#ruff_workaround_20269-name">name</a>, <a href="#ruff_workaround_20269-build_file_content">build_file_content</a>, <a href="#ruff_workaround_20269-repo_mapping">repo_mapping</a>, <a href="#ruff_workaround_20269-sha256">sha256</a>, <a href="#ruff_workaround_20269-strip_prefix">strip_prefix</a>, <a href="#ruff_workaround_20269-url">url</a>)
-</pre>
-
-Workaround for https://github.com/bazelbuild/bazel/issues/20269
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="ruff_workaround_20269-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="ruff_workaround_20269-build_file_content"></a>build_file_content |  -   | String | optional | <code>""</code> |
-| <a id="ruff_workaround_20269-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | required |  |
-| <a id="ruff_workaround_20269-sha256"></a>sha256 |  -   | String | optional | <code>""</code> |
-| <a id="ruff_workaround_20269-strip_prefix"></a>strip_prefix |  unlike http_archive, any value causes us to pass --strip-components=1 to tar   | String | optional | <code>""</code> |
-| <a id="ruff_workaround_20269-url"></a>url |  -   | String | optional | <code>""</code> |
-
-
 <a id="fetch_ruff"></a>
 
 ## fetch_ruff
 
 <pre>
+load("@aspect_rules_lint//lint:ruff.bzl", "fetch_ruff")
+
 fetch_ruff(<a href="#fetch_ruff-tag">tag</a>)
 </pre>
 
@@ -90,7 +68,7 @@ Allows the user to select a particular ruff version, rather than get whatever is
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="fetch_ruff-tag"></a>tag |  a tag of ruff that we have mirrored, e.g. <code>v0.1.0</code>   |  none |
+| <a id="fetch_ruff-tag"></a>tag |  a tag of ruff that we have mirrored, e.g. `v0.1.0`   |  none |
 
 
 <a id="lint_ruff_aspect"></a>
@@ -98,6 +76,8 @@ Allows the user to select a particular ruff version, rather than get whatever is
 ## lint_ruff_aspect
 
 <pre>
+load("@aspect_rules_lint//lint:ruff.bzl", "lint_ruff_aspect")
+
 lint_ruff_aspect(<a href="#lint_ruff_aspect-binary">binary</a>, <a href="#lint_ruff_aspect-configs">configs</a>, <a href="#lint_ruff_aspect-rule_kinds">rule_kinds</a>)
 </pre>
 
@@ -115,7 +95,7 @@ Attrs:
 | :------------- | :------------- | :------------- |
 | <a id="lint_ruff_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
 | <a id="lint_ruff_aspect-configs"></a>configs |  <p align="center"> - </p>   |  none |
-| <a id="lint_ruff_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  <code>["py_binary", "py_library", "py_test"]</code> |
+| <a id="lint_ruff_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  `["py_binary", "py_library", "py_test"]` |
 
 
 <a id="ruff_action"></a>
@@ -123,6 +103,8 @@ Attrs:
 ## ruff_action
 
 <pre>
+load("@aspect_rules_lint//lint:ruff.bzl", "ruff_action")
+
 ruff_action(<a href="#ruff_action-ctx">ctx</a>, <a href="#ruff_action-executable">executable</a>, <a href="#ruff_action-srcs">srcs</a>, <a href="#ruff_action-config">config</a>, <a href="#ruff_action-stdout">stdout</a>, <a href="#ruff_action-exit_code">exit_code</a>, <a href="#ruff_action-env">env</a>)
 </pre>
 
@@ -152,8 +134,8 @@ However this is needed because:
 | <a id="ruff_action-srcs"></a>srcs |  python files to be linted   |  none |
 | <a id="ruff_action-config"></a>config |  labels of ruff config files (pyproject.toml, ruff.toml, or .ruff.toml)   |  none |
 | <a id="ruff_action-stdout"></a>stdout |  output file of linter results to generate   |  none |
-| <a id="ruff_action-exit_code"></a>exit_code |  output file to write the exit code. If None, then fail the build when ruff exits non-zero. See https://github.com/astral-sh/ruff/blob/dfe4291c0b7249ae892f5f1d513e6f1404436c13/docs/linter.md#exit-codes   |  <code>None</code> |
-| <a id="ruff_action-env"></a>env |  environment variaables for ruff   |  <code>{}</code> |
+| <a id="ruff_action-exit_code"></a>exit_code |  output file to write the exit code. If None, then fail the build when ruff exits non-zero. See https://github.com/astral-sh/ruff/blob/dfe4291c0b7249ae892f5f1d513e6f1404436c13/docs/linter.md#exit-codes   |  `None` |
+| <a id="ruff_action-env"></a>env |  environment variaables for ruff   |  `{}` |
 
 
 <a id="ruff_fix"></a>
@@ -161,6 +143,8 @@ However this is needed because:
 ## ruff_fix
 
 <pre>
+load("@aspect_rules_lint//lint:ruff.bzl", "ruff_fix")
+
 ruff_fix(<a href="#ruff_fix-ctx">ctx</a>, <a href="#ruff_fix-executable">executable</a>, <a href="#ruff_fix-srcs">srcs</a>, <a href="#ruff_fix-config">config</a>, <a href="#ruff_fix-patch">patch</a>, <a href="#ruff_fix-stdout">stdout</a>, <a href="#ruff_fix-exit_code">exit_code</a>, <a href="#ruff_fix-env">env</a>)
 </pre>
 
@@ -178,6 +162,31 @@ Create a Bazel Action that spawns ruff with --fix.
 | <a id="ruff_fix-patch"></a>patch |  output file containing the applied fixes that can be applied with the patch(1) command.   |  none |
 | <a id="ruff_fix-stdout"></a>stdout |  output file of linter results to generate   |  none |
 | <a id="ruff_fix-exit_code"></a>exit_code |  output file to write the exit code   |  none |
-| <a id="ruff_fix-env"></a>env |  environment variaables for ruff   |  <code>{}</code> |
+| <a id="ruff_fix-env"></a>env |  environment variaables for ruff   |  `{}` |
+
+
+<a id="ruff_workaround_20269"></a>
+
+## ruff_workaround_20269
+
+<pre>
+load("@aspect_rules_lint//lint:ruff.bzl", "ruff_workaround_20269")
+
+ruff_workaround_20269(<a href="#ruff_workaround_20269-name">name</a>, <a href="#ruff_workaround_20269-build_file_content">build_file_content</a>, <a href="#ruff_workaround_20269-repo_mapping">repo_mapping</a>, <a href="#ruff_workaround_20269-sha256">sha256</a>, <a href="#ruff_workaround_20269-strip_prefix">strip_prefix</a>, <a href="#ruff_workaround_20269-url">url</a>)
+</pre>
+
+Workaround for https://github.com/bazelbuild/bazel/issues/20269
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="ruff_workaround_20269-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="ruff_workaround_20269-build_file_content"></a>build_file_content |  -   | String | optional |  `""`  |
+| <a id="ruff_workaround_20269-repo_mapping"></a>repo_mapping |  In `WORKSPACE` context only: a dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<br><br>For example, an entry `"@foo": "@bar"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).<br><br>This attribute is _not_ supported in `MODULE.bazel` context (when invoking a repository rule inside a module extension's implementation function).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  |
+| <a id="ruff_workaround_20269-sha256"></a>sha256 |  -   | String | optional |  `""`  |
+| <a id="ruff_workaround_20269-strip_prefix"></a>strip_prefix |  unlike http_archive, any value causes us to pass --strip-components=1 to tar   | String | optional |  `""`  |
+| <a id="ruff_workaround_20269-url"></a>url |  -   | String | optional |  `""`  |
 
 

--- a/docs/shellcheck.md
+++ b/docs/shellcheck.md
@@ -15,12 +15,13 @@ shellcheck = shellcheck_aspect(
 )
 ```
 
-
 <a id="lint_shellcheck_aspect"></a>
 
 ## lint_shellcheck_aspect
 
 <pre>
+load("@aspect_rules_lint//lint:shellcheck.bzl", "lint_shellcheck_aspect")
+
 lint_shellcheck_aspect(<a href="#lint_shellcheck_aspect-binary">binary</a>, <a href="#lint_shellcheck_aspect-config">config</a>, <a href="#lint_shellcheck_aspect-rule_kinds">rule_kinds</a>)
 </pre>
 
@@ -37,7 +38,7 @@ Attrs:
 | :------------- | :------------- | :------------- |
 | <a id="lint_shellcheck_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
 | <a id="lint_shellcheck_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
-| <a id="lint_shellcheck_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  <code>["sh_binary", "sh_library"]</code> |
+| <a id="lint_shellcheck_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  `["sh_binary", "sh_library"]` |
 
 
 <a id="shellcheck_action"></a>
@@ -45,6 +46,8 @@ Attrs:
 ## shellcheck_action
 
 <pre>
+load("@aspect_rules_lint//lint:shellcheck.bzl", "shellcheck_action")
+
 shellcheck_action(<a href="#shellcheck_action-ctx">ctx</a>, <a href="#shellcheck_action-executable">executable</a>, <a href="#shellcheck_action-srcs">srcs</a>, <a href="#shellcheck_action-config">config</a>, <a href="#shellcheck_action-stdout">stdout</a>, <a href="#shellcheck_action-exit_code">exit_code</a>, <a href="#shellcheck_action-options">options</a>)
 </pre>
 
@@ -63,7 +66,7 @@ Based on https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md
 | <a id="shellcheck_action-srcs"></a>srcs |  bash files to be linted   |  none |
 | <a id="shellcheck_action-config"></a>config |  label of the .shellcheckrc file   |  none |
 | <a id="shellcheck_action-stdout"></a>stdout |  output file containing stdout of shellcheck   |  none |
-| <a id="shellcheck_action-exit_code"></a>exit_code |  output file containing shellcheck exit code. If None, then fail the build when vale exits non-zero. See https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md#return-values   |  <code>None</code> |
-| <a id="shellcheck_action-options"></a>options |  additional command-line options, see https://github.com/koalaman/shellcheck/blob/master/shellcheck.hs#L95   |  <code>[]</code> |
+| <a id="shellcheck_action-exit_code"></a>exit_code |  output file containing shellcheck exit code. If None, then fail the build when vale exits non-zero. See https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md#return-values   |  `None` |
+| <a id="shellcheck_action-options"></a>options |  additional command-line options, see https://github.com/koalaman/shellcheck/blob/master/shellcheck.hs#L95   |  `[]` |
 
 

--- a/docs/stylelint.md
+++ b/docs/stylelint.md
@@ -38,12 +38,13 @@ stylelint = lint_stylelint_aspect(
 
 Finally, register the aspect with your linting workflow, such as in `.aspect/cli/config.yaml` for `aspect lint`.
 
-
 <a id="lint_stylelint_aspect"></a>
 
 ## lint_stylelint_aspect
 
 <pre>
+load("@aspect_rules_lint//lint:stylelint.bzl", "lint_stylelint_aspect")
+
 lint_stylelint_aspect(<a href="#lint_stylelint_aspect-binary">binary</a>, <a href="#lint_stylelint_aspect-config">config</a>, <a href="#lint_stylelint_aspect-rule_kinds">rule_kinds</a>, <a href="#lint_stylelint_aspect-filegroup_tags">filegroup_tags</a>)
 </pre>
 
@@ -54,10 +55,10 @@ A factory function to create a linter aspect.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="lint_stylelint_aspect-binary"></a>binary |  the stylelint binary, typically a rule like<br><br><pre><code> load("@npm//:stylelint/package_json.bzl", stylelint_bin = "bin") stylelint_bin.stylelint_binary(name = "stylelint") </code></pre>   |  none |
+| <a id="lint_stylelint_aspect-binary"></a>binary |  the stylelint binary, typically a rule like<br><br><pre><code>load("@npm//:stylelint/package_json.bzl", stylelint_bin = "bin")&#10;stylelint_bin.stylelint_binary(name = "stylelint")</code></pre>   |  none |
 | <a id="lint_stylelint_aspect-config"></a>config |  label(s) of the stylelint config file(s)   |  none |
-| <a id="lint_stylelint_aspect-rule_kinds"></a>rule_kinds |  which [kinds](https://bazel.build/query/language#kind) of rules should be visited by the aspect   |  <code>["css_library"]</code> |
-| <a id="lint_stylelint_aspect-filegroup_tags"></a>filegroup_tags |  which tags on a <code>filegroup</code> indicate that it should be visited by the aspect   |  <code>["lint-with-stylelint"]</code> |
+| <a id="lint_stylelint_aspect-rule_kinds"></a>rule_kinds |  which [kinds](https://bazel.build/query/language#kind) of rules should be visited by the aspect   |  `["css_library"]` |
+| <a id="lint_stylelint_aspect-filegroup_tags"></a>filegroup_tags |  which tags on a `filegroup` indicate that it should be visited by the aspect   |  `["lint-with-stylelint"]` |
 
 
 <a id="stylelint_action"></a>
@@ -65,6 +66,8 @@ A factory function to create a linter aspect.
 ## stylelint_action
 
 <pre>
+load("@aspect_rules_lint//lint:stylelint.bzl", "stylelint_action")
+
 stylelint_action(<a href="#stylelint_action-ctx">ctx</a>, <a href="#stylelint_action-executable">executable</a>, <a href="#stylelint_action-srcs">srcs</a>, <a href="#stylelint_action-config">config</a>, <a href="#stylelint_action-stderr">stderr</a>, <a href="#stylelint_action-exit_code">exit_code</a>, <a href="#stylelint_action-env">env</a>, <a href="#stylelint_action-options">options</a>)
 </pre>
 
@@ -80,9 +83,9 @@ Spawn stylelint as a Bazel action
 | <a id="stylelint_action-srcs"></a>srcs |  list of file objects to lint   |  none |
 | <a id="stylelint_action-config"></a>config |  js_library representing the config file (and its dependencies)   |  none |
 | <a id="stylelint_action-stderr"></a>stderr |  output file containing the stderr or --output-file of stylelint   |  none |
-| <a id="stylelint_action-exit_code"></a>exit_code |  output file containing the exit code of stylelint. If None, then fail the build when stylelint exits non-zero. Exit codes may be:     1 - fatal error     2 - lint problem     64 - invalid CLI usage     78 - invalid configuration file   |  <code>None</code> |
-| <a id="stylelint_action-env"></a>env |  environment variables for stylelint   |  <code>{}</code> |
-| <a id="stylelint_action-options"></a>options |  additional command-line arguments   |  <code>[]</code> |
+| <a id="stylelint_action-exit_code"></a>exit_code |  output file containing the exit code of stylelint. If None, then fail the build when stylelint exits non-zero. Exit codes may be:     1 - fatal error     2 - lint problem     64 - invalid CLI usage     78 - invalid configuration file   |  `None` |
+| <a id="stylelint_action-env"></a>env |  environment variables for stylelint   |  `{}` |
+| <a id="stylelint_action-options"></a>options |  additional command-line arguments   |  `[]` |
 
 
 <a id="stylelint_fix"></a>
@@ -90,6 +93,8 @@ Spawn stylelint as a Bazel action
 ## stylelint_fix
 
 <pre>
+load("@aspect_rules_lint//lint:stylelint.bzl", "stylelint_fix")
+
 stylelint_fix(<a href="#stylelint_fix-ctx">ctx</a>, <a href="#stylelint_fix-executable">executable</a>, <a href="#stylelint_fix-srcs">srcs</a>, <a href="#stylelint_fix-config">config</a>, <a href="#stylelint_fix-patch">patch</a>, <a href="#stylelint_fix-stderr">stderr</a>, <a href="#stylelint_fix-exit_code">exit_code</a>, <a href="#stylelint_fix-env">env</a>, <a href="#stylelint_fix-options">options</a>)
 </pre>
 
@@ -107,7 +112,7 @@ Create a Bazel Action that spawns stylelint with --fix.
 | <a id="stylelint_fix-patch"></a>patch |  output file containing the applied fixes that can be applied with the patch(1) command.   |  none |
 | <a id="stylelint_fix-stderr"></a>stderr |  output file containing the stderr or --output-file of stylelint   |  none |
 | <a id="stylelint_fix-exit_code"></a>exit_code |  output file containing the exit code of stylelint   |  none |
-| <a id="stylelint_fix-env"></a>env |  environment variables for stylelint   |  <code>{}</code> |
-| <a id="stylelint_fix-options"></a>options |  additional command line options   |  <code>[]</code> |
+| <a id="stylelint_fix-env"></a>env |  environment variables for stylelint   |  `{}` |
+| <a id="stylelint_fix-options"></a>options |  additional command line options   |  `[]` |
 
 

--- a/docs/vale.md
+++ b/docs/vale.md
@@ -13,7 +13,7 @@ filegroup(
 )
 ```
 
-or use a `markdown_library` rule such as the one in &lt;https://github.com/dwtj/dwtj_rules_markdown&gt;.
+or use a `markdown_library` rule such as the one in <https://github.com/dwtj/dwtj_rules_markdown>.
 Aspect plans to provide support for Markdown in [configure]() so these rules can be automatically
 maintained rather than requiring developers to write them by hand.
 
@@ -63,12 +63,13 @@ vale = vale_aspect(
 )
 ```
 
-
 <a id="fetch_vale"></a>
 
 ## fetch_vale
 
 <pre>
+load("@aspect_rules_lint//lint:vale.bzl", "fetch_vale")
+
 fetch_vale(<a href="#fetch_vale-tag">tag</a>)
 </pre>
 
@@ -79,7 +80,7 @@ A repository macro used from WORKSPACE to fetch vale binaries
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="fetch_vale-tag"></a>tag |  a tag of vale that we have mirrored, e.g. <code>v3.0.5</code>   |  <code>"v3.7.0"</code> |
+| <a id="fetch_vale-tag"></a>tag |  a tag of vale that we have mirrored, e.g. `v3.0.5`   |  `"v3.7.0"` |
 
 
 <a id="lint_vale_aspect"></a>
@@ -87,6 +88,8 @@ A repository macro used from WORKSPACE to fetch vale binaries
 ## lint_vale_aspect
 
 <pre>
+load("@aspect_rules_lint//lint:vale.bzl", "lint_vale_aspect")
+
 lint_vale_aspect(<a href="#lint_vale_aspect-binary">binary</a>, <a href="#lint_vale_aspect-config">config</a>, <a href="#lint_vale_aspect-styles">styles</a>, <a href="#lint_vale_aspect-rule_kinds">rule_kinds</a>, <a href="#lint_vale_aspect-filegroup_tags">filegroup_tags</a>)
 </pre>
 
@@ -99,9 +102,9 @@ A factory function to create a linter aspect.
 | :------------- | :------------- | :------------- |
 | <a id="lint_vale_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
 | <a id="lint_vale_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
-| <a id="lint_vale_aspect-styles"></a>styles |  <p align="center"> - </p>   |  <code>Label("//lint:empty_styles")</code> |
-| <a id="lint_vale_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  <code>["markdown_library"]</code> |
-| <a id="lint_vale_aspect-filegroup_tags"></a>filegroup_tags |  <p align="center"> - </p>   |  <code>["markdown", "lint-with-vale"]</code> |
+| <a id="lint_vale_aspect-styles"></a>styles |  <p align="center"> - </p>   |  `Label("@aspect_rules_lint//lint:empty_styles")` |
+| <a id="lint_vale_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  `["markdown_library"]` |
+| <a id="lint_vale_aspect-filegroup_tags"></a>filegroup_tags |  <p align="center"> - </p>   |  `["markdown", "lint-with-vale"]` |
 
 
 <a id="vale_action"></a>
@@ -109,6 +112,8 @@ A factory function to create a linter aspect.
 ## vale_action
 
 <pre>
+load("@aspect_rules_lint//lint:vale.bzl", "vale_action")
+
 vale_action(<a href="#vale_action-ctx">ctx</a>, <a href="#vale_action-executable">executable</a>, <a href="#vale_action-srcs">srcs</a>, <a href="#vale_action-styles">styles</a>, <a href="#vale_action-config">config</a>, <a href="#vale_action-stdout">stdout</a>, <a href="#vale_action-exit_code">exit_code</a>, <a href="#vale_action-output">output</a>, <a href="#vale_action-env">env</a>)
 </pre>
 
@@ -125,8 +130,8 @@ Run Vale as an action under Bazel.
 | <a id="vale_action-styles"></a>styles |  a directory containing vale extensions, following https://vale.sh/docs/topics/styles/   |  none |
 | <a id="vale_action-config"></a>config |  label of the .vale.ini file, see https://vale.sh/docs/vale-cli/structure/#valeini   |  none |
 | <a id="vale_action-stdout"></a>stdout |  output file containing stdout of Vale   |  none |
-| <a id="vale_action-exit_code"></a>exit_code |  output file containing Vale exit code. If None, then fail the build when Vale exits non-zero.   |  <code>None</code> |
-| <a id="vale_action-output"></a>output |  the value for the --output flag   |  <code>"CLI"</code> |
-| <a id="vale_action-env"></a>env |  environment variables for vale   |  <code>{}</code> |
+| <a id="vale_action-exit_code"></a>exit_code |  output file containing Vale exit code. If None, then fail the build when Vale exits non-zero.   |  `None` |
+| <a id="vale_action-output"></a>output |  the value for the --output flag   |  `"CLI"` |
+| <a id="vale_action-env"></a>env |  environment variables for vale   |  `{}` |
 
 


### PR DESCRIPTION
It produces better markdown output (e.g. no more HTML for code blocks) and includes `load` statements on examples.

Also uses `native.starlark_doc_extract`, which Aspect docsite now requires.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases

Note, I had to change our testing matrix, since newer stardoc module has a hard requirement in BCR of Bazel 7 or greater.