### PR TITLE
fix: Add option to skip target without srcs

### DIFF
--- a/docs/clang-tidy.md
+++ b/docs/clang-tidy.md
@@ -122,7 +122,7 @@ is_parent_in_list(<a href="#is_parent_in_list-dir">dir</a>, <a href="#is_parent_
 load("@aspect_rules_lint//lint:clang_tidy.bzl", "lint_clang_tidy_aspect")
 
 lint_clang_tidy_aspect(<a href="#lint_clang_tidy_aspect-binary">binary</a>, <a href="#lint_clang_tidy_aspect-configs">configs</a>, <a href="#lint_clang_tidy_aspect-global_config">global_config</a>, <a href="#lint_clang_tidy_aspect-header_filter">header_filter</a>, <a href="#lint_clang_tidy_aspect-lint_target_headers">lint_target_headers</a>,
-                       <a href="#lint_clang_tidy_aspect-angle_includes_are_system">angle_includes_are_system</a>, <a href="#lint_clang_tidy_aspect-verbose">verbose</a>)
+                       <a href="#lint_clang_tidy_aspect-angle_includes_are_system">angle_includes_are_system</a>, <a href="#lint_clang_tidy_aspect-skip_if_no_srcs">skip_if_no_srcs</a>, <a href="#lint_clang_tidy_aspect-verbose">verbose</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -138,6 +138,7 @@ A factory function to create a linter aspect.
 | <a id="lint_clang_tidy_aspect-header_filter"></a>header_filter |  optional, set to a posix regex to supply to clang-tidy with the -header-filter option   |  `""` |
 | <a id="lint_clang_tidy_aspect-lint_target_headers"></a>lint_target_headers |  optional, set to True to pass a pattern that includes all headers with the target's directory prefix. This crude control may include headers from the linted target in the results. If supplied, overrides the header_filter option.   |  `False` |
 | <a id="lint_clang_tidy_aspect-angle_includes_are_system"></a>angle_includes_are_system |  controls how angle includes are passed to clang-tidy. By default, Bazel passes these as -isystem. Change this to False to pass these as -I, which allows clang-tidy to regard them as regular header files.   |  `True` |
+| <a id="lint_clang_tidy_aspect-skip_if_no_srcs"></a>skip_if_no_srcs |  optional, set to True to skip target if it provides CcInfo but has no source files. By default this will generate an error.   |  `False` |
 | <a id="lint_clang_tidy_aspect-verbose"></a>verbose |  print debug messages including clang-tidy command lines being invoked.   |  `False` |
 
 


### PR DESCRIPTION
Description
---
Add option 'skip_if_no_srcs' to lint_clang_tidy aspect.
Set to True to skip target if it provides CcInfo but has no source files. By default this will generate an error.

See issue #406 

Adding an option to skip these targets enables us to run `./lint.sh //package//...` even if some target has no source files, e.g. code generation targets.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes
Add option 'skip_if_no_srcs' to lint_clang_tidy aspect.

### Test plan

- Manual testing; please provide instructions so we can reproduce:
bazel build with lint_clang_tidy_aspect for a target that provides 'CcInfo' but does not have 'srcs' attribute.
With skip_if_no_srcs set to True:
Build completes with empty `target.AspectRulesLintClangTidy.out` file.
Without new option / new option set to False:
```shell
File ".../aspect_rules_lint~/lint/clang_tidy.bzl", line 186, column 38, in _filter_srcs
                return [s for s in rule.files.srcs if _is_source(s)]
Error: No attribute 'srcs' in files. Make sure there is a label or label_list type attribute with this name
```