### PR TITLE
Fix broken link in linting.md

### DIFF
--- a/docs/linting.md
+++ b/docs/linting.md
@@ -13,7 +13,7 @@ We suggest creating a `linters.bzl` file in whatever package contains most of yo
 custom Bazel configuration, commonly in `tools/lint`.
 This `linters.bzl` should contain linter aspect declarations.
 
-See the [example linters.bzl](./examples/tools/lint/linters.bzl) for a complete install example.
+See the [example linters.bzl](/example/tools/lint/linters.bzl) for a complete install example.
 See the `docs/` folder for API docs of the "aspect factory functions" that declare your linters.
 
 Finally, register those linter aspects in the lint runner. See details below.


### PR DESCRIPTION
Fix minor typo in linting.md leading to a broken link to linters.bzl.
