### PR TITLE
Patch rules_lint buildifier and checkstyle

### DIFF
--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -40,7 +40,7 @@ BUILTIN_TOOL_LABELS = {
 
 # Flags to pass each tool's CLI when running in check mode
 CHECK_FLAGS = {
-    "buildifier": "-mode=check",
+    "buildifier": "-mode=check -lint=warn",
     "swiftformat": "--lint",
     "prettier": "--check",
     "ruff": "format --check --force-exclude --diff",
@@ -59,7 +59,7 @@ CHECK_FLAGS = {
 
 # Flags to pass each tool when running in default mode
 FIX_FLAGS = {
-    "buildifier": "-mode=fix",
+    "buildifier": "-mode=fix -lint=fix",
     "swiftformat": "",
     "prettier": "--write",
     # Force exclusions in the configuration file to be honored even when file paths are supplied

--- a/lint/checkstyle.bzl
+++ b/lint/checkstyle.bzl
@@ -161,6 +161,6 @@ def lint_checkstyle_aspect(binary, config, data = [], rule_kinds = ["java_binary
 def fetch_checkstyle():
     http_jar(
         name = "com_puppycrawl_tools_checkstyle",
-        url = "https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.17.0/checkstyle-10.17.0-all.jar",
-        sha256 = "51c34d738520c1389d71998a9ab0e6dabe0d7cf262149f3e01a7294496062e42",
+        url = "https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.20.1/checkstyle-10.20.1-all.jar",
+        sha256 = "591524e5321421272c16fbb38009a91b5f3d95535fb3cb52140f7a3ac07ea9fe",
     )


### PR DESCRIPTION
- Patch buildifier to support linter warnings. https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md
- Upgrade checkstyle to version 10.20.1

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
