### PR TITLE
feat: add XML format via prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Linters which are not language-specific:
 | TSX                    | [Prettier]            | [ESLint]                         |
 | TypeScript             | [Prettier]            | [ESLint]                         |
 | YAML                   | [yamlfmt]             |                                  |
+| XML                    | [@prettier/plugin-xml]|                                  |
 
 [prettier]: https://prettier.io
 [google-java-format]: https://github.com/google/google-java-format

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Linters which are not language-specific:
 | TSX                    | [Prettier]            | [ESLint]                         |
 | TypeScript             | [Prettier]            | [ESLint]                         |
 | YAML                   | [yamlfmt]             |                                  |
-| XML                    | [@prettier/plugin-xml]|                                  |
+| XML                    | [prettier/plugin-xml] |                                  |
 
 [prettier]: https://prettier.io
 [google-java-format]: https://github.com/google/google-java-format
@@ -69,6 +69,7 @@ Linters which are not language-specific:
 [ktlint]: https://github.com/pinterest/ktlint
 [buildifier]: https://github.com/keith/buildifier-prebuilt
 [prettier-plugin-sql]: https://github.com/un-ts/prettier
+[prettier/plugin-xml]: https://github.com/prettier/plugin-xml
 [gofmt]: https://pkg.go.dev/cmd/gofmt
 [gofumpt]: https://github.com/mvdan/gofumpt
 [jsonnetfmt]: https://github.com/google/go-jsonnet

--- a/docs/format.md
+++ b/docs/format.md
@@ -23,7 +23,7 @@ See the example/tools/format/BUILD file in this repo for full examples of declar
 load("@aspect_rules_lint//format:defs.bzl", "languages")
 
 languages(<a href="#languages-name">name</a>, <a href="#languages-c">c</a>, <a href="#languages-cc">cc</a>, <a href="#languages-css">css</a>, <a href="#languages-cuda">cuda</a>, <a href="#languages-go">go</a>, <a href="#languages-graphql">graphql</a>, <a href="#languages-html">html</a>, <a href="#languages-java">java</a>, <a href="#languages-javascript">javascript</a>, <a href="#languages-jsonnet">jsonnet</a>, <a href="#languages-kotlin">kotlin</a>, <a href="#languages-markdown">markdown</a>,
-          <a href="#languages-protocol_buffer">protocol_buffer</a>, <a href="#languages-python">python</a>, <a href="#languages-rust">rust</a>, <a href="#languages-scala">scala</a>, <a href="#languages-shell">shell</a>, <a href="#languages-sql">sql</a>, <a href="#languages-starlark">starlark</a>, <a href="#languages-swift">swift</a>, <a href="#languages-terraform">terraform</a>, <a href="#languages-yaml">yaml</a>)
+          <a href="#languages-protocol_buffer">protocol_buffer</a>, <a href="#languages-python">python</a>, <a href="#languages-rust">rust</a>, <a href="#languages-scala">scala</a>, <a href="#languages-shell">shell</a>, <a href="#languages-sql">sql</a>, <a href="#languages-starlark">starlark</a>, <a href="#languages-swift">swift</a>, <a href="#languages-terraform">terraform</a>, <a href="#languages-xml">xml</a>, <a href="#languages-yaml">yaml</a>)
 </pre>
 
 Language attributes that may be passed to [format_multirun](#format_multirun) or [format_test](#format_test).
@@ -65,6 +65,7 @@ Some languages have dialects:
 | <a id="languages-starlark"></a>starlark |  a `buildifier` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="languages-swift"></a>swift |  a `swiftformat` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="languages-terraform"></a>terraform |  a `terraform-fmt` binary, or any other tool that has a matching command-line interface. Use `@aspect_rules_lint//format:terraform` to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-xml"></a>xml |  a `prettier` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="languages-yaml"></a>yaml |  a `yamlfmt` binary, or any other tool that has a matching command-line interface. Use `@aspect_rules_lint//format:yamlfmt` to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 
 

--- a/example/package.json
+++ b/example/package.json
@@ -9,6 +9,7 @@
     "eslint": "^9.16.0",
     "prettier": "^2.8.7",
     "prettier-plugin-sql": "^0.14.0",
+    "@prettier/plugin-xml": "^0.10.0",
     "stylelint": "^16",
     "stylelint-config-standard": "^36.0.1",
     "typescript": "4.9.5",

--- a/example/src/hello.xml
+++ b/example/src/hello.xml
@@ -1,0 +1,4 @@
+<hello>
+<world>
+  todo</world>
+</hello>

--- a/example/tools/format/BUILD.bazel
+++ b/example/tools/format/BUILD.bazel
@@ -93,6 +93,7 @@ format_multirun(
     swift = ":swiftformat",
     terraform = "@aspect_rules_lint//format:terraform",
     visibility = ["//:__subpackages__"],
+    xml = ":prettier",
     yaml = "@aspect_rules_lint//format:yamlfmt",
 )
 

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -142,6 +142,7 @@ function ls-files {
       'TypeScript') patterns=('*.ts' '*.cts' '*.mts') ;;
       'Vue') patterns=('*.vue') ;;
       'YAML') patterns=('*.yml' '*.yaml' '.clang-format' '.clang-tidy' '.gemrc') ;;
