### PR TITLE
chore: re-vendor newer eslint stylish formatter

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -4,14 +4,14 @@
     "moment": "*"
   },
   "devDependencies": {
-    "@eslint/js": "^9",
+    "@eslint/js": "^9.16.0",
     "@types/node": "^18",
-    "eslint": "^9",
+    "eslint": "^9.16.0",
     "prettier": "^2.8.7",
     "prettier-plugin-sql": "^0.14.0",
     "stylelint": "^16",
     "stylelint-config-standard": "^36.0.1",
     "typescript": "4.9.5",
-    "typescript-eslint": "^7.10.0"
+    "typescript-eslint": "^8.17.0"
   }
 }

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: "6.0"
 
 settings:
   autoInstallPeers: true
@@ -9,19 +9,19 @@ dependencies:
     specifier: ^1.11.11
     version: 1.11.11
   moment:
-    specifier: '*'
+    specifier: "*"
     version: 1.0.0
 
 devDependencies:
-  '@eslint/js':
-    specifier: ^9
-    version: 9.3.0
-  '@types/node':
+  "@eslint/js":
+    specifier: ^9.16.0
+    version: 9.16.0
+  "@types/node":
     specifier: ^18
     version: 18.0.0
   eslint:
-    specifier: ^9
-    version: 9.3.0
+    specifier: ^9.16.0
+    version: 9.16.0
   prettier:
     specifier: ^2.8.7
     version: 2.8.8
@@ -38,8 +38,8 @@ devDependencies:
     specifier: 4.9.5
     version: 4.9.5
   typescript-eslint:
-    specifier: ^7.10.0
-    version: 7.10.0(eslint@9.3.0)(typescript@4.9.5)
+    specifier: ^8.17.0
+    version: 8.17.0(eslint@9.16.0)(typescript@4.9.5)
 
 packages:
   /@babel/code-frame@7.24.7:
@@ -47,9 +47,9 @@ packages:
       {
         integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==,
       }
-    engines: { node: '>=6.9.0' }
+    engines: { node: ">=6.9.0" }
     dependencies:
-      '@babel/highlight': 7.24.7
+      "@babel/highlight": 7.24.7
       picocolors: 1.0.1
     dev: true
 
@@ -58,7 +58,7 @@ packages:
       {
         integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==,
       }
-    engines: { node: '>=6.9.0' }
+    engines: { node: ">=6.9.0" }
     dev: true
 
   /@babel/highlight@7.24.7:
@@ -66,9 +66,9 @@ packages:
       {
         integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==,
       }
-    engines: { node: '>=6.9.0' }
+    engines: { node: ">=6.9.0" }
     dependencies:
-      '@babel/helper-validator-identifier': 7.24.7
+      "@babel/helper-validator-identifier": 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.0.1
@@ -81,9 +81,9 @@ packages:
       }
     engines: { node: ^14 || ^16 || >=18 }
     peerDependencies:
-      '@csstools/css-tokenizer': ^2.4.1
+      "@csstools/css-tokenizer": ^2.4.1
     dependencies:
-      '@csstools/css-tokenizer': 2.4.1
+      "@csstools/css-tokenizer": 2.4.1
     dev: true
 
   /@csstools/css-tokenizer@2.4.1:
@@ -101,11 +101,11 @@ packages:
       }
     engines: { node: ^14 || ^16 || >=18 }
     peerDependencies:
-      '@csstools/css-parser-algorithms': ^2.7.1
-      '@csstools/css-tokenizer': ^2.4.1
+      "@csstools/css-parser-algorithms": ^2.7.1
+      "@csstools/css-tokenizer": ^2.4.1
     dependencies:
-      '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
-      '@csstools/css-tokenizer': 2.4.1
+      "@csstools/css-parser-algorithms": 2.7.1(@csstools/css-tokenizer@2.4.1)
+      "@csstools/css-tokenizer": 2.4.1
     dev: true
 
   /@csstools/selector-specificity@3.1.1(postcss-selector-parser@6.1.1):
@@ -127,7 +127,7 @@ packages:
       }
     dev: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@9.3.0):
