### PR TITLE
fix: clang_tidy - Add defines and local_defines attributes to commandline args

### DIFF
--- a/example/src/cpp/lib/BUILD
+++ b/example/src/cpp/lib/BUILD
@@ -13,6 +13,7 @@ cc_library(
         "hello-time.h",
         "xhello-time.h",
     ],
+    local_defines = ["LOCAL_DEFINE_IS_DEFINED=\\\"a_string\\\""],
     includes = ["."],
     visibility = ["//src/cpp/main:__pkg__"],
 )

--- a/example/src/cpp/lib/hello-time.cc
+++ b/example/src/cpp/lib/hello-time.cc
@@ -11,4 +11,8 @@ void print_localtime() {
   // warning: do not call c-style vararg functions
   // [cppcoreguidelines-pro-type-vararg,hicpp-vararg]
   printf("%s\n", localtime);
+
+  // local defines are added to clang-tidy so it can compile
+  static const char* str = LOCAL_DEFINE_IS_DEFINED;
+  printf("%s\n   ", str);
 }

--- a/lint/clang_tidy.bzl
+++ b/lint/clang_tidy.bzl
@@ -273,10 +273,10 @@ def _get_compiler_args(ctx, compilation_context, srcs):
         args.append("-D" + define)
     for define in compilation_context.local_defines.to_list():
         args.append("-D" + define)
-    if hasattr(ctx.rule.attr,"defines"):
+    if hasattr(ctx.rule.attr, "defines"):
         for define in ctx.rule.attr.defines:
             args.append("-D" + define)
-    if hasattr(ctx.rule.attr,"local_defines"):
+    if hasattr(ctx.rule.attr, "local_defines"):
         for define in ctx.rule.attr.local_defines:
             args.append("-D" + define)
 

--- a/lint/clang_tidy.bzl
+++ b/lint/clang_tidy.bzl
@@ -178,6 +178,9 @@ def _is_source(file):
 
 # modification of filter_srcs in lint_aspect.bzl that filters out header files
 def _filter_srcs(rule):
+    # some rules can return a CcInfo without having a srcs attribute
+    if not hasattr(rule.attr,"srcs"):
+        return []
     if "lint-genfiles" in rule.attr.tags:
         return rule.files.srcs
     else:
@@ -270,6 +273,12 @@ def _get_compiler_args(ctx, compilation_context, srcs):
         args.append("-D" + define)
     for define in compilation_context.local_defines.to_list():
         args.append("-D" + define)
+    if hasattr(ctx.rule.attr,"defines"):
+        for define in ctx.rule.attr.defines:
+            args.append("-D" + define)
+    if hasattr(ctx.rule.attr,"local_defines"):
+        for define in ctx.rule.attr.local_defines:
+            args.append("-D" + define)
 
     # add includes
     args.extend(_prefixed(compilation_context.framework_includes.to_list(), "-F"))

--- a/lint/clang_tidy.bzl
+++ b/lint/clang_tidy.bzl
@@ -179,7 +179,7 @@ def _is_source(file):
 # modification of filter_srcs in lint_aspect.bzl that filters out header files
 def _filter_srcs(rule):
     # some rules can return a CcInfo without having a srcs attribute
-    if not hasattr(rule.attr,"srcs"):
+    if not hasattr(rule.attr, "srcs"):
         return []
     if "lint-genfiles" in rule.attr.tags:
         return rule.files.srcs


### PR DESCRIPTION
The clang_tidy aspect did not read the `defines` and `local_defines` attribute of the rule, causing clang_tidy to error 
on parsing code that references these defines. This PR extends the clang_tidy.bzl with support for reading these attributes and adds them to the clang-tidy commandline. 

I also added a guard against rules that do not have a `srcs` attribute, but do return a CcInfo. 
---

### Changes are visible to end-users: yes/no

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Extended the example with a `local_defines` attribute and tried to lint the code without my changes, where i got the 
error 
```
_main/src/cpp/lib/hello-time.cc:16:28: error: use of undeclared identifier 'LOCAL_DEFINE_IS_DEFINED' [clang-diagnostic-error]
  static const char* str = LOCAL_DEFINE_IS_DEFINED;
```

after my change the error is gone and the normal fixes are proposed when running `bazel lint //src/cpp/...`.

I only tested on ubuntu x86.