+      'XML') patterns=('*.xml') ;;
 
       # Note: terraform fmt cannot handle all HCL files such as .terraform.lock
       # "Only .tf and .tfvars files can be processed with terraform fmt"

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -142,7 +142,9 @@ function ls-files {
       'TypeScript') patterns=('*.ts' '*.cts' '*.mts') ;;
       'Vue') patterns=('*.vue') ;;
       'YAML') patterns=('*.yml' '*.yaml' '.clang-format' '.clang-tidy' '.gemrc') ;;
-      'XML') patterns=('*.xml') ;;
+      # Note: https://github.com/github-linguist/linguist/blob/559a6426942abcae16b6d6b328147476432bf6cb/lib/linguist/languages.yml#L7767-L7882
+      # has a giant list of patterns. We arbitrarily choose some "common" ones.
+      'XML') patterns=('*.xml' '*.xsd') ;;
 
       # Note: terraform fmt cannot handle all HCL files such as .terraform.lock
       # "Only .tf and .tfvars files can be processed with terraform fmt"

--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -26,6 +26,7 @@ TOOLS = {
     "Cuda": "clang-format",
     "YAML": "yamlfmt",
     "Rust": "rustfmt",
+    "XML": "prettier",
 }
 
 # Provided to make install more convenient

--- a/format/test/BUILD.bazel
+++ b/format/test/BUILD.bazel
@@ -57,5 +57,6 @@ format_multirun(
     swift = ":mock_swiftformat.sh",
     # TODO: this attribute should be renamed to hcl
     terraform = ":mock_terraform-fmt.sh",
+    xml = ":mock_prettier.sh",
     yaml = ":mock_yamlfmt.sh",
 )

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -44,7 +44,7 @@ bats_load_library "bats-assert"
     run bazel run //format/test:format_XML_with_prettier
     assert_success
 
-    assert_output --partial "+ prettier --write example/src/hello.xml"
+    assert_output --partial "+ prettier --write example/checkstyle-suppressions.xml"
 }
 
 @test "should run prettier on CSS" {

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -40,6 +40,13 @@ bats_load_library "bats-assert"
     assert_output --partial "+ prettier --write .bcr/README.md CONTRIBUTING.md README.md"
 }
 
+@test "should run prettier on XML" {
+    run bazel run //format/test:format_XML_with_prettier
+    assert_success
+
+    assert_output --partial "+ prettier --write example/src/hello.xml"
+}
+
 @test "should run prettier on CSS" {
     run bazel run //format/test:format_CSS_with_prettier
     assert_success


### PR DESCRIPTION
Added XML as a supported formatter and make it use prettier by default. I am not interested in using prettier myself but it's already configured so I might as well. 

### Changes are visible to end-users: yes/no

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- New test cases added
- Tested on my own repo with a custom xml formatter.  
   - Commit is here but i do not expect you to run it yourself https://github.com/b0inbot/tools/commit/0b13ed07555c8e8081055cd41dd30c8cc9bcb3d6
- unable to test via bazel run format within the example/ folder (Error running code complaining about libcrypt so.) Hoping CI/CD within ubuntu can run the test case.
- test folder does work:

```
$ pwd
/home/boin/Projects/tools/tools/rules_lint/format/test
$ bazel run format 2>&1 | grep -i xml
+ prettier --write example/checkstyle-suppressions.xml example/checkstyle.xml example/ktlint-baseline.xml example/pmd.xml example/spotbugs-exclude.xml example/src/hello.xml
Formatted XML in 0m0.011s
```