### PR TITLE
Add --lint=fix and --lint=warn to buildifier

### DIFF
--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -40,7 +40,7 @@ BUILTIN_TOOL_LABELS = {
 
 # Flags to pass each tool's CLI when running in check mode
 CHECK_FLAGS = {
-    "buildifier": "-mode=check",
+    "buildifier": "-mode=check -lint=warn",
     "swiftformat": "--lint",
     "prettier": "--check",
     "ruff": "format --check --force-exclude --diff",
@@ -59,7 +59,7 @@ CHECK_FLAGS = {
 
 # Flags to pass each tool when running in default mode
 FIX_FLAGS = {
-    "buildifier": "-mode=fix",
+    "buildifier": "-mode=fix -lint=fix",
     "swiftformat": "",
     "prettier": "--write",
     # Force exclusions in the configuration file to be honored even when file paths are supplied


### PR DESCRIPTION

Add flag --lint=fix and --lint=warn to the buildifier. 
https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md


---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
