### PR TITLE
fix: try to unstick release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   release:
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@c9d6d1893b10a8d68584a6ba52c3dd35506486d0 # 2024-12-03
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@cb461f299b8d472a82d1d88c4cef7d6013721742 # 2024-12-03
     with:
       prerelease: false
       release_files: rules_lint-*.tar.gz


### PR DESCRIPTION
Last release is broken, somehow it didn't find an argument to pass to release_prep.sh
https://github.com/aspect-build/rules_lint/actions/runs/12933556117

Grabs this delta https://github.com/bazel-contrib/.github/compare/master...alexeagle-patch-3

Have to land it on main in order to test