### PR TITLE
Revert "feat: start testing on Bazel 8"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,11 +18,18 @@ concurrency:
 
 jobs:
   bazel-test:
-    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@bazel8
+    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v6
     with:
       folders: '[".", "example"]'
       # Don't try for Windows support yet.
       exclude_windows: true
+      # Root module is bzlmod-only and uses newer stardoc that requires Bazel 7.
+      # Example uses incompatible_enable_proto_toolchain_resolution
+      exclude: |
+        [
+          {"bzlmodEnabled": false, "folder": "."},
+          {"bazelversion": "6.4.0"}
+        ]
 
   integration-test:
     runs-on: ubuntu-latest

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,6 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
 # Minimum version needs 'chore: bump bazel-lib to 2.0 by @alexeagle in #1311'
 # to allow users on bazel-lib 2.0
 bazel_dep(name = "aspect_rules_js", version = "1.40.0")
-bazel_dep(name = "bazel_features", version = "1.18.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "platforms", version = "0.0.7")
 bazel_dep(name = "rules_multirun", version = "0.9.0")

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -1,7 +1,6 @@
 # This load statement must be in the docs/ package rather than anything users depend on
 # so that the dependency on stardoc doesn't leak to them.
 load("@aspect_bazel_lib//lib:docs.bzl", "stardoc_with_diff_test", "update_docs")
-load("@bazel_features//private:util.bzl", "lt")
 
 stardoc_with_diff_test(
     name = "lint_test",
@@ -36,8 +35,6 @@ stardoc_with_diff_test(
 stardoc_with_diff_test(
     name = "format",
     bzl_library_target = "//format:defs",
-    # See https://github.com/bazel-contrib/bazel_features/pull/75
-    target_compatible_with = ["@platforms//:incompatible"] if lt("8.0.0-pre.20240911.1") else [],
 )
 
 stardoc_with_diff_test(

--- a/docs/format.md
+++ b/docs/format.md
@@ -101,7 +101,7 @@ Some languages have dialects:
 <pre>
 load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
 
-format_multirun(<a href="#format_multirun-name">name</a>, <a href="#format_multirun-jobs">jobs</a>, <a href="#format_multirun-print_command">print_command</a>, <a href="#format_multirun-disable_git_attribute_checks">disable_git_attribute_checks</a>, <a href="#format_multirun-kwargs">**kwargs</a>)
+format_multirun(<a href="#format_multirun-name">name</a>, <a href="#format_multirun-jobs">jobs</a>, <a href="#format_multirun-print_command">print_command</a>, <a href="#format_multirun-disable_git_attribute_checks">disable_git_attribute_checks</a>, <a href="#format_multirun-kwargs">kwargs</a>)
 </pre>
 
 Create a [multirun] binary for the given languages.
@@ -135,7 +135,7 @@ To check formatting with `bazel test`, use [format_test](#format_test) instead.
 <pre>
 load("@aspect_rules_lint//format:defs.bzl", "format_test")
 
-format_test(<a href="#format_test-name">name</a>, <a href="#format_test-srcs">srcs</a>, <a href="#format_test-workspace">workspace</a>, <a href="#format_test-no_sandbox">no_sandbox</a>, <a href="#format_test-disable_git_attribute_checks">disable_git_attribute_checks</a>, <a href="#format_test-tags">tags</a>, <a href="#format_test-kwargs">**kwargs</a>)
+format_test(<a href="#format_test-name">name</a>, <a href="#format_test-srcs">srcs</a>, <a href="#format_test-workspace">workspace</a>, <a href="#format_test-no_sandbox">no_sandbox</a>, <a href="#format_test-disable_git_attribute_checks">disable_git_attribute_checks</a>, <a href="#format_test-tags">tags</a>, <a href="#format_test-kwargs">kwargs</a>)
 </pre>
 
 Create test for the given formatters.


### PR DESCRIPTION
Reverts aspect-build/rules_lint#401

It broke main. I should have pinned the new reusable workflow at a commit instead of using a branch.