### PR TITLE
fix(ruff): honor exclusions when linting

### DIFF
--- a/example/.ruff.toml
+++ b/example/.ruff.toml
@@ -1,0 +1,1 @@
+exclude = ['test/excluded.py']

--- a/example/test/BUILD.bazel
+++ b/example/test/BUILD.bazel
@@ -52,6 +52,11 @@ py_library(
     srcs = ["generated.py"],
 )
 
+py_library(
+    name = "excluded_py",
+    srcs = ["excluded.py"],
+)
+
 java_library(
     name = "generated_java",
     srcs = ["generated.java"],
@@ -71,6 +76,11 @@ flake8_test(
 ruff_test(
     name = "ruff_should_ignore_generated",
     srcs = [":generated_py"],
+)
+
+ruff_test(
+    name = "ruff_should_ignore_excluded",
+    srcs = ["excluded_py"],
 )
 
 pmd_test(

--- a/example/test/excluded.py
+++ b/example/test/excluded.py
@@ -1,0 +1,1 @@
+import os

--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -91,6 +91,8 @@ def ruff_action(ctx, executable, srcs, config, stdout, exit_code = None, env = {
     # `ruff help check` to see available options
     args = ctx.actions.args()
     args.add("check")
+    # Honor exclusions in pyproject.toml even though we pass explicit list of files
+    args.add("--force-exclude")
     args.add_all(srcs)
 
     if exit_code:
@@ -130,7 +132,7 @@ def ruff_fix(ctx, executable, srcs, config, patch, stdout, exit_code, env = {}):
         output = patch_cfg,
         content = json.encode({
             "linter": executable._ruff.path,
-            "args": ["check", "--fix"] + [s.path for s in srcs],
+            "args": ["check", "--fix", "--force-exclude"] + [s.path for s in srcs],
             "files_to_diff": [s.path for s in srcs],
             "output": patch.path,
         }),


### PR DESCRIPTION
Without this flag, it will lint files that are excluded by the config file since we pass explicit filename arguments
