### PR TITLE
Add a checkstyle linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,37 +21,38 @@ Features:
 
 New tools are being added frequently, so check this page again!
 
-| Language               | Formatter             | Linter(s)        |
-| ---------------------- | --------------------- | ---------------- |
-| C / C++                | [clang-format]        | [clang-tidy]     |
-| Cuda                   | [clang-format]        |                  |
-| CSS, Less, Sass        | [Prettier]            | [Stylelint]      |
-| Go                     | [gofmt] or [gofumpt]  |                  |
-| GraphQL                | [Prettier]            |                  |
-| HCL (Hashicorp Config) | [terraform] fmt       |                  |
-| HTML                   | [Prettier]            |                  |
-| JSON                   | [Prettier]            |                  |
-| Java                   | [google-java-format]  | [pmd]            |
-| JavaScript             | [Prettier]            | [ESLint]         |
-| Jsonnet                | [jsonnetfmt]          |                  |
-| Kotlin                 | [ktfmt]               | [ktlint]         |
-| Markdown               | [Prettier]            | [Vale]           |
-| Protocol Buffer        | [buf]                 | [buf lint]       |
-| Python                 | [ruff]                | [flake8], [ruff] |
-| Rust                   | [rustfmt]             |                  |
-| SQL                    | [prettier-plugin-sql] |                  |
-| Scala                  | [scalafmt]            |                  |
-| Shell                  | [shfmt]               | [shellcheck]     |
-| Starlark               | [Buildifier]          |                  |
-| Swift                  | [SwiftFormat] (1)     |                  |
-| TSX                    | [Prettier]            | [ESLint]         |
-| TypeScript             | [Prettier]            | [ESLint]         |
-| YAML                   | [yamlfmt]             |                  |
+| Language               | Formatter             | Linter(s)            |
+| ---------------------- | --------------------- |----------------------|
+| C / C++                | [clang-format]        | [clang-tidy]         |
+| Cuda                   | [clang-format]        |                      |
+| CSS, Less, Sass        | [Prettier]            | [Stylelint]          |
+| Go                     | [gofmt] or [gofumpt]  |                      |
+| GraphQL                | [Prettier]            |                      |
+| HCL (Hashicorp Config) | [terraform] fmt       |                      |
+| HTML                   | [Prettier]            |                      |
+| JSON                   | [Prettier]            |                      |
+| Java                   | [google-java-format]  | [pmd] , [Checkstyle] |
+| JavaScript             | [Prettier]            | [ESLint]             |
+| Jsonnet                | [jsonnetfmt]          |                      |
+| Kotlin                 | [ktfmt]               | [ktlint]             |
+| Markdown               | [Prettier]            | [Vale]               |
+| Protocol Buffer        | [buf]                 | [buf lint]           |
+| Python                 | [ruff]                | [flake8], [ruff]     |
+| Rust                   | [rustfmt]             |                      |
+| SQL                    | [prettier-plugin-sql] |                      |
+| Scala                  | [scalafmt]            |                      |
+| Shell                  | [shfmt]               | [shellcheck]         |
+| Starlark               | [Buildifier]          |                      |
+| Swift                  | [SwiftFormat] (1)     |                      |
+| TSX                    | [Prettier]            | [ESLint]             |
+| TypeScript             | [Prettier]            | [ESLint]             |
+| YAML                   | [yamlfmt]             |                      |
 
 [prettier]: https://prettier.io
 [google-java-format]: https://github.com/google/google-java-format
 [flake8]: https://flake8.pycqa.org/en/latest/index.html
 [pmd]: https://docs.pmd-code.org/latest/index.html
+[checkstyle]: https://checkstyle.sourceforge.io/cmdline.html
 [buf lint]: https://buf.build/docs/lint/overview
 [eslint]: https://eslint.org/
 [swiftformat]: https://github.com/nicklockwood/SwiftFormat

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -28,6 +28,11 @@ stardoc_with_diff_test(
 )
 
 stardoc_with_diff_test(
+    name = "checkstyle",
+    bzl_library_target = "//lint:checkstyle",
+)
+
+stardoc_with_diff_test(
     name = "format",
     bzl_library_target = "//format:defs",
 )