+  /@eslint-community/eslint-utils@4.4.0(eslint@9.16.0):
     resolution:
       {
         integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==,
@@ -136,30 +136,54 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 9.3.0
-      eslint-visitor-keys: 3.4.0
+      eslint: 9.16.0
+      eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@eslint-community/regexpp@4.10.0:
+  /@eslint-community/regexpp@4.12.1:
     resolution:
       {
-        integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==,
+        integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==,
       }
     engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
     dev: true
 
-  /@eslint/eslintrc@3.1.0:
+  /@eslint/config-array@0.19.1:
     resolution:
       {
-        integrity: sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==,
+        integrity: sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    dependencies:
+      "@eslint/object-schema": 2.1.5
+      debug: 4.3.5
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@eslint/core@0.9.1:
+    resolution:
+      {
+        integrity: sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    dependencies:
+      "@types/json-schema": 7.0.15
+    dev: true
+
+  /@eslint/eslintrc@3.2.0:
+    resolution:
+      {
+        integrity: sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
-      espree: 10.0.1
+      debug: 4.3.5
+      espree: 10.3.0
       globals: 14.0.0
-      ignore: 5.2.4
+      ignore: 5.3.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -168,26 +192,49 @@ packages:
       - supports-color
     dev: true
 
-  /@eslint/js@9.3.0:
+  /@eslint/js@9.16.0:
     resolution:
       {
-        integrity: sha512-niBqk8iwv96+yuTwjM6bWg8ovzAPF9qkICsGtcoa5/dmqcEMfdwNAX7+/OHcJHc7wj7XqPxH98oAHytFYlw6Sw==,
+        integrity: sha512-tw2HxzQkrbeuvyj1tG2Yqq+0H9wGoI2IMk4EOsQeX+vmd75FtJAzf+gTA69WF+baUKRYQ3x2kbLE08js5OsTVg==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     dev: true
 
-  /@humanwhocodes/config-array@0.13.0:
+  /@eslint/object-schema@2.1.5:
     resolution:
       {
-        integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==,
+        integrity: sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==,
       }
-    engines: { node: '>=10.10.0' }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    dev: true
+
+  /@eslint/plugin-kit@0.2.4:
+    resolution:
+      {
+        integrity: sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     dependencies:
-      '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.4
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
+      levn: 0.4.1
+    dev: true
+
+  /@humanfs/core@0.19.1:
+    resolution:
+      {
+        integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==,
+      }
+    engines: { node: ">=18.18.0" }
+    dev: true
+
+  /@humanfs/node@0.16.6:
+    resolution:
+      {
+        integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==,
+      }
+    engines: { node: ">=18.18.0" }
+    dependencies:
+      "@humanfs/core": 0.19.1
+      "@humanwhocodes/retry": 0.3.0
     dev: true
 
   /@humanwhocodes/module-importer@1.0.1:
@@ -195,14 +242,7 @@ packages:
       {
         integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==,
       }
-    engines: { node: '>=12.22' }
-    dev: true
-
-  /@humanwhocodes/object-schema@2.0.3:
-    resolution:
-      {
-        integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==,
-      }
+    engines: { node: ">=12.22" }
     dev: true
 
   /@humanwhocodes/retry@0.3.0:
@@ -210,7 +250,15 @@ packages:
       {
         integrity: sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==,
       }
-    engines: { node: '>=18.18' }
+    engines: { node: ">=18.18" }
+    dev: true
+
+  /@humanwhocodes/retry@0.4.1:
+    resolution:
+      {
+        integrity: sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==,
+      }
+    engines: { node: ">=18.18" }
     dev: true
 
   /@nodelib/fs.scandir@2.1.5:
@@ -218,9 +266,9 @@ packages:
       {
         integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==,
       }
-    engines: { node: '>= 8' }
+    engines: { node: ">= 8" }
     dependencies:
-      '@nodelib/fs.stat': 2.0.5
+      "@nodelib/fs.stat": 2.0.5
       run-parallel: 1.2.0
     dev: true
 
@@ -229,7 +277,7 @@ packages:
       {
         integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==,
       }
-    engines: { node: '>= 8' }
+    engines: { node: ">= 8" }
     dev: true
 
   /@nodelib/fs.walk@1.2.8:
@@ -237,10 +285,24 @@ packages:
       {
         integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
       }
-    engines: { node: '>= 8' }
+    engines: { node: ">= 8" }
     dependencies:
-      '@nodelib/fs.scandir': 2.1.5
+      "@nodelib/fs.scandir": 2.1.5
       fastq: 1.15.0
+    dev: true
+
+  /@types/estree@1.0.6:
+    resolution:
+      {
+        integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==,
+      }
+    dev: true
+
+  /@types/json-schema@7.0.15:
+    resolution:
+      {
+        integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
+      }
     dev: true
 
   /@types/node@18.0.0:
@@ -250,27 +312,27 @@ packages:
       }
     dev: true
 
-  /@typescript-eslint/eslint-plugin@7.10.0(@typescript-eslint/parser@7.10.0)(eslint@9.3.0)(typescript@4.9.5):
+  /@typescript-eslint/eslint-plugin@8.17.0(@typescript-eslint/parser@8.17.0)(eslint@9.16.0)(typescript@4.9.5):
     resolution:
       {
-        integrity: sha512-PzCr+a/KAef5ZawX7nbyNwBDtM1HdLIT53aSA2DDlxmxMngZ43O8SIePOeX8H5S+FHXeI6t97mTt/dDdzY4Fyw==,
+        integrity: sha512-HU1KAdW3Tt8zQkdvNoIijfWDMvdSweFYm4hWh+KwhPstv+sCmWb89hCIP8msFm9N1R/ooh9honpSuvqKWlYy3w==,
       }
-    engines: { node: ^18.18.0 || >=20.0.0 }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      '@typescript-eslint/parser': ^7.0.0
-      eslint: ^8.56.0
-      typescript: '*'
+      "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: "*"
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 7.10.0(eslint@9.3.0)(typescript@4.9.5)
-      '@typescript-eslint/scope-manager': 7.10.0
-      '@typescript-eslint/type-utils': 7.10.0(eslint@9.3.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 7.10.0(eslint@9.3.0)(typescript@4.9.5)
-      '@typescript-eslint/visitor-keys': 7.10.0
-      eslint: 9.3.0
+      "@eslint-community/regexpp": 4.12.1
+      "@typescript-eslint/parser": 8.17.0(eslint@9.16.0)(typescript@4.9.5)
+      "@typescript-eslint/scope-manager": 8.17.0
+      "@typescript-eslint/type-utils": 8.17.0(eslint@9.16.0)(typescript@4.9.5)
+      "@typescript-eslint/utils": 8.17.0(eslint@9.16.0)(typescript@4.9.5)
+      "@typescript-eslint/visitor-keys": 8.17.0
+      eslint: 9.16.0
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
@@ -280,88 +342,88 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@7.10.0(eslint@9.3.0)(typescript@4.9.5):
+  /@typescript-eslint/parser@8.17.0(eslint@9.16.0)(typescript@4.9.5):
     resolution:
       {
-        integrity: sha512-2EjZMA0LUW5V5tGQiaa2Gys+nKdfrn2xiTIBLR4fxmPmVSvgPcKNW+AE/ln9k0A4zDUti0J/GZXMDupQoI+e1w==,
+        integrity: sha512-Drp39TXuUlD49F7ilHHCG7TTg8IkA+hxCuULdmzWYICxGXvDXmDmWEjJYZQYgf6l/TFfYNE167m7isnc3xlIEg==,
       }
-    engines: { node: ^18.18.0 || >=20.0.0 }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: "*"
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 7.10.0
-      '@typescript-eslint/types': 7.10.0
-      '@typescript-eslint/typescript-estree': 7.10.0(typescript@4.9.5)
-      '@typescript-eslint/visitor-keys': 7.10.0
-      debug: 4.3.4
-      eslint: 9.3.0
+      "@typescript-eslint/scope-manager": 8.17.0
+      "@typescript-eslint/types": 8.17.0
+      "@typescript-eslint/typescript-estree": 8.17.0(typescript@4.9.5)
+      "@typescript-eslint/visitor-keys": 8.17.0
+      debug: 4.3.5
+      eslint: 9.16.0
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager@7.10.0:
+  /@typescript-eslint/scope-manager@8.17.0:
     resolution:
       {
-        integrity: sha512-7L01/K8W/VGl7noe2mgH0K7BE29Sq6KAbVmxurj8GGaPDZXPr8EEQ2seOeAS+mEV9DnzxBQB6ax6qQQ5C6P4xg==,
+        integrity: sha512-/ewp4XjvnxaREtqsZjF4Mfn078RD/9GmiEAtTeLQ7yFdKnqwTOgRMSvFz4et9U5RiJQ15WTGXPLj89zGusvxBg==,
       }
-    engines: { node: ^18.18.0 || >=20.0.0 }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     dependencies:
-      '@typescript-eslint/types': 7.10.0
-      '@typescript-eslint/visitor-keys': 7.10.0
+      "@typescript-eslint/types": 8.17.0
+      "@typescript-eslint/visitor-keys": 8.17.0
     dev: true
 
-  /@typescript-eslint/type-utils@7.10.0(eslint@9.3.0)(typescript@4.9.5):
+  /@typescript-eslint/type-utils@8.17.0(eslint@9.16.0)(typescript@4.9.5):
     resolution:
       {
-        integrity: sha512-D7tS4WDkJWrVkuzgm90qYw9RdgBcrWmbbRkrLA4d7Pg3w0ttVGDsvYGV19SH8gPR5L7OtcN5J1hTtyenO9xE9g==,
+        integrity: sha512-q38llWJYPd63rRnJ6wY/ZQqIzPrBCkPdpIsaCfkR3Q4t3p6sb422zougfad4TFW9+ElIFLVDzWGiGAfbb/v2qw==,
       }
-    engines: { node: ^18.18.0 || >=20.0.0 }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: "*"
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.10.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 7.10.0(eslint@9.3.0)(typescript@4.9.5)
-      debug: 4.3.4
-      eslint: 9.3.0
+      "@typescript-eslint/typescript-estree": 8.17.0(typescript@4.9.5)
+      "@typescript-eslint/utils": 8.17.0(eslint@9.16.0)(typescript@4.9.5)
+      debug: 4.3.5
+      eslint: 9.16.0
       ts-api-utils: 1.3.0(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types@7.10.0:
+  /@typescript-eslint/types@8.17.0:
     resolution:
       {
-        integrity: sha512-7fNj+Ya35aNyhuqrA1E/VayQX9Elwr8NKZ4WueClR3KwJ7Xx9jcCdOrLW04h51de/+gNbyFMs+IDxh5xIwfbNg==,
+        integrity: sha512-gY2TVzeve3z6crqh2Ic7Cr+CAv6pfb0Egee7J5UAVWCpVvDI/F71wNfolIim4FE6hT15EbpZFVUj9j5i38jYXA==,
       }
-    engines: { node: ^18.18.0 || >=20.0.0 }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     dev: true
 
-  /@typescript-eslint/typescript-estree@7.10.0(typescript@4.9.5):
+  /@typescript-eslint/typescript-estree@8.17.0(typescript@4.9.5):
     resolution:
       {
-        integrity: sha512-LXFnQJjL9XIcxeVfqmNj60YhatpRLt6UhdlFwAkjNc6jSUlK8zQOl1oktAP8PlWFzPQC1jny/8Bai3/HPuvN5g==,
+        integrity: sha512-JqkOopc1nRKZpX+opvKqnM3XUlM7LpFMD0lYxTqOTKQfCWAmxw45e3qlOCsEqEB2yuacujivudOFpCnqkBDNMw==,
       }
-    engines: { node: ^18.18.0 || >=20.0.0 }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      typescript: '*'
+      typescript: "*"
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 7.10.0
-      '@typescript-eslint/visitor-keys': 7.10.0
-      debug: 4.3.4
-      globby: 11.1.0
+      "@typescript-eslint/types": 8.17.0
+      "@typescript-eslint/visitor-keys": 8.17.0
+      debug: 4.3.5
+      fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.4
       semver: 7.6.2
@@ -371,37 +433,41 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@7.10.0(eslint@9.3.0)(typescript@4.9.5):
+  /@typescript-eslint/utils@8.17.0(eslint@9.16.0)(typescript@4.9.5):
     resolution:
       {
-        integrity: sha512-olzif1Fuo8R8m/qKkzJqT7qwy16CzPRWBvERS0uvyc+DHd8AKbO4Jb7kpAvVzMmZm8TrHnI7hvjN4I05zow+tg==,
+        integrity: sha512-bQC8BnEkxqG8HBGKwG9wXlZqg37RKSMY7v/X8VEWD8JG2JuTHuNK0VFvMPMUKQcbk6B+tf05k+4AShAEtCtJ/w==,
       }
-    engines: { node: ^18.18.0 || >=20.0.0 }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: "*"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.3.0)
-      '@typescript-eslint/scope-manager': 7.10.0
-      '@typescript-eslint/types': 7.10.0
-      '@typescript-eslint/typescript-estree': 7.10.0(typescript@4.9.5)
-      eslint: 9.3.0
+      "@eslint-community/eslint-utils": 4.4.0(eslint@9.16.0)
+      "@typescript-eslint/scope-manager": 8.17.0
+      "@typescript-eslint/types": 8.17.0
+      "@typescript-eslint/typescript-estree": 8.17.0(typescript@4.9.5)
+      eslint: 9.16.0
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
-      - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys@7.10.0:
+  /@typescript-eslint/visitor-keys@8.17.0:
     resolution:
       {
-        integrity: sha512-9ntIVgsi6gg6FIq9xjEO4VQJvwOqA3jaBFQJ/6TK5AvEup2+cECI6Fh7QiBxmfMHXU0V0J4RyPeOU1VDNzl9cg==,
+        integrity: sha512-1Hm7THLpO6ww5QU6H/Qp+AusUUl+z/CAm3cNZZ0jQvon9yicgO7Rwd+/WWRpMKLYV6p2UvdbR27c86rzCPpreg==,
       }
-    engines: { node: ^18.18.0 || >=20.0.0 }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     dependencies:
-      '@typescript-eslint/types': 7.10.0
-      eslint-visitor-keys: 3.4.3
+      "@typescript-eslint/types": 8.17.0
+      eslint-visitor-keys: 4.2.0
     dev: true
 
-  /acorn-jsx@5.3.2(acorn@8.11.3):
+  /acorn-jsx@5.3.2(acorn@8.14.0):
     resolution:
       {
         integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
@@ -409,15 +475,15 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.11.3
+      acorn: 8.14.0
     dev: true
 
-  /acorn@8.11.3:
+  /acorn@8.14.0:
     resolution:
       {
-        integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==,
+        integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==,
       }
-    engines: { node: '>=0.4.0' }
+    engines: { node: ">=0.4.0" }
     hasBin: true
     dev: true
 
@@ -450,7 +516,7 @@ packages:
       {
         integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dev: true
 
   /ansi-regex@6.0.1:
@@ -458,7 +524,7 @@ packages:
       {
         integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==,
       }
-    engines: { node: '>=12' }
+    engines: { node: ">=12" }
     dev: true
 
   /ansi-styles@3.2.1:
@@ -466,7 +532,7 @@ packages:
       {
         integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==,
       }
-    engines: { node: '>=4' }
+    engines: { node: ">=4" }
     dependencies:
       color-convert: 1.9.3
     dev: true
@@ -476,7 +542,7 @@ packages:
       {
         integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dependencies:
       color-convert: 2.0.1
     dev: true
@@ -494,7 +560,7 @@ packages:
       {
         integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dev: true
 
   /astral-regex@2.0.0:
@@ -502,7 +568,7 @@ packages:
       {
         integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dev: true
 
   /balanced-match@1.0.2:
@@ -524,7 +590,7 @@ packages:
       {
         integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==,
       }
-    engines: { node: '>=0.6' }
+    engines: { node: ">=0.6" }
     dev: true
 
   /brace-expansion@1.1.11:
@@ -551,7 +617,7 @@ packages:
       {
         integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dependencies:
       fill-range: 7.1.1
     dev: true
@@ -561,7 +627,7 @@ packages:
       {
         integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
       }
-    engines: { node: '>=6' }
+    engines: { node: ">=6" }
     dev: true
 
   /chalk@2.4.2:
@@ -569,7 +635,7 @@ packages:
       {
         integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==,
       }
-    engines: { node: '>=4' }
+    engines: { node: ">=4" }
     dependencies:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
@@ -581,7 +647,7 @@ packages:
       {
         integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
       }
-    engines: { node: '>=10' }
+    engines: { node: ">=10" }
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
@@ -601,7 +667,7 @@ packages:
       {
         integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
       }
-    engines: { node: '>=7.0.0' }
+    engines: { node: ">=7.0.0" }
     dependencies:
       color-name: 1.1.4
     dev: true
@@ -646,9 +712,9 @@ packages:
       {
         integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==,
       }
-    engines: { node: '>=14' }
+    engines: { node: ">=14" }
     peerDependencies:
-      typescript: '>=4.9.5'
+      typescript: ">=4.9.5"
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -660,12 +726,12 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /cross-spawn@7.0.3:
+  /cross-spawn@7.0.6:
     resolution:
       {
-        integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==,
+        integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
       }
-    engines: { node: '>= 8' }
+    engines: { node: ">= 8" }
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
@@ -677,7 +743,7 @@ packages:
       {
         integrity: sha512-c+N0v6wbKVxTu5gOBBFkr9BEdBWaqqjQeiJ8QvSRIJOf+UxlJh930m8e6/WNeODIK0mYLFkoONrnj16i2EcvfQ==,
       }
-    engines: { node: '>=12 || >=16' }
+    engines: { node: ">=12 || >=16" }
     dev: true
 
   /css-tree@2.3.1:
@@ -696,7 +762,7 @@ packages:
       {
         integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==,
       }
-    engines: { node: '>=4' }
+    engines: { node: ">=4" }
     hasBin: true
     dev: true
 
@@ -707,29 +773,14 @@ packages:
       }
     dev: false
 
-  /debug@4.3.4:
-    resolution:
-      {
-        integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==,
-      }
-    engines: { node: '>=6.0' }
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-    dev: true
-
   /debug@4.3.5:
     resolution:
       {
         integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==,
       }
-    engines: { node: '>=6.0' }
+    engines: { node: ">=6.0" }
     peerDependencies:
-      supports-color: '*'
+      supports-color: "*"
     peerDependenciesMeta:
       supports-color:
         optional: true
@@ -749,7 +800,7 @@ packages:
       {
         integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dependencies:
       path-type: 4.0.0
     dev: true
@@ -773,7 +824,7 @@ packages:
       {
         integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==,
       }
-    engines: { node: '>=6' }
+    engines: { node: ">=6" }
     dev: true
 
   /error-ex@1.3.2:
@@ -790,7 +841,7 @@ packages:
       {
         integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==,
       }
-    engines: { node: '>=0.8.0' }
+    engines: { node: ">=0.8.0" }
     dev: true
 
   /escape-string-regexp@4.0.0:
@@ -798,26 +849,18 @@ packages:
       {
         integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
       }
-    engines: { node: '>=10' }
+    engines: { node: ">=10" }
     dev: true
 
-  /eslint-scope@8.0.1:
+  /eslint-scope@8.2.0:
     resolution:
       {
-        integrity: sha512-pL8XjgP4ZOmmwfFE8mEhSxA7ZY4C+LWyqjQ3o4yWkkmD0qcMT9kkW3zWHOczhWcjTSgqycYAgwSlXvZltv65og==,
+        integrity: sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
-    dev: true
-
-  /eslint-visitor-keys@3.4.0:
-    resolution:
-      {
-        integrity: sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==,
-      }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
     dev: true
 
   /eslint-visitor-keys@3.4.3:
@@ -828,70 +871,75 @@ packages:
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
     dev: true
 
-  /eslint-visitor-keys@4.0.0:
+  /eslint-visitor-keys@4.2.0:
     resolution:
       {
-        integrity: sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==,
+        integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     dev: true
 
-  /eslint@9.3.0:
+  /eslint@9.16.0:
     resolution:
       {
-        integrity: sha512-5Iv4CsZW030lpUqHBapdPo3MJetAPtejVW8B84GIcIIv8+ohFaddXsrn1Gn8uD9ijDb+kcYKFUVmC8qG8B2ORQ==,
+        integrity: sha512-whp8mSQI4C8VXd+fLgSM0lh3UlmcFtVwUQjyKCFfsp+2ItAIYhlq/hqGahGqHE6cv9unM41VlqKk2VtKYR2TaA==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     hasBin: true
+    peerDependencies:
+      jiti: "*"
+    peerDependenciesMeta:
+      jiti:
+        optional: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.3.0)
-      '@eslint-community/regexpp': 4.10.0
-      '@eslint/eslintrc': 3.1.0
-      '@eslint/js': 9.3.0
-      '@humanwhocodes/config-array': 0.13.0
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.3.0
-      '@nodelib/fs.walk': 1.2.8
+      "@eslint-community/eslint-utils": 4.4.0(eslint@9.16.0)
+      "@eslint-community/regexpp": 4.12.1
+      "@eslint/config-array": 0.19.1
+      "@eslint/core": 0.9.1
+      "@eslint/eslintrc": 3.2.0
+      "@eslint/js": 9.16.0
+      "@eslint/plugin-kit": 0.2.4
+      "@humanfs/node": 0.16.6
+      "@humanwhocodes/module-importer": 1.0.1
+      "@humanwhocodes/retry": 0.4.1
+      "@types/estree": 1.0.6
+      "@types/json-schema": 7.0.15
       ajv: 6.12.6
       chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4
+      cross-spawn: 7.0.6
+      debug: 4.3.5
       escape-string-regexp: 4.0.0
-      eslint-scope: 8.0.1
-      eslint-visitor-keys: 4.0.0
-      espree: 10.0.1
+      eslint-scope: 8.2.0
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
       esquery: 1.5.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 8.0.0
       find-up: 5.0.0
       glob-parent: 6.0.2
-      ignore: 5.2.4
+      ignore: 5.3.1
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      is-path-inside: 3.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
       lodash.merge: 4.6.2
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.4
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /espree@10.0.1:
+  /espree@10.3.0:
     resolution:
       {
-        integrity: sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==,
+        integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     dependencies:
-      acorn: 8.11.3
-      acorn-jsx: 5.3.2(acorn@8.11.3)
-      eslint-visitor-keys: 4.0.0
+      acorn: 8.14.0
+      acorn-jsx: 5.3.2(acorn@8.14.0)
+      eslint-visitor-keys: 4.2.0
     dev: true
 
   /esquery@1.5.0:
@@ -899,7 +947,7 @@ packages:
       {
         integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==,
       }
-    engines: { node: '>=0.10' }
+    engines: { node: ">=0.10" }
     dependencies:
       estraverse: 5.3.0
     dev: true
@@ -909,7 +957,7 @@ packages:
       {
         integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
       }
-    engines: { node: '>=4.0' }
+    engines: { node: ">=4.0" }
     dependencies:
       estraverse: 5.3.0
     dev: true
@@ -919,7 +967,7 @@ packages:
       {
         integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==,
       }
-    engines: { node: '>=4.0' }
+    engines: { node: ">=4.0" }
     dev: true
 
   /esutils@2.0.3:
@@ -927,7 +975,7 @@ packages:
       {
         integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
       }
-    engines: { node: '>=0.10.0' }
+    engines: { node: ">=0.10.0" }
     dev: true
 
   /fast-deep-equal@3.1.3:
@@ -942,10 +990,10 @@ packages:
       {
         integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==,
       }
-    engines: { node: '>=8.6.0' }
+    engines: { node: ">=8.6.0" }
     dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
+      "@nodelib/fs.stat": 2.0.5
+      "@nodelib/fs.walk": 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.7
@@ -977,7 +1025,7 @@ packages:
       {
         integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==,
       }
-    engines: { node: '>= 4.9.1' }
+    engines: { node: ">= 4.9.1" }
     dev: true
 
   /fastq@1.15.0:
@@ -994,7 +1042,7 @@ packages:
       {
         integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==,
       }
-    engines: { node: '>=16.0.0' }
+    engines: { node: ">=16.0.0" }
     dependencies:
       flat-cache: 4.0.1
     dev: true
@@ -1004,7 +1052,7 @@ packages:
       {
         integrity: sha512-6MgEugi8p2tiUhqO7GnPsmbCCzj0YRCwwaTbpGRyKZesjRSzkqkAE9fPp7V2yMs5hwfgbQLgdvSSkGNg1s5Uvw==,
       }
-    engines: { node: '>=18' }
+    engines: { node: ">=18" }
     dependencies:
       flat-cache: 5.0.0
     dev: true
@@ -1014,7 +1062,7 @@ packages:
       {
         integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dependencies:
       to-regex-range: 5.0.1
     dev: true
@@ -1024,7 +1072,7 @@ packages:
       {
         integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==,
       }
-    engines: { node: '>=10' }
+    engines: { node: ">=10" }
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
@@ -1035,7 +1083,7 @@ packages:
       {
         integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==,
       }
-    engines: { node: '>=16' }
+    engines: { node: ">=16" }
     dependencies:
       flatted: 3.3.1
       keyv: 4.5.4
@@ -1046,7 +1094,7 @@ packages:
       {
         integrity: sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==,
       }
-    engines: { node: '>=18' }
+    engines: { node: ">=18" }
     dependencies:
       flatted: 3.3.1
       keyv: 4.5.4
@@ -1064,7 +1112,7 @@ packages:
       {
         integrity: sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==,
       }
-    engines: { node: '>=10' }
+    engines: { node: ">=10" }
     dev: true
 
   /glob-parent@5.1.2:
@@ -1072,7 +1120,7 @@ packages:
       {
         integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
       }
-    engines: { node: '>= 6' }
+    engines: { node: ">= 6" }
     dependencies:
       is-glob: 4.0.3
     dev: true
@@ -1082,7 +1130,7 @@ packages:
       {
         integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==,
       }
-    engines: { node: '>=10.13.0' }
+    engines: { node: ">=10.13.0" }
     dependencies:
       is-glob: 4.0.3
     dev: true
@@ -1092,7 +1140,7 @@ packages:
       {
         integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==,
       }
-    engines: { node: '>=6' }
+    engines: { node: ">=6" }
     dependencies:
       global-prefix: 3.0.0
     dev: true
@@ -1102,7 +1150,7 @@ packages:
       {
         integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==,
       }
-    engines: { node: '>=6' }
+    engines: { node: ">=6" }
     dependencies:
       ini: 1.3.8
       kind-of: 6.0.3
@@ -1114,7 +1162,7 @@ packages:
       {
         integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==,
       }
-    engines: { node: '>=18' }
+    engines: { node: ">=18" }
     dev: true
 
   /globby@11.1.0:
@@ -1122,7 +1170,7 @@ packages:
       {
         integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==,
       }
-    engines: { node: '>=10' }
+    engines: { node: ">=10" }
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
@@ -1151,7 +1199,7 @@ packages:
       {
         integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==,
       }
-    engines: { node: '>=4' }
+    engines: { node: ">=4" }
     dev: true
 
   /has-flag@4.0.0:
@@ -1159,7 +1207,7 @@ packages:
       {
         integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dev: true
 
   /html-tags@3.3.1:
@@ -1167,15 +1215,7 @@ packages:
       {
         integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==,
       }
-    engines: { node: '>=8' }
-    dev: true
-
-  /ignore@5.2.4:
-    resolution:
-      {
-        integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==,
-      }
-    engines: { node: '>= 4' }
+    engines: { node: ">=8" }
     dev: true
 
   /ignore@5.3.1:
@@ -1183,7 +1223,7 @@ packages:
       {
         integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==,
       }
-    engines: { node: '>= 4' }
+    engines: { node: ">= 4" }
     dev: true
 
   /import-fresh@3.3.0:
@@ -1191,7 +1231,7 @@ packages:
       {
         integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==,
       }
-    engines: { node: '>=6' }
+    engines: { node: ">=6" }
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
@@ -1202,7 +1242,7 @@ packages:
       {
         integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==,
       }
-    engines: { node: '>=0.8.19' }
+    engines: { node: ">=0.8.19" }
     dev: true
 
   /ini@1.3.8:
@@ -1224,7 +1264,7 @@ packages:
       {
         integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
       }
-    engines: { node: '>=0.10.0' }
+    engines: { node: ">=0.10.0" }
     dev: true
 
   /is-fullwidth-code-point@3.0.0:
@@ -1232,7 +1272,7 @@ packages:
       {
         integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dev: true
 
   /is-glob@4.0.3:
@@ -1240,7 +1280,7 @@ packages:
       {
         integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
       }
-    engines: { node: '>=0.10.0' }
+    engines: { node: ">=0.10.0" }
     dependencies:
       is-extglob: 2.1.1
     dev: true
@@ -1250,15 +1290,7 @@ packages:
       {
         integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
       }
-    engines: { node: '>=0.12.0' }
-    dev: true
-
-  /is-path-inside@3.0.3:
-    resolution:
-      {
-        integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==,
-      }
-    engines: { node: '>=8' }
+    engines: { node: ">=0.12.0" }
     dev: true
 
   /is-plain-object@5.0.0:
@@ -1266,7 +1298,7 @@ packages:
       {
         integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==,
       }
-    engines: { node: '>=0.10.0' }
+    engines: { node: ">=0.10.0" }
     dev: true
 
   /isexe@2.0.0:
@@ -1342,7 +1374,7 @@ packages:
       {
         integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==,
       }
-    engines: { node: '>=0.10.0' }
+    engines: { node: ">=0.10.0" }
     dev: true
 
   /known-css-properties@0.34.0:
@@ -1357,7 +1389,7 @@ packages:
       {
         integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
       }
-    engines: { node: '>= 0.8.0' }
+    engines: { node: ">= 0.8.0" }
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
@@ -1375,7 +1407,7 @@ packages:
       {
         integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
       }
-    engines: { node: '>=10' }
+    engines: { node: ">=10" }
     dependencies:
       p-locate: 5.0.0
     dev: true
@@ -1413,7 +1445,7 @@ packages:
       {
         integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==,
       }
-    engines: { node: '>=18' }
+    engines: { node: ">=18" }
     dev: true
 
   /merge2@1.4.1:
@@ -1421,7 +1453,7 @@ packages:
       {
         integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
       }
-    engines: { node: '>= 8' }
+    engines: { node: ">= 8" }
     dev: true
 
   /micromatch@4.0.7:
@@ -1429,7 +1461,7 @@ packages:
       {
         integrity: sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==,
       }
-    engines: { node: '>=8.6' }
+    engines: { node: ">=8.6" }
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
@@ -1449,7 +1481,7 @@ packages:
       {
         integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==,
       }
-    engines: { node: '>=16 || 14 >=14.17' }
+    engines: { node: ">=16 || 14 >=14.17" }
     dependencies:
       brace-expansion: 2.0.1
     dev: true
@@ -1509,7 +1541,7 @@ packages:
       {
         integrity: sha512-ElheoPibjc7IVyRdsORgkzJi0DWm3f0LYSsm/eJIeUt3M/csDLTblLDR4zl5Qi7jmVjJ1KpEkPKSbgVGEzU5Xw==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dependencies:
       big-integer: 1.6.51
     dev: true
@@ -1519,7 +1551,7 @@ packages:
       {
         integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==,
       }
-    engines: { node: '>=0.10.0' }
+    engines: { node: ">=0.10.0" }
     dev: true
 
   /optionator@0.9.4:
@@ -1527,7 +1559,7 @@ packages:
       {
         integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==,
       }
-    engines: { node: '>= 0.8.0' }
+    engines: { node: ">= 0.8.0" }
     dependencies:
       deep-is: 0.1.4
       fast-levenshtein: 2.0.6
@@ -1542,7 +1574,7 @@ packages:
       {
         integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==,
       }
-    engines: { node: '>=10' }
+    engines: { node: ">=10" }
     dependencies:
       yocto-queue: 0.1.0
     dev: true
@@ -1552,7 +1584,7 @@ packages:
       {
         integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
       }
-    engines: { node: '>=10' }
+    engines: { node: ">=10" }
     dependencies:
       p-limit: 3.1.0
     dev: true
@@ -1562,7 +1594,7 @@ packages:
       {
         integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
       }
-    engines: { node: '>=6' }
+    engines: { node: ">=6" }
     dependencies:
       callsites: 3.1.0
     dev: true
@@ -1572,9 +1604,9 @@ packages:
       {
         integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dependencies:
-      '@babel/code-frame': 7.24.7
+      "@babel/code-frame": 7.24.7
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -1585,7 +1617,7 @@ packages:
       {
         integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dev: true
 
   /path-key@3.1.1:
@@ -1593,7 +1625,7 @@ packages:
       {
         integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dev: true
 
   /path-type@4.0.0:
@@ -1601,7 +1633,7 @@ packages:
       {
         integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dev: true
 
   /picocolors@1.0.1:
@@ -1616,7 +1648,7 @@ packages:
       {
         integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
       }
-    engines: { node: '>=8.6' }
+    engines: { node: ">=8.6" }
     dev: true
 
   /postcss-resolve-nested-selector@0.1.1:
@@ -1631,7 +1663,7 @@ packages:
       {
         integrity: sha512-ovehqRNVCpuFzbXoTb4qLtyzK3xn3t/CUBxOs8LsnQjQrShaB4lKiHoVqY8ANaC0hBMHq5QVWk77rwGklFUDrg==,
       }
-    engines: { node: '>=18.0' }
+    engines: { node: ">=18.0" }
     peerDependencies:
       postcss: ^8.4.31
     dependencies:
@@ -1643,7 +1675,7 @@ packages:
       {
         integrity: sha512-b4dlw/9V8A71rLIDsSwVmak9z2DuBUB7CA1/wSdelNEzqsjoSPeADTWNO09lpH49Diy3/JIZ2bSPB1dI3LJCHg==,
       }
-    engines: { node: '>=4' }
+    engines: { node: ">=4" }
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
@@ -1673,7 +1705,7 @@ packages:
       {
         integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==,
       }
-    engines: { node: '>= 0.8.0' }
+    engines: { node: ">= 0.8.0" }
     dev: true
 
   /prettier-plugin-sql@0.14.0(prettier@2.8.8):
@@ -1696,7 +1728,7 @@ packages:
       {
         integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==,
       }
-    engines: { node: '>=10.13.0' }
+    engines: { node: ">=10.13.0" }
     hasBin: true
     dev: true
 
@@ -1705,7 +1737,7 @@ packages:
       {
         integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==,
       }
-    engines: { node: '>=6' }
+    engines: { node: ">=6" }
     dev: true
 
   /queue-microtask@1.2.3:
@@ -1727,7 +1759,7 @@ packages:
       {
         integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==,
       }
-    engines: { node: '>=0.12' }
+    engines: { node: ">=0.12" }
     dependencies:
       discontinuous-range: 1.0.0
       ret: 0.1.15
@@ -1738,7 +1770,7 @@ packages:
       {
         integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==,
       }
-    engines: { node: '>=0.10.0' }
+    engines: { node: ">=0.10.0" }
     dev: true
 
   /resolve-from@4.0.0:
@@ -1746,7 +1778,7 @@ packages:
       {
         integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
       }
-    engines: { node: '>=4' }
+    engines: { node: ">=4" }
     dev: true
 
   /resolve-from@5.0.0:
@@ -1754,7 +1786,7 @@ packages:
       {
         integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dev: true
 
   /ret@0.1.15:
@@ -1762,7 +1794,7 @@ packages:
       {
         integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==,
       }
-    engines: { node: '>=0.12' }
+    engines: { node: ">=0.12" }
     dev: true
 
   /reusify@1.0.4:
@@ -1770,7 +1802,7 @@ packages:
       {
         integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==,
       }
-    engines: { iojs: '>=1.0.0', node: '>=0.10.0' }
+    engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
     dev: true
 
   /run-parallel@1.2.0:
@@ -1787,7 +1819,7 @@ packages:
       {
         integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==,
       }
-    engines: { node: '>=10' }
+    engines: { node: ">=10" }
     hasBin: true
     dev: true
 
@@ -1796,7 +1828,7 @@ packages:
       {
         integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dependencies:
       shebang-regex: 3.0.0
     dev: true
@@ -1806,7 +1838,7 @@ packages:
       {
         integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dev: true
 
   /signal-exit@4.1.0:
@@ -1814,7 +1846,7 @@ packages:
       {
         integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
       }
-    engines: { node: '>=14' }
+    engines: { node: ">=14" }
     dev: true
 
   /slash@3.0.0:
@@ -1822,7 +1854,7 @@ packages:
       {
         integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dev: true
 
   /slice-ansi@4.0.0:
@@ -1830,7 +1862,7 @@ packages:
       {
         integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==,
       }
-    engines: { node: '>=10' }
+    engines: { node: ">=10" }
     dependencies:
       ansi-styles: 4.3.0
       astral-regex: 2.0.0
@@ -1842,7 +1874,7 @@ packages:
       {
         integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==,
       }
-    engines: { node: '>=0.10.0' }
+    engines: { node: ">=0.10.0" }
     dev: true
 
   /sql-formatter@12.2.4:
@@ -1862,7 +1894,7 @@ packages:
       {
         integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
@@ -1874,7 +1906,7 @@ packages:
       {
         integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dependencies:
       ansi-regex: 5.0.1
     dev: true
@@ -1884,7 +1916,7 @@ packages:
       {
         integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==,
       }
-    engines: { node: '>=12' }
+    engines: { node: ">=12" }
     dependencies:
       ansi-regex: 6.0.1
     dev: true
@@ -1894,7 +1926,7 @@ packages:
       {
         integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dev: true
 
   /stylelint-config-recommended@14.0.1(stylelint@16.7.0):
@@ -1902,7 +1934,7 @@ packages:
       {
         integrity: sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==,
       }
-    engines: { node: '>=18.12.0' }
+    engines: { node: ">=18.12.0" }
     peerDependencies:
       stylelint: ^16.1.0
     dependencies:
@@ -1914,7 +1946,7 @@ packages:
       {
         integrity: sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==,
       }
-    engines: { node: '>=18.12.0' }
+    engines: { node: ">=18.12.0" }
     peerDependencies:
       stylelint: ^16.1.0
     dependencies:
@@ -1927,14 +1959,14 @@ packages:
       {
         integrity: sha512-Q1ATiXlz+wYr37a7TGsfvqYn2nSR3T/isw3IWlZQzFzCNoACHuGBb6xBplZXz56/uDRJHIygxjh7jbV/8isewA==,
       }
-    engines: { node: '>=18.12.0' }
+    engines: { node: ">=18.12.0" }
     hasBin: true
     dependencies:
-      '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
-      '@csstools/css-tokenizer': 2.4.1
-      '@csstools/media-query-list-parser': 2.1.13(@csstools/css-parser-algorithms@2.7.1)(@csstools/css-tokenizer@2.4.1)
-      '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.1)
-      '@dual-bundle/import-meta-resolve': 4.1.0
+      "@csstools/css-parser-algorithms": 2.7.1(@csstools/css-tokenizer@2.4.1)
+      "@csstools/css-tokenizer": 2.4.1
+      "@csstools/media-query-list-parser": 2.1.13(@csstools/css-parser-algorithms@2.7.1)(@csstools/css-tokenizer@2.4.1)
+      "@csstools/selector-specificity": 3.1.1(postcss-selector-parser@6.1.1)
+      "@dual-bundle/import-meta-resolve": 4.1.0
       balanced-match: 2.0.0
       colord: 2.9.3
       cosmiconfig: 9.0.0(typescript@4.9.5)
@@ -1979,7 +2011,7 @@ packages:
       {
         integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==,
       }
-    engines: { node: '>=4' }
+    engines: { node: ">=4" }
     dependencies:
       has-flag: 3.0.0
     dev: true
@@ -1989,7 +2021,7 @@ packages:
       {
         integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ">=8" }
     dependencies:
       has-flag: 4.0.0
     dev: true
@@ -1999,7 +2031,7 @@ packages:
       {
         integrity: sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==,
       }
-    engines: { node: '>=14.18' }
+    engines: { node: ">=14.18" }
     dependencies:
       has-flag: 4.0.0
       supports-color: 7.2.0
@@ -2017,7 +2049,7 @@ packages:
       {
         integrity: sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==,
       }
-    engines: { node: '>=10.0.0' }
+    engines: { node: ">=10.0.0" }
     dependencies:
       ajv: 8.17.1
       lodash.truncate: 4.4.2
@@ -2026,19 +2058,12 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
-  /text-table@0.2.0:
-    resolution:
-      {
-        integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==,
-      }
-    dev: true
-
   /to-regex-range@5.0.1:
     resolution:
       {
         integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
       }
-    engines: { node: '>=8.0' }
+    engines: { node: ">=8.0" }
     dependencies:
       is-number: 7.0.0
     dev: true
@@ -2048,9 +2073,9 @@ packages:
       {
         integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==,
       }
-    engines: { node: '>=16' }
+    engines: { node: ">=16" }
     peerDependencies:
-      typescript: '>=4.2.0'
+      typescript: ">=4.2.0"
     dependencies:
       typescript: 4.9.5
     dev: true
@@ -2067,28 +2092,28 @@ packages:
       {
         integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
       }
-    engines: { node: '>= 0.8.0' }
+    engines: { node: ">= 0.8.0" }
     dependencies:
       prelude-ls: 1.2.1
     dev: true
 
-  /typescript-eslint@7.10.0(eslint@9.3.0)(typescript@4.9.5):
+  /typescript-eslint@8.17.0(eslint@9.16.0)(typescript@4.9.5):
     resolution:
       {
-        integrity: sha512-thO8nyqptXdfWHQrMJJiJyftpW8aLmwRNs11xA8pSrXneoclFPstQZqXvDWuH1WNL4CHffqHvYUeCHTit6yfhQ==,
+        integrity: sha512-409VXvFd/f1br1DCbuKNFqQpXICoTB+V51afcwG1pn1a3Cp92MqAUges3YjwEdQ0cMUoCIodjVDAYzyD8h3SYA==,
       }
-    engines: { node: ^18.18.0 || >=20.0.0 }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: "*"
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.10.0(@typescript-eslint/parser@7.10.0)(eslint@9.3.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 7.10.0(eslint@9.3.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 7.10.0(eslint@9.3.0)(typescript@4.9.5)
-      eslint: 9.3.0
+      "@typescript-eslint/eslint-plugin": 8.17.0(@typescript-eslint/parser@8.17.0)(eslint@9.16.0)(typescript@4.9.5)
+      "@typescript-eslint/parser": 8.17.0(eslint@9.16.0)(typescript@4.9.5)
+      "@typescript-eslint/utils": 8.17.0(eslint@9.16.0)(typescript@4.9.5)
+      eslint: 9.16.0
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
@@ -2099,7 +2124,7 @@ packages:
       {
         integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==,
       }
-    engines: { node: '>=4.2.0' }
+    engines: { node: ">=4.2.0" }
     hasBin: true
     dev: true
 
@@ -2134,7 +2159,7 @@ packages:
       {
         integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
       }
-    engines: { node: '>= 8' }
+    engines: { node: ">= 8" }
     hasBin: true
     dependencies:
       isexe: 2.0.0
@@ -2145,7 +2170,7 @@ packages:
       {
         integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==,
       }
-    engines: { node: '>=0.10.0' }
+    engines: { node: ">=0.10.0" }
     dev: true
 
   /write-file-atomic@5.0.1:
@@ -2164,5 +2189,5 @@ packages:
       {
         integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
       }
-    engines: { node: '>=10' }
+    engines: { node: ">=10" }
     dev: true

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -110,6 +110,8 @@ bzl_library(
     ],
 )
 
+# Aliases introduced in #432 for fear of breaking users.
+# TODO(2.0) remove them
 alias(
     name = "eslint.workaround_17660",
     actual = "//lint/js:eslint.workaround_17660",

--- a/lint/js/eslint.stylish-formatter.js
+++ b/lint/js/eslint.stylish-formatter.js
@@ -74,7 +74,10 @@ module.exports = function (results) {
     fixableErrorCount += result.fixableErrorCount;
     fixableWarningCount += result.fixableWarningCount;
 
-    output += `${chalk.underline(result.filePath)}\n`;
+    // LOCAL MODIFICATION: print path relative to the working directory
+    output += `${chalk.underline(
+      require("node:path").relative(context.cwd, result.filePath)
+    )}\n`;
 
     output += `${table(
       messages.map((message) => {

--- a/lint/js/eslint.stylish-formatter.js
+++ b/lint/js/eslint.stylish-formatter.js
@@ -13,6 +13,8 @@
  * The eslint dependencies should be loaded from the user's node_modules tree, not from rules_lint.
  */
 
+const util = require("node:util");
+
 // This script is used as a command-line flag to eslint, so the command line is "node eslint.js --format this_script.js"
 // That means we can grab the path of the eslint entry point, which is beneath its node modules tree.
 const eslintEntry = process.argv[1];
@@ -23,18 +25,18 @@ if (idx < 0) {
     "node_modules not found in eslint entry point " + eslintEntry
   );
 }
-const searchPath = eslintEntry.substring(0, idx);
+const options = { paths: [eslintEntry.substring(0, idx)] };
+
 // Modify the upstream code to pass through an explicit `require.resolve` that starts from eslint
+const chalk = require(require.resolve("chalk", options));
+
 let table_path;
 try {
-  table_path = require.resolve("text-table", { paths: [searchPath] });
+  table_path = require.resolve("text-table", options);
 } catch (e) {
-  table_path = require.resolve("./lib/shared/text-table", {
-    paths: [searchPath],
-  });
+  table_path = require.resolve("./lib/shared/text-table", options);
 }
 const table = require(table_path);
-const chalk = require(require.resolve("chalk", { paths: [searchPath] }));
 
 //------------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
They changed some dependencies. One of them we can just drop with their newer code that works with older eslint releases. The other (text-table) needs to be vendored so it works with both versions, both older ones which expected a third-party package, and newer ones that don't depend on that package.

Fixes #434

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
