### PR TITLE
chore: upgrade PMD to version 7

### DIFF
--- a/example/tools/lint/BUILD.bazel
+++ b/example/tools/lint/BUILD.bazel
@@ -32,7 +32,11 @@ stylelint_bin.stylelint_binary(name = "stylelint")
 
 java_binary(
     name = "pmd",
-    main_class = "net.sourceforge.pmd.PMD",
+    # In PMD 6.x, this was the main class:
+    # main_class = "net.sourceforge.pmd.PMD",
+    # It changed in version 7.0
+    # https://docs.pmd-code.org/pmd-doc-7.0.0/pmd_userdocs_migrating_to_pmd7.html
+    main_class = "net.sourceforge.pmd.cli.PmdCli",
     runtime_deps = ["@net_sourceforge_pmd"],
 )
 

--- a/lint/pmd.bzl
+++ b/lint/pmd.bzl
@@ -53,6 +53,13 @@ def pmd_action(ctx, executable, srcs, rulesets, stdout, exit_code = None, option
     # Wire command-line options, see
     # https://docs.pmd-code.org/latest/pmd_userdocs_cli_reference.html
     args = ctx.actions.args()
+    args.add("check")
+    args.add("--no-progress")
+
+    # https://docs.pmd-code.org/pmd-doc-7.7.0/pmd_userdocs_incremental_analysis.html
+    # is non-hermetic, and requires some thought and care before trying to use previous results.
+    # If this is actually needed, it will probably have to be run as a Persistent worker :(
+    args.add("--no-cache")
     args.add_all(options)
     args.add("--rulesets")
     args.add_joined(rulesets, join_with = ",")
@@ -62,7 +69,8 @@ def pmd_action(ctx, executable, srcs, rulesets, stdout, exit_code = None, option
     src_args.add_all(srcs)
 
     if exit_code:
-        command = "{PMD} $@ >{stdout}; echo $? > " + exit_code.path
+        args.add_all(["--report-file", stdout.path])
+        command = "{PMD} $@; echo $? > " + exit_code.path
         outputs.append(exit_code)
     else:
         # Create empty stdout file on success, as Bazel expects one
@@ -144,7 +152,7 @@ def fetch_pmd():
     http_archive(
         name = "net_sourceforge_pmd",
         build_file_content = """java_import(name = "net_sourceforge_pmd", jars = glob(["*.jar"]), visibility = ["//visibility:public"])""",
-        sha256 = "21acf96d43cb40d591cacccc1c20a66fc796eaddf69ea61812594447bac7a11d",
-        strip_prefix = "pmd-bin-6.55.0/lib",
-        url = "https://github.com/pmd/pmd/releases/download/pmd_releases/6.55.0/pmd-bin-6.55.0.zip",
+        integrity = "sha256-vov2j2wdZphL2WRak+Yxt4ocL0L18PhxkIL+rWdVOUA=",
+        strip_prefix = "pmd-bin-7.7.0/lib",
+        url = "https://github.com/pmd/pmd/releases/download/pmd_releases/7.7.0/pmd-dist-7.7.0-bin.zip",
     )


### PR DESCRIPTION
There is a minor breaking change to the CLI args, so users have to upgrade along with rules_lint. If they use our fetch_pmd helper this works automatically.

However they also must update the java_binary main_class attribute.

Fixes #418
