### PR TITLE
fix: Add implementation_deps to the compilation_context used for clang-tidy

### DIFF
--- a/lint/clang_tidy.bzl
+++ b/lint/clang_tidy.bzl
@@ -371,6 +371,11 @@ def _clang_tidy_aspect_impl(target, ctx):
 
     files_to_lint = _filter_srcs(ctx.rule)
     compilation_context = target[CcInfo].compilation_context
+    if hasattr(ctx.rule.attr, "implementation_deps"):
+        compilation_context = cc_common.merge_compilation_contexts(
+            compilation_contexts = [compilation_context] +
+                [implementation_dep[CcInfo].compilation_context for implementation_dep in ctx.rule.attr.implementation_deps])
+
     if ctx.attr._options[LintOptionsInfo].fix:
         outputs, info = patch_and_output_files(_MNEMONIC, target, ctx)
     else:


### PR DESCRIPTION
Updated the compilation_context used by clang-tidy lint actions to include implementation_deps so that any headers that are made available via implementation_deps targets are now visible to clang-tidy.

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes
clang-tidy can now see headers provided by `implementation_deps`

### Test plan

- Manual testing; please provide instructions so we can reproduce:
Create a C++ target that has an implementation_dep that provides a header file; try to include the header and clang_tidy will fail to find it without this change.
