### PR TITLE
fix: support newer eslint versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,3 +30,10 @@ multitool.hub(lockfile = "//lint:multitool.lock.json")
 use_repo(multitool, "multitool")
 
 bazel_dep(name = "stardoc", version = "0.7.0", dev_dependency = True, repo_name = "io_bazel_stardoc")
+
+npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
+npm.npm_translate_lock(
+    name = "rules_lint_npm",
+    pnpm_lock = "//lint/js:pnpm-lock.yaml",
+)
+use_repo(npm, "rules_lint_npm")

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -274,12 +274,10 @@ def lint_eslint_aspect(binary, configs, rule_kinds = ["js_library", "ts_project"
             ),
             "_compact_formatter": attr.label(
                 default = "@aspect_rules_lint//lint:eslint.compact-formatter",
-                allow_single_file = True,
                 cfg = "exec",
             ),
             "_stylish_formatter": attr.label(
                 default = "@aspect_rules_lint//lint:eslint.stylish-formatter",
-                allow_single_file = True,
                 cfg = "exec",
             ),
             "_rule_kinds": attr.string_list(

--- a/lint/js/BUILD.bazel
+++ b/lint/js/BUILD.bazel
@@ -1,4 +1,7 @@
 load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@rules_lint_npm//:defs.bzl", "npm_link_all_packages")
+
+npm_link_all_packages()
 
 js_library(
     name = "eslint.workaround_17660",
@@ -15,6 +18,10 @@ js_library(
 js_library(
     name = "eslint.stylish-formatter",
     srcs = ["eslint.stylish-formatter.js"],
+    deps = [
+        ":node_modules/chalk",
+        ":node_modules/strip-ansi",
+        ":node_modules/text-table",
+    ],
     visibility = ["//visibility:public"],
 )
-

--- a/lint/js/eslint.stylish-formatter.js
+++ b/lint/js/eslint.stylish-formatter.js
@@ -25,9 +25,9 @@ if (idx < 0) {
 }
 const searchPath = eslintEntry.substring(0, idx);
 // Modify the upstream code to pass through an explicit `require.resolve` that starts from eslint
-const chalk = require(require.resolve("chalk", { paths: [searchPath] })),
-  stripAnsi = require(require.resolve("strip-ansi", { paths: [searchPath] })),
-  table = require(require.resolve("text-table", { paths: [searchPath] }));
+const chalk = require("chalk"),
+  stripAnsi = require("strip-ansi"),
+  table = require("text-table");
 
 //------------------------------------------------------------------------------
 // Helpers

--- a/lint/js/package.json
+++ b/lint/js/package.json
@@ -1,0 +1,10 @@
+{
+	"dependencies": {
+		"chalk": "^4.0.0",
+		"text-table": "^0.2.0",
+		"strip-ansi": "^6.0.1"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": []
+	}
+}

--- a/lint/js/pnpm-lock.yaml
+++ b/lint/js/pnpm-lock.yaml
@@ -1,0 +1,109 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      chalk:
+        specifier: ^4.0.0
+        version: 4.1.2
+      strip-ansi:
+        specifier: ^6.0.1
+        version: 6.0.1
+      text-table:
+        specifier: ^0.2.0
+        version: 0.2.0
+
+  lint/js:
+    dependencies:
+      strip-ansi:
+        specifier: ^7.1.0
+        version: 7.1.0
+      text-table:
+        specifier: ^0.2.0
+        version: 0.2.0
+
+packages:
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+snapshots:
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.1.0: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  has-flag@4.0.0: {}
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.1.0
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  text-table@0.2.0: {}


### PR DESCRIPTION
Support more recent eslint versions as up to 9.15.0. Instead of implicilty depending on the dependency tree of eslint itself add dependencies of eslint.stylish-formatter expliclity.

Fixes #434

---

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Created repository which has eslint 9.15.0 as requirement. Add local_path_override to the branch of this repository and try to run the linting.
