### PR TITLE
fix: release snippet missing escaping

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -27,7 +27,7 @@ bazel_dep(name = "aspect_rules_lint", version = "${TAG:1}")
 
 ## Using WORKSPACE
 
-Paste this snippet into your `WORKSPACE.bazel` file:
+Paste this snippet into your \`WORKSPACE.bazel\` file:
 
 \`\`\`starlark
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")


### PR DESCRIPTION
caused `.github/workflows/release_prep.sh: line 14: WORKSPACE.bazel: command not found`
