### PR TITLE
fix: handle empty exit_code File when fail_on_violation is set

### DIFF
--- a/lint/private/lint_aspect.bzl
+++ b/lint/private/lint_aspect.bzl
@@ -105,8 +105,8 @@ def patch_file(mnemonic, target, ctx):
 def patch_and_output_files(*args):
     patch, _ = patch_file(*args)
     outputs, _ = output_files(*args)
-    human_outputs = [outputs.human.out, outputs.human.exit_code]
-    machine_outputs = [outputs.machine.out, outputs.machine.exit_code]
+    human_outputs = [f for f in [outputs.human.out, outputs.human.exit_code] if f]
+    machine_outputs = [f for f in [outputs.machine.out, outputs.machine.exit_code] if f]
     return struct(
         human = outputs.human,
         machine = outputs.machine,


### PR DESCRIPTION
Fixes failure when requesting machine outputs if --@aspect_rules_lint//lint:fail_on_violation is set

```
#   Loading:
#   Loading:
#   Loading: 0 packages loaded
#   INFO: Build option --@aspect_rules_lint~1.0.0-rc9//lint:fail_on_violation has changed, discarding analysis cache.
#   Analyzing: target //:shell (0 packages loaded, 0 targets configured)
#   ERROR: /mnt/ephemeral/output/silo/__main__/sandbox/linux-sandbox/35427/execroot/_main/_tmp/fb5e425c745cfcb964d22e0dd572d176/mock-repo/BUILD.bazel:2:11: in //:lint.bzl%shellcheck aspect on sh_library rule //:shell:
#   Traceback (most recent call last):
#   	File "/mnt/ephemeral/output/silo/__main__/sandbox/linux-sandbox/35427/execroot/_main/_tmp/fb5e425c745cfcb964d22e0dd572d176/_bazel_aspect-runner/e7b451ac297d2a5c6b4fe1683d7d8851/external/aspect_rules_lint~1.0.0-rc9/lint/shellcheck.bzl", line 74, column 47, in _shellcheck_aspect_impl
#   		outputs, info = patch_and_output_files(_MNEMONIC, target, ctx)
#   	File "/mnt/ephemeral/output/silo/__main__/sandbox/linux-sandbox/35427/execroot/_main/_tmp/fb5e425c745cfcb964d22e0dd572d176/_bazel_aspect-runner/e7b451ac297d2a5c6b4fe1683d7d8851/external/aspect_rules_lint~1.0.0-rc9/lint/private/lint_aspect.bzl", line 115, column 34, in patch_and_output_files
#   		rules_lint_human = depset(human_outputs),
#   Error in depset: cannot add an item of type 'NoneType' to a depset of 'File'
#   ERROR: Analysis of aspects '[//:lint.bzl%shellcheck] with parameters {} on //:shell' failed; build aborted: Analysis of target '//:shell' failed
#   INFO: Elapsed time: 0.673s
#   INFO: 0 processes.
#   FAILED: Build did NOT complete successfully (0 packages loaded, 395 targets configured)
#   FAILED: Build did NOT complete successfully (0 packages loaded, 395 targets configured)
```
