### PR TITLE
fix(format): Allow git-attributes to be set to true

### DIFF
--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -84,11 +84,11 @@ Assuming you installed with the typical layout:
 Commonly, the underlying formatters that rules_lint invokes provide their own methods of excluding files (.prettierignore for example). At times when that is not the case, rules_lint provides its
 own escape hatch to exclude files from linting using attributes specified via [`.gitattributes` files](https://git-scm.com/docs/gitattributes).
 
-If any of following attributes are set on a file it will be excluded:
+If any of following attributes are set or have a value of `true` on a file it will be excluded:
 
-- `rules-lint-ignored`
-- `gitlab-generated`
-- `linguist-generated`
+- `rules-lint-ignored=true`
+- `gitlab-generated=true`
+- `linguist-generated=true`
 
 ### Install as a pre-commit hook
 

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -162,7 +162,7 @@ function ls-files {
           fi
 
           # Check if the attribute is set
-          if [[ "$line" == *"set" ]]; then
+          if [[ "$line" == *": set" || "$line" == *": true" ]]; then
               attribute_set=true
           fi
       done <<< "$git_attributes"

--- a/format/test/ls-files_test.sh
+++ b/format/test/ls-files_test.sh
@@ -36,8 +36,8 @@ kt=$(ls-files Kotlin)
 # .gitattributes should allow more excludes
 cat >.gitattributes <<EOF
 gen1.js rules-lint-ignored
-gen2.js rules-lint-ignored
-gen2.js gitlab-generated
+gen2.js rules-lint-ignored=false
+gen2.js gitlab-generated=true
 gen3.js linguist-generated
 EOF
 js=$(ls-files JavaScript)


### PR DESCRIPTION
Prior to this change, if one of the git attributes used to disable format checks was set to a value
of `true`, it was still formatted since the only
valid syntax was setting the attribute without
any value.

After this change the attributes can be used without a value or with the value of `true`

Fixes https://github.com/aspect-build/rules_lint/issues/383

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Test plan

- New test cases added

Git attributes for disabling format checks now support both unset values and `true`. This allows for more flexible configuration when excluding files from formatting.