--- a/docs/checkstyle.md
+++ b/docs/checkstyle.md
@@ -24,7 +24,7 @@ load("@aspect_rules_lint//lint:checkstyle.bzl", "checkstyle_aspect")
 
 checkstyle = checkstyle_aspect(
     binary = "@@//tools/lint:checkstyle",
-    rulesets = ["@@//:checkstyle.xml"],
+    config = ["@@//:checkstyle.xml"],
 )
 ```
 
@@ -96,7 +96,7 @@ Attrs:
         )
         ```
 
-    config: the PMD ruleset XML files
+    config: the Checkstyle XML file
 
 **PARAMETERS**
 

--- a/docs/checkstyle.md
+++ b/docs/checkstyle.md
@@ -1,0 +1,111 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+API for declaring a checkstyle lint aspect that visits java_library rules.
+
+Typical usage:
+
+First, call the `fetch_checkstyle` helper in `WORKSPACE` to download the jar file.
+Alternatively you could use whatever you prefer for managing Java dependencies, such as a Maven integration rule.
+
+Next, declare a binary target for it, typically in `tools/lint/BUILD.bazel`:
+
+```starlark
+java_binary(
+    name = "checkstyle",
+    main_class = "com.puppycrawl.tools.checkstyle.Main",
+    runtime_deps = ["@com_puppycrawl_tools_checkstyle"],
+)
+```
+
+Finally, declare an aspect for it, typically in `tools/lint/linters.bzl`:
+
+```starlark
+load("@aspect_rules_lint//lint:checkstyle.bzl", "checkstyle_aspect")
+
+checkstyle = checkstyle_aspect(
+    binary = "@@//tools/lint:checkstyle",
+    rulesets = ["@@//:checkstyle.xml"],
+)
+```
+
+<a id="checkstyle_action"></a>
+
+## checkstyle_action
+
+<pre>
+load("@aspect_rules_lint//lint:checkstyle.bzl", "checkstyle_action")
+
+checkstyle_action(<a href="#checkstyle_action-ctx">ctx</a>, <a href="#checkstyle_action-executable">executable</a>, <a href="#checkstyle_action-srcs">srcs</a>, <a href="#checkstyle_action-config">config</a>, <a href="#checkstyle_action-data">data</a>, <a href="#checkstyle_action-stdout">stdout</a>, <a href="#checkstyle_action-exit_code">exit_code</a>, <a href="#checkstyle_action-options">options</a>)
+</pre>
+
+Run Checkstyle as an action under Bazel.
+
+Based on https://checkstyle.sourceforge.io/cmdline.html
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="checkstyle_action-ctx"></a>ctx |  Bazel Rule or Aspect evaluation context   |  none |
+| <a id="checkstyle_action-executable"></a>executable |  label of the the Checkstyle program   |  none |
+| <a id="checkstyle_action-srcs"></a>srcs |  java files to be linted   |  none |
+| <a id="checkstyle_action-config"></a>config |  label of the checkstyle.xml file   |  none |
+| <a id="checkstyle_action-data"></a>data |  labels of additional xml files such as suppressions.xml   |  none |
+| <a id="checkstyle_action-stdout"></a>stdout |  output file to generate   |  none |
+| <a id="checkstyle_action-exit_code"></a>exit_code |  output file to write the exit code. If None, then fail the build when Checkstyle exits non-zero.   |  `None` |
+| <a id="checkstyle_action-options"></a>options |  additional command-line options, see https://checkstyle.sourceforge.io/cmdline.html   |  `[]` |
+
+
+<a id="fetch_checkstyle"></a>
+
+## fetch_checkstyle
+
+<pre>
+load("@aspect_rules_lint//lint:checkstyle.bzl", "fetch_checkstyle")
+
+fetch_checkstyle()
+</pre>
+
+
+
+
+
+<a id="lint_checkstyle_aspect"></a>
+
+## lint_checkstyle_aspect
+
+<pre>
+load("@aspect_rules_lint//lint:checkstyle.bzl", "lint_checkstyle_aspect")
+
+lint_checkstyle_aspect(<a href="#lint_checkstyle_aspect-binary">binary</a>, <a href="#lint_checkstyle_aspect-config">config</a>, <a href="#lint_checkstyle_aspect-data">data</a>, <a href="#lint_checkstyle_aspect-rule_kinds">rule_kinds</a>)
+</pre>
+
+A factory function to create a linter aspect.
+
+Attrs:
+    binary: a Checkstyle executable. Can be obtained from rules_java like so:
+
+        ```
+        java_binary(
+            name = "checkstyle",
+            main_class = "com.puppycrawl.tools.checkstyle.Main",
+            # Point to wherever you have the java_import rule defined, see our example
+            runtime_deps = ["@com_puppycrawl_tools_checkstyle"],
+        )
+        ```
+
+    config: the PMD ruleset XML files
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="lint_checkstyle_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
+| <a id="lint_checkstyle_aspect-config"></a>config |  <p align="center"> - </p>   |  none |
+| <a id="lint_checkstyle_aspect-data"></a>data |  <p align="center"> - </p>   |  `[]` |
+| <a id="lint_checkstyle_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  `["java_binary", "java_library"]` |
+
+

