### PR TITLE
fix: drop Bazel 6 support

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "example"
   matrix:
-    bazel: ["7.x", "6.x"]
+    bazel: ["7.x"]
     platform: ["debian10", "macos", "ubuntu2004"]
   tasks:
     run_tests:


### PR DESCRIPTION
We depend on rules_jvm_external which no longer supports it.

error is like
```
(03:51:09) ERROR: file:///workdir/modules/rules_jvm_external/6.5/MODULE.bazel:101:13: name 'use_repo_rule' is not defined
(03:51:09) ERROR: Error computing the main repository mapping: in module dependency chain <root> -> rules_jvm_external@6.5: error executing MODULE.bazel file for rules_jvm_external@6.5
```

had to make this change previously as part of https://github.com/bazelbuild/bazel-central-registry/pull/3452

