### PR TITLE
Pass disable_git_attribute_checks via env instead

### DIFF
--- a/format/defs.bzl
+++ b/format/defs.bzl
@@ -24,8 +24,6 @@ def _format_attr_factory(target_name, lang, toolname, tool_label, mode, disable_
         fail("Invalid mode", mode)
 
     args = []
-    if disable_git_attribute_checks:
-        args.append("--disable_git_attribute_checks")
 
     # this dict is used to create the attributes both to pass to command() (for
     # format_multirun) and to sh_test() (for format_test, so it has to toggle
@@ -41,6 +39,7 @@ def _format_attr_factory(target_name, lang, toolname, tool_label, mode, disable_
             "lang": lang,
             "flags": FIX_FLAGS[toolname] if mode == "fix" else CHECK_FLAGS[toolname],
             "mode": "check" if mode == "test" else mode,
+            "disable_git_attribute_checks": "true" if disable_git_attribute_checks else "false",
         },
         "data": [tool_label],
         ("args" if mode == "test" else "arguments"): args,

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -110,12 +110,6 @@ function process_args_in_batches() {
 # Exports a function that is similar to 'git ls-files'
 # ls-files <language> [<file>...]
 function ls-files {
-    disable_git_attribute_checks=false
-    if [[ "${!#}" == "--disable_git_attribute_checks" ]]; then
-      set -- "${@:1:$#-1}"
-      disable_git_attribute_checks=true
-    fi
-
     language="$1" && shift;
     # Copied file patterns from
     # https://github.com/github-linguist/linguist/blob/559a6426942abcae16b6d6b328147476432bf6cb/lib/linguist/languages.yml

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -183,7 +183,7 @@ function ls-files {
         files=$(find "$@" "${find_args[@]}")
     fi
 
-    if [[ $disable_git_attribute_checks == true ]]; then
+    if [[ ${disable_git_attribute_checks:-} == true ]]; then
       # files should be returned newline separated to avoid a "File name too long" error
       for file in $files; do
         echo "$file"

--- a/format/test/ls-files_test.sh
+++ b/format/test/ls-files_test.sh
@@ -55,7 +55,7 @@ js=$(ls-files JavaScript  gen1.js gen2.js gen3.js src.js)
     echo >&2 -e "expected ls-files to return src.js, was\n$js"
     exit 1
 }
-js=$(ls-files JavaScript src.js gen1.js gen2.js gen3.js --disable_git_attribute_checks)
+js=$(disable_git_attribute_checks=true ls-files JavaScript src.js gen1.js gen2.js gen3.js)
 expected='src.js
 gen1.js
 gen2.js


### PR DESCRIPTION
This fixes the ability to run `bazel run //:format -- <filenames>` with git attribute parsing disabled.

`format.sh` expected this flag to be the last argument, however when running with `rules_multirun` all arguments passed at the end of `bazel run` get appended to the `args`. So, the flag that was expected to be last was no longer last, and it re-enabled gitattribute parsing and caused an issue with `find` not expecting this flag.

This patch makes it an environment variable, like all other information that's passed to the format.sh script.

-----

The bug:
```
❯ bazel run //:format -- defs.bzl
...
INFO: Running command line: bazel-bin/format.bash defs.bzl
...
find: illegal option -- -
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
...
```