--- a/example/.aspect/cli/config.yaml
+++ b/example/.aspect/cli/config.yaml
@@ -8,3 +8,4 @@ lint:
     - //tools/lint:linters.bzl%stylelint
     - //tools/lint:linters.bzl%ruff
     - //tools/lint:linters.bzl%vale
+    - //tools/lint:linters.bzl%checkstyle

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -17,6 +17,7 @@ exports_files(
         ".flake8",
         "pmd.xml",
         "checkstyle.xml",
+        "checkstyle-suppressions.xml",
         ".ruff.toml",
         ".shellcheckrc",
         ".scalafmt.conf",

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -16,6 +16,7 @@ exports_files(
         "buf.yaml",
         ".flake8",
         "pmd.xml",
+        "checkstyle.xml",
         ".ruff.toml",
         ".shellcheckrc",
         ".scalafmt.conf",

--- a/example/WORKSPACE.bazel
+++ b/example/WORKSPACE.bazel
@@ -303,6 +303,10 @@ fetch_ktfmt()
 
 fetch_swiftformat()
 
+load("@aspect_rules_lint//lint:checkstyle.bzl", "fetch_checkstyle")
+
+fetch_checkstyle()
+
 load("@aspect_rules_lint//lint:pmd.bzl", "fetch_pmd")
 
 fetch_pmd()

--- a/example/WORKSPACE.bzlmod
+++ b/example/WORKSPACE.bzlmod
@@ -20,6 +20,10 @@ load("@aspect_rules_lint//lint:pmd.bzl", "fetch_pmd")
 
 fetch_pmd()
 
+load("@aspect_rules_lint//lint:checkstyle.bzl", "fetch_checkstyle")
+
+fetch_checkstyle()
+
 load("@aspect_rules_lint//lint:vale.bzl", "fetch_vale")
 
 fetch_vale()

--- a/example/checkstyle-suppressions.xml
+++ b/example/checkstyle-suppressions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+    <suppress files="Bar.java" checks="UnusedImports" />
+</suppressions>

--- a/example/checkstyle.xml
+++ b/example/checkstyle.xml
@@ -3,7 +3,17 @@
           "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
           "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
+
   <module name="TreeWalker">
     <module name="UnusedImports"/>
   </module>
+
+  <module name="LineLength">
+    <property name="max" value="20"/>
+  </module>
+
+  <module name="SuppressionFilter">
+    <property name="file" value="checkstyle-suppressions.xml"/>
+  </module>
+
 </module>

--- a/example/checkstyle.xml
+++ b/example/checkstyle.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="UnusedImports"/>
+  </module>
+</module>

--- a/example/src/BUILD.bazel
+++ b/example/src/BUILD.bazel
@@ -71,6 +71,11 @@ java_library(
     srcs = ["Foo.java"],
 )
 
+java_library(
+    name = "bar",
+    srcs = ["Bar.java"],
+)
+
 sh_library(
     name = "hello_shell",
     srcs = ["hello.sh"],

--- a/example/src/Bar.java
+++ b/example/src/Bar.java
@@ -1,8 +1,10 @@
 package src;
 
+// Unused imports are suppressed in suppressions.xml, so this should not raise issue.
 import java.util.Objects;
 import java.io.BufferedInputStream;
 
 public class Bar {
+  // Max line length set to 20, so this should raise issue.
   protected void finalize(int a) {}
 }

--- a/example/src/Bar.java
+++ b/example/src/Bar.java
@@ -1,0 +1,8 @@
+package src;
+
+import java.util.Objects;
+import java.io.BufferedInputStream;
+
+public class Bar {
+  protected void finalize(int a) {}
+}

--- a/example/test/BUILD.bazel
+++ b/example/test/BUILD.bazel
@@ -3,7 +3,7 @@
 load("@aspect_rules_lint//format:defs.bzl", "format_test")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("//tools/lint:linters.bzl", "eslint_test", "flake8_test", "pmd_test", "ruff_test", "shellcheck_test")
+load("//tools/lint:linters.bzl", "checkstyle_test", "eslint_test", "flake8_test", "pmd_test", "ruff_test", "shellcheck_test")
 
 write_file(
     name = "ts_code_generator",
@@ -91,6 +91,12 @@ pmd_test(
     srcs = ["//src:foo"],
     # Expected to fail based on current content of the file.
     # Normally you'd fix the file instead of tagging this test.
+    tags = ["manual"],
+)
+
+checkstyle_test(
+    name = "checkstyle",
+    srcs = ["//src:bar"],
     tags = ["manual"],
 )
 

--- a/example/tools/lint/BUILD.bazel
+++ b/example/tools/lint/BUILD.bazel
@@ -36,6 +36,12 @@ java_binary(
     runtime_deps = ["@net_sourceforge_pmd"],
 )
 
+java_binary(
+    name = "checkstyle",
+    main_class = "com.puppycrawl.tools.checkstyle.Main",
+    runtime_deps = ["@com_puppycrawl_tools_checkstyle//jar"],
+)
+
 native_binary(
     name = "vale",
     src = select(

--- a/example/tools/lint/linters.bzl
+++ b/example/tools/lint/linters.bzl
@@ -52,6 +52,7 @@ pmd_test = lint_test(aspect = pmd)
 checkstyle = lint_checkstyle_aspect(
     binary = "@@//tools/lint:checkstyle",
     config = "@@//:checkstyle.xml",
+    data = ["@@//:checkstyle-suppressions.xml"],
 )
 
 checkstyle_test = lint_test(aspect = checkstyle)

--- a/example/tools/lint/linters.bzl
+++ b/example/tools/lint/linters.bzl
@@ -1,6 +1,7 @@
 "Define linter aspects"
 
 load("@aspect_rules_lint//lint:buf.bzl", "lint_buf_aspect")
+load("@aspect_rules_lint//lint:checkstyle.bzl", "lint_checkstyle_aspect")
 load("@aspect_rules_lint//lint:clang_tidy.bzl", "lint_clang_tidy_aspect")
 load("@aspect_rules_lint//lint:eslint.bzl", "lint_eslint_aspect")
 load("@aspect_rules_lint//lint:flake8.bzl", "lint_flake8_aspect")
@@ -47,6 +48,13 @@ pmd = lint_pmd_aspect(
 )
 
 pmd_test = lint_test(aspect = pmd)
+
+checkstyle = lint_checkstyle_aspect(
+    binary = "@@//tools/lint:checkstyle",
+    config = "@@//:checkstyle.xml",
+)
+
+checkstyle_test = lint_test(aspect = checkstyle)
 
 ruff = lint_ruff_aspect(
     binary = "@multitool//tools/ruff",

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -95,7 +95,7 @@ bats_load_library "bats-assert"
     run bazel run //format/test:format_Java_with_java-format
     assert_success
 
-    assert_output --partial "+ java-format --replace example/src/Foo.java"
+    assert_output --partial "+ java-format --replace example/src/Bar.java example/src/Foo.java"
 }
 
 @test "should run ktfmt on Kotlin" {

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -164,6 +164,15 @@ bzl_library(
 )
 
 bzl_library(
+    name = "checkstyle",
+    srcs = ["checkstyle.bzl"],
+    visibility = ["//visibility:public"],
+    deps = _BAZEL_TOOLS + [
+        "//lint/private:lint_aspect",
+    ],
+)
+
+bzl_library(
     name = "ruff",
     srcs = ["ruff.bzl"],
     visibility = ["//visibility:public"],

--- a/lint/checkstyle.bzl
+++ b/lint/checkstyle.bzl
@@ -87,9 +87,26 @@ def _checkstyle_aspect_impl(target, ctx):
         noop_lint_action(ctx, outputs)
         return [info]
 
-    format_options = []
-    checkstyle_action(ctx, ctx.executable._checkstyle, files_to_lint, ctx.file._config, ctx.files._data, outputs.human.out, outputs.human.exit_code, format_options)
-    checkstyle_action(ctx, ctx.executable._checkstyle, files_to_lint, ctx.file._config, ctx.files._data, outputs.machine.out, outputs.machine.exit_code)
+    checkstyle_action(
+        ctx,
+        ctx.executable._checkstyle,
+        files_to_lint,
+        ctx.file._config,
+        ctx.files._data,
+        outputs.human.out,
+        outputs.human.exit_code,
+        ["-f", "plain"],
+    )
+    checkstyle_action(
+        ctx,
+        ctx.executable._checkstyle,
+        files_to_lint,
+        ctx.file._config,
+        ctx.files._data,
+        outputs.machine.out,
+        outputs.machine.exit_code,
+        ["-f", "sarif"],
+    )
     return [info]
 
 def lint_checkstyle_aspect(binary, config, data = [], rule_kinds = ["java_binary", "java_library"]):

--- a/lint/checkstyle.bzl
+++ b/lint/checkstyle.bzl
@@ -22,7 +22,7 @@ load("@aspect_rules_lint//lint:checkstyle.bzl", "checkstyle_aspect")
 
 checkstyle = checkstyle_aspect(
     binary = "@@//tools/lint:checkstyle",
-    rulesets = ["@@//:checkstyle.xml"],
+    config = ["@@//:checkstyle.xml"],
 )
 ```
 """
@@ -107,7 +107,7 @@ def lint_checkstyle_aspect(binary, config, data = [], rule_kinds = ["java_binary
             )
             ```
 
-        config: the PMD ruleset XML files
+        config: the Checkstyle XML file
     """
     return aspect(
         implementation = _checkstyle_aspect_impl,

--- a/lint/checkstyle.bzl
+++ b/lint/checkstyle.bzl
@@ -1,4 +1,4 @@
-"""API for declaring a PMD lint aspect that visits java_library rules.
+"""API for declaring a checkstyle lint aspect that visits java_library rules.
 
 Typical usage:
 
@@ -35,24 +35,24 @@ _MNEMONIC = "AspectRulesLintCheckstyle"
 def checkstyle_action(ctx, executable, srcs, config, data, stdout, exit_code = None, options = []):
     """Run Checkstyle as an action under Bazel.
 
-    Based on https://docs.pmd-code.org/latest/pmd_userdocs_installation.html#running-pmd-via-command-line
+    Based on https://checkstyle.sourceforge.io/cmdline.html
 
     Args:
         ctx: Bazel Rule or Aspect evaluation context
-        executable: label of the the PMD program
+        executable: label of the the Checkstyle program
         srcs: java files to be linted
         config: label of the checkstyle.xml file
         data: labels of additional xml files such as suppressions.xml
         stdout: output file to generate
         exit_code: output file to write the exit code.
-            If None, then fail the build when PMD exits non-zero.
-        options: additional command-line options, see https://pmd.github.io/pmd/pmd_userdocs_cli_reference.html
+            If None, then fail the build when Checkstyle exits non-zero.
+        options: additional command-line options, see https://checkstyle.sourceforge.io/cmdline.html
     """
     inputs = srcs + [config] + data
     outputs = [stdout]
 
     # Wire command-line options, see
-    # https://docs.pmd-code.org/latest/pmd_userdocs_cli_reference.html
+    # https://checkstyle.sourceforge.io/cmdline.html
     args = ctx.actions.args()
     args.add_all(options)
 
@@ -87,8 +87,6 @@ def _checkstyle_aspect_impl(target, ctx):
         noop_lint_action(ctx, outputs)
         return [info]
 
-    # https://github.com/pmd/pmd/blob/master/docs/pages/pmd/userdocs/pmd_report_formats.md
-    # format_options = ["textcolor" if ctx.attr._options[LintOptionsInfo].color else "text"]
     format_options = []
     checkstyle_action(ctx, ctx.executable._checkstyle, files_to_lint, ctx.file._config, ctx.files._data, outputs.human.out, outputs.human.exit_code, format_options)
     checkstyle_action(ctx, ctx.executable._checkstyle, files_to_lint, ctx.file._config, ctx.files._data, outputs.machine.out, outputs.machine.exit_code)

--- a/lint/checkstyle.bzl
+++ b/lint/checkstyle.bzl
@@ -1,0 +1,153 @@
+"""API for declaring a PMD lint aspect that visits java_library rules.
+
+Typical usage:
+
+First, call the `fetch_checkstyle` helper in `WORKSPACE` to download the jar file.
+Alternatively you could use whatever you prefer for managing Java dependencies, such as a Maven integration rule.
+
+Next, declare a binary target for it, typically in `tools/lint/BUILD.bazel`:
+
+```starlark
+java_binary(
+    name = "checkstyle",
+    main_class = "com.puppycrawl.tools.checkstyle.Main",
+    runtime_deps = ["@com_puppycrawl_tools_checkstyle"],
+)
+```
+
+Finally, declare an aspect for it, typically in `tools/lint/linters.bzl`:
+
+```starlark
+load("@aspect_rules_lint//lint:checkstyle.bzl", "checkstyle_aspect")
+
+checkstyle = checkstyle_aspect(
+    binary = "@@//tools/lint:checkstyle",
+    rulesets = ["@@//:checkstyle.xml"],
+)
+```
+"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "noop_lint_action", "output_files", "should_visit")
+
+_MNEMONIC = "AspectRulesLintCheckstyle"
+
+def checkstyle_action(ctx, executable, srcs, config, stdout, exit_code = None, options = []):
+    """Run Checkstyle as an action under Bazel.
+
+    Based on https://docs.pmd-code.org/latest/pmd_userdocs_installation.html#running-pmd-via-command-line
+
+    Args:
+        ctx: Bazel Rule or Aspect evaluation context
+        executable: label of the the PMD program
+        srcs: java files to be linted
+        config: label of the checkstyle.xml file
+        stdout: output file to generate
+        exit_code: output file to write the exit code.
+            If None, then fail the build when PMD exits non-zero.
+        options: additional command-line options, see https://pmd.github.io/pmd/pmd_userdocs_cli_reference.html
+    """
+    inputs = srcs + [config]
+    outputs = [stdout]
+
+    # Wire command-line options, see
+    # https://docs.pmd-code.org/latest/pmd_userdocs_cli_reference.html
+    args = ctx.actions.args()
+    args.add_all(options)
+    args.add_all(["-c", config.path])
+
+    args.add_all(["--debug"])
+
+    args.add_all(srcs)
+    #    args.add("--rulesets")
+    # args.add_joined(rulesets, join_with = ",")
+    #    src_args = ctx.actions.args()
+    #    src_args.use_param_file("%s", use_always = True)
+    #    src_args.add_all(srcs)
+    #    print(args, src_args)
+
+    if exit_code:
+        command = "{CHECKSTYLE} $@ >{stdout}; echo $? > " + exit_code.path
+        outputs.append(exit_code)
+    else:
+        # Create empty stdout file on success, as Bazel expects one
+        command = "{CHECKSTYLE} $@ && touch {stdout}"
+
+    ctx.actions.run_shell(
+        inputs = inputs,
+        outputs = outputs,
+        command = command.format(CHECKSTYLE = executable.path, stdout = stdout.path),
+        arguments = [args],  #src_args],
+        mnemonic = _MNEMONIC,
+        tools = [executable],
+        progress_message = "Linting %{label} with Checkstyle",
+    )
+
+# buildifier: disable=function-docstring
+def _checkstyle_aspect_impl(target, ctx):
+    if not should_visit(ctx.rule, ctx.attr._rule_kinds):
+        return []
+
+    files_to_lint = filter_srcs(ctx.rule)
+    outputs, info = output_files(_MNEMONIC, target, ctx)
+    if len(files_to_lint) == 0:
+        noop_lint_action(ctx, outputs)
+        return [info]
+
+    # https://github.com/pmd/pmd/blob/master/docs/pages/pmd/userdocs/pmd_report_formats.md
+    # format_options = ["textcolor" if ctx.attr._options[LintOptionsInfo].color else "text"]
+    format_options = []
+    checkstyle_action(ctx, ctx.executable._checkstyle, files_to_lint, ctx.file._config, outputs.human.out, outputs.human.exit_code, format_options)
+    checkstyle_action(ctx, ctx.executable._checkstyle, files_to_lint, ctx.file._config, outputs.machine.out, outputs.machine.exit_code)
+    return [info]
+
+def lint_checkstyle_aspect(binary, config, rule_kinds = ["java_binary", "java_library"]):
+    """A factory function to create a linter aspect.
+
+    Attrs:
+        binary: a Checkstyle executable. Can be obtained from rules_java like so:
+
+            ```
+            java_binary(
+                name = "checkstyle",
+                main_class = "com.puppycrawl.tools.checkstyle.Main",
+                # Point to wherever you have the java_import rule defined, see our example
+                runtime_deps = ["@com_puppycrawl_tools_checkstyle"],
+            )
+            ```
+
+        config: the PMD ruleset XML files
+    """
+    return aspect(
+        implementation = _checkstyle_aspect_impl,
+        # Edges we need to walk up the graph from the selected targets.
+        # Needed for linters that need semantic information like transitive type declarations.
+        # attr_aspects = ["deps"],
+        attrs = {
+            "_options": attr.label(
+                default = "//lint:options",
+                providers = [LintOptionsInfo],
+            ),
+            "_checkstyle": attr.label(
+                default = binary,
+                executable = True,
+                cfg = "exec",
+            ),
+            "_config": attr.label(
+                allow_single_file = True,
+                mandatory = True,
+                doc = "Config file",
+                default = config,
+            ),
+            "_rule_kinds": attr.string_list(
+                default = rule_kinds,
+            ),
+        },
+    )
+
+def fetch_checkstyle():
+    http_jar(
+        name = "com_puppycrawl_tools_checkstyle",
+        url = "https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.17.0/checkstyle-10.17.0-all.jar",
+        sha256 = "51c34d738520c1389d71998a9ab0e6dabe0d7cf262149f3e01a7294496062e42",
+    )


### PR DESCRIPTION
Adds a Checkstyle linter for Java. I pretty much copied the pmd implementation, so let me know if anything is out of place. I updated the examples and in my [own repo](https://github.com/vinnybod/bazel_java_example/tree/rules_lint_checkstyle).

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- New test cases added
- Manual testing; please provide instructions so we can reproduce:

Run the checkstyle linter in the examples repo. See that it raises linting issues. Note that the unused import should not raise an issue because it is excluded in suppressions.xml
