### PR TITLE
Use --diff when running ruff as check

### DIFF
--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -43,7 +43,7 @@ CHECK_FLAGS = {
     "buildifier": "-mode=check",
     "swiftformat": "--lint",
     "prettier": "--check",
-    "ruff": "format --check --force-exclude",
+    "ruff": "format --check --force-exclude --diff",
     "shfmt": "--diff --apply-ignore",
     "java-format": "--set-exit-if-changed --dry-run",
     "ktfmt": "--set-exit-if-changed --dry-run",


### PR DESCRIPTION
### Changes are visible to end-users: yes

- when using ruff as formatter and during check, a diff will be displayed in case of files to format

