### PR TITLE
Make buf format fast

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -248,7 +248,7 @@ function run-format {
       'Protocol Buffer')
         time {
           for file in $files; do
-            "$bin" $args $file >&2
+            "$bin" $args --path $file >&2
           done
         }
         ;;

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -152,8 +152,8 @@ bats_load_library "bats-assert"
     assert_success
 
     # Buf only formats one file at a time
-    assert_output --partial "+ buf format -w example/src/file.proto"
-    assert_output --partial "+ buf format -w example/src/unused.proto"
+    assert_output --partial "+ buf format -w --path example/src/file.proto"
+    assert_output --partial "+ buf format -w --path example/src/unused.proto"
 }
 
 @test "should run yamlfmt on YAML" {


### PR DESCRIPTION
**buf** seems to be painfully slow when running with the positional argument `<source>`.
(I opened https://github.com/bufbuild/buf/issues/3593 for them to track but 🤷 if they will provide anything meaningful).

The downside of this repo is that `--path` is a very **buf** specific option.
I couldn't see how to pipe args from the tool -> _format.sh_ but that might be an improvement later.

You can see the discrepancy here (tested with latest buf release 1.41.0): 

### total repository
**original**
```shell
> time bazel run //tools/format:format_Protocol_Buffer_with_buf
INFO: Invocation ID: 7458a050-c88b-4fce-a3da-11c781947b98
INFO: Analyzed target //tools/format:format_Protocol_Buffer_with_buf (69 packages loaded, 328 targets configured).
INFO: Found 1 target...
Target //tools/format:format_Protocol_Buffer_with_buf up-to-date:
  bazel-bin/tools/format/format_Protocol_Buffer_with_buf.bash
INFO: Elapsed time: 0.383s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/tools/format/format_Protocol_Buffer_with_buf.bash
Formatted Protocol Buffer in 0m23.380s
```
**--path**
```shell
> time bazel run //tools/format:format_Protocol_Buffer_with_buf --override_module=aspect_rules_lint=/Users/fzakaria/code/github.com/aspect-build/rules_lint
INFO: Invocation ID: 08cdad1d-906c-4f97-a276-0badf7589cfd
INFO: Analyzed target //tools/format:format_Protocol_Buffer_with_buf (10 packages loaded, 66 targets configured).
INFO: Found 1 target...
Target //tools/format:format_Protocol_Buffer_with_buf up-to-date:
  bazel-bin/tools/format/format_Protocol_Buffer_with_buf.bash
INFO: Elapsed time: 0.309s, Critical Path: 0.00s
INFO: 3 processes: 3 internal.
INFO: Build completed successfully, 3 total actions
INFO: Running command line: bazel-bin/tools/format/format_Protocol_Buffer_with_buf.bash
Formatted Protocol Buffer in 0m0.295s
```

### individual file
**original**
```shell
> time /private/var/tmp/_bazel_fzakaria/1e65f71ad5377a6871390147418ed439/external/rules_buf~~buf~rules_buf_toolchains/buf format apps/cts/gc/src/main/protobuf/tasks.proto -d
 format apps/cts/gc/src/main/protobuf/tasks.proto -d  0.30s user 0.77s system 104% cpu 1.017 total
```
**--path**
```shell
> time /private/var/tmp/_bazel_fzakaria/1e65f71ad5377a6871390147418ed439/external/rules_buf~~buf~rules_buf_toolchains/buf format --path apps/cts/gc/src/main/protobuf/tasks.proto -d
 format --path apps/cts/gc/src/main/protobuf/tasks.proto -d  0.01s user 0.01s system 54% cpu 0.025 total
```
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; 
