### PR TITLE
chore: Silence prettier output unless error

### DIFF
--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -42,7 +42,7 @@ BUILTIN_TOOL_LABELS = {
 CHECK_FLAGS = {
     "buildifier": "-mode=check",
     "swiftformat": "--lint",
-    "prettier": "--check --log-level error",
+    "prettier": "--check --log-level warn",
     "ruff": "format --check --force-exclude --diff",
     "shfmt": "--diff --apply-ignore",
     "java-format": "--set-exit-if-changed --dry-run",
@@ -61,7 +61,7 @@ CHECK_FLAGS = {
 FIX_FLAGS = {
     "buildifier": "-mode=fix",
     "swiftformat": "",
-    "prettier": "--write --log-level error",
+    "prettier": "--write --log-level warn",
     # Force exclusions in the configuration file to be honored even when file paths are supplied
     # as command-line arguments; see
     # https://github.com/astral-sh/ruff/discussions/5857#discussioncomment-6583943

--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -42,7 +42,7 @@ BUILTIN_TOOL_LABELS = {
 CHECK_FLAGS = {
     "buildifier": "-mode=check",
     "swiftformat": "--lint",
-    "prettier": "--check",
+    "prettier": "--check --log-level error",
     "ruff": "format --check --force-exclude --diff",
     "shfmt": "--diff --apply-ignore",
     "java-format": "--set-exit-if-changed --dry-run",
@@ -61,7 +61,7 @@ CHECK_FLAGS = {
 FIX_FLAGS = {
     "buildifier": "-mode=fix",
     "swiftformat": "",
-    "prettier": "--write",
+    "prettier": "--write --log-level error",
     # Force exclusions in the configuration file to be honored even when file paths are supplied
     # as command-line arguments; see
     # https://github.com/astral-sh/ruff/discussions/5857#discussioncomment-6583943

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -9,11 +9,11 @@ bats_load_library "bats-assert"
     run bazel run //format/test:format_JavaScript_with_prettier
     assert_success
 
-    assert_output --partial "+ prettier --write --log-level error example/eslint.config.mjs"
-    assert_output --partial "+ prettier --write --log-level error example/src/file-dep.ts example/src/file.ts example/src/subdir/test.ts example/test/no_violations.ts"
-    assert_output --partial "+ prettier --write --log-level error example/src/hello.tsx"
-    assert_output --partial "+ prettier --write --log-level error example/src/hello.vue"
-    assert_output --partial "+ prettier --write --log-level error .bcr/metadata.template.json"
+    assert_output --partial "+ prettier --write --log-level warn example/eslint.config.mjs"
+    assert_output --partial "+ prettier --write --log-level warn example/src/file-dep.ts example/src/file.ts example/src/subdir/test.ts example/test/no_violations.ts"
+    assert_output --partial "+ prettier --write --log-level warn example/src/hello.tsx"
+    assert_output --partial "+ prettier --write --log-level warn example/src/hello.vue"
+    assert_output --partial "+ prettier --write --log-level warn .bcr/metadata.template.json"
 }
 
 # File arguments: will filter with find
@@ -37,37 +37,37 @@ bats_load_library "bats-assert"
     run bazel run //format/test:format_Markdown_with_prettier
     assert_success
 
-    assert_output --partial "+ prettier --write --log-level error .bcr/README.md CONTRIBUTING.md README.md"
+    assert_output --partial "+ prettier --write --log-level warn .bcr/README.md CONTRIBUTING.md README.md"
 }
 
 @test "should run prettier on CSS" {
     run bazel run //format/test:format_CSS_with_prettier
     assert_success
 
-    assert_output --partial "+ prettier --write --log-level error example/src/hello.css"
-    assert_output --partial "+ prettier --write --log-level error example/src/hello.less"
-    assert_output --partial "+ prettier --write --log-level error example/src/hello.scss"
+    assert_output --partial "+ prettier --write --log-level warn example/src/hello.css"
+    assert_output --partial "+ prettier --write --log-level warn example/src/hello.less"
+    assert_output --partial "+ prettier --write --log-level warn example/src/hello.scss"
 }
 
 @test "should run prettier on HTML" {
     run bazel run //format/test:format_HTML_with_prettier
     assert_success
 
-    assert_output --partial "+ prettier --write --log-level error example/src/index.html"
+    assert_output --partial "+ prettier --write --log-level warn example/src/index.html"
 }
 
 @test "should run prettier on GraphQL" {
     run bazel run //format/test:format_GraphQL_with_prettier
     assert_success
 
-    assert_output --partial "+ prettier --write --log-level error example/src/hello.graphql"
+    assert_output --partial "+ prettier --write --log-level warn example/src/hello.graphql"
 }
 
 @test "should run prettier on SQL" {
     run bazel run //format/test:format_SQL_with_prettier
     assert_success
 
-    assert_output --partial "+ prettier --write --log-level error example/src/hello.sql"
+    assert_output --partial "+ prettier --write --log-level warn example/src/hello.sql"
 }
 
 @test "should run ruff on Python" {

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -9,11 +9,11 @@ bats_load_library "bats-assert"
     run bazel run //format/test:format_JavaScript_with_prettier
     assert_success
 
-    assert_output --partial "+ prettier --write example/eslint.config.mjs"
-    assert_output --partial "+ prettier --write example/src/file-dep.ts example/src/file.ts example/src/subdir/test.ts example/test/no_violations.ts"
-    assert_output --partial "+ prettier --write example/src/hello.tsx"
-    assert_output --partial "+ prettier --write example/src/hello.vue"
-    assert_output --partial "+ prettier --write .bcr/metadata.template.json"
+    assert_output --partial "+ prettier --write --log-level error example/eslint.config.mjs"
+    assert_output --partial "+ prettier --write --log-level error example/src/file-dep.ts example/src/file.ts example/src/subdir/test.ts example/test/no_violations.ts"
+    assert_output --partial "+ prettier --write --log-level error example/src/hello.tsx"
+    assert_output --partial "+ prettier --write --log-level error example/src/hello.vue"
+    assert_output --partial "+ prettier --write --log-level error .bcr/metadata.template.json"
 }
 
 # File arguments: will filter with find
@@ -37,37 +37,37 @@ bats_load_library "bats-assert"
     run bazel run //format/test:format_Markdown_with_prettier
     assert_success
 
-    assert_output --partial "+ prettier --write .bcr/README.md CONTRIBUTING.md README.md"
+    assert_output --partial "+ prettier --write --log-level error .bcr/README.md CONTRIBUTING.md README.md"
 }
 
 @test "should run prettier on CSS" {
     run bazel run //format/test:format_CSS_with_prettier
     assert_success
 
-    assert_output --partial "+ prettier --write example/src/hello.css"
-    assert_output --partial "+ prettier --write example/src/hello.less"
-    assert_output --partial "+ prettier --write example/src/hello.scss"
+    assert_output --partial "+ prettier --write --log-level error example/src/hello.css"
+    assert_output --partial "+ prettier --write --log-level error example/src/hello.less"
+    assert_output --partial "+ prettier --write --log-level error example/src/hello.scss"
 }
 
 @test "should run prettier on HTML" {
     run bazel run //format/test:format_HTML_with_prettier
     assert_success
 
-    assert_output --partial "+ prettier --write example/src/index.html"
+    assert_output --partial "+ prettier --write --log-level error example/src/index.html"
 }
 
 @test "should run prettier on GraphQL" {
     run bazel run //format/test:format_GraphQL_with_prettier
     assert_success
 
-    assert_output --partial "+ prettier --write example/src/hello.graphql"
+    assert_output --partial "+ prettier --write --log-level error example/src/hello.graphql"
 }
 
 @test "should run prettier on SQL" {
     run bazel run //format/test:format_SQL_with_prettier
     assert_success
 
-    assert_output --partial "+ prettier --write example/src/hello.sql"
+    assert_output --partial "+ prettier --write --log-level error example/src/hello.sql"
 }
 
 @test "should run ruff on Python" {


### PR DESCRIPTION
Silence prettier output unless error because it defaults to `log` that is too verbose: https://prettier.io/docs/en/cli.html#--log-level

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: no update needed
- Breaking change (forces users to change their own code or config): yes because users will no longer see detailed outputs
- Suggested release notes appear below: yes

> `Prettier` is now configured to by default log at `error` level.

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
