### PR TITLE
Add --respect-project-filters to scalafmt

### DIFF
--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -51,7 +51,7 @@ CHECK_FLAGS = {
     "buf": "format -d --exit-code",
     "terraform-fmt": "fmt -check -diff",
     "jsonnetfmt": "--test",
-    "scalafmt": "--test",
+    "scalafmt": "--test --respect-project-filters",
     "clang-format": "--style=file --fallback-style=none --dry-run -Werror",
     "yamlfmt": "-lint",
     "rustfmt": "--check",
@@ -74,6 +74,10 @@ FIX_FLAGS = {
     "buf": "format -w",
     "terraform-fmt": "fmt",
     "jsonnetfmt": "--in-place",
+    # Force exclusions in the configuration file to be honored even when file paths are supplied
+    # as command-line arguments; see
+    # https://github.com/scalameta/scalafmt/pull/2020
+    "scalafmt": "--respect-project-filters",
     "scalafmt": "",
     "clang-format": "-style=file --fallback-style=none -i",
     "yamlfmt": "",

--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -78,7 +78,6 @@ FIX_FLAGS = {
     # as command-line arguments; see
     # https://github.com/scalameta/scalafmt/pull/2020
     "scalafmt": "--respect-project-filters",
-    "scalafmt": "",
     "clang-format": "-style=file --fallback-style=none -i",
     "yamlfmt": "",
     "rustfmt": "",

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -109,7 +109,7 @@ bats_load_library "bats-assert"
     run bazel run //format/test:format_Scala_with_scalafmt
     assert_success
 
-    assert_output --partial "+ scalafmt example/src/hello.scala"
+    assert_output --partial "+ scalafmt --respect-project-filters example/src/hello.scala"
 }
 
 @test "should run gofmt on Go" {


### PR DESCRIPTION
https://github.com/aspect-build/rules_lint/issues/371
This is a similar solution how rules_lint handles ruff with the `--force-exclude` flag.

---

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Follow the reproduction instructions in my example repo before and after this change: https://github.com/vinnybod/bazel_java_example/tree/rules_lint_config
After this change, it only formats the file that is expected to be formatted.
