### PR TITLE
chore: fix new BCR release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   publish:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@f1ccce0ff0a5b80da1be497facc8b6c0e0cf097c # 2025 March 15
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@refs/heads/main # 2025 March 15
     with:
       tag_name: ${{ inputs.tag_name }}
       # GitHub repository which is a fork of the upstream where the Pull Request will be opened.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   publish:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@fdba2ee58b51f339e438137634830100fa8c9bc2 # 2025 March 15
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@fb1dc6802c3c999e17ad7afce9474a90bd89e132 # 2025 March 15
     with:
       tag_name: ${{ inputs.tag_name }}
       # GitHub repository which is a fork of the upstream where the Pull Request will be opened.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,3 +1,6 @@
+# See https://github.com/bazel-contrib/publish-to-bcr
+name: Publish to BCR
+
 on:
   # Run the publish workflow after a successful release
   # Can be triggered from the release.yaml workflow
@@ -16,12 +19,14 @@ on:
 
 jobs:
   publish:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@165f8b872b32a54bcc3c77156db4a74f54a51986 # 2025 March 14
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@f974bb91ba8a58c6d448f5eea864d18fed25a5df # 2025 March 14
     with:
       tag_name: ${{ inputs.tag_name }}
       # GitHub repository which is a fork of the upstream where the Pull Request will be opened.
       registry_fork: aspect-build/bazel-central-registry
     permissions:
+      attestations: write
       contents: write
+      id-token: write
     secrets:
       publish_token: ${{ secrets.PUBLISH_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   publish:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@fb1dc6802c3c999e17ad7afce9474a90bd89e132 # 2025 March 15
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@f1ccce0ff0a5b80da1be497facc8b6c0e0cf097c # 2025 March 15
     with:
       tag_name: ${{ inputs.tag_name }}
       # GitHub repository which is a fork of the upstream where the Pull Request will be opened.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   publish:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@refs/heads/main # 2025 March 15
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.0.1 # 2025 March 15
     with:
       tag_name: ${{ inputs.tag_name }}
       # GitHub repository which is a fork of the upstream where the Pull Request will be opened.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   publish:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@f974bb91ba8a58c6d448f5eea864d18fed25a5df # 2025 March 14
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@8bbf2a17734ebd8600f619c36f75d2f3acd9017d # 2025 March 14
     with:
       tag_name: ${{ inputs.tag_name }}
       # GitHub repository which is a fork of the upstream where the Pull Request will be opened.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   publish:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@8bbf2a17734ebd8600f619c36f75d2f3acd9017d # 2025 March 14
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@fdba2ee58b51f339e438137634830100fa8c9bc2 # 2025 March 15
     with:
       tag_name: ${{ inputs.tag_name }}
       # GitHub repository which is a fork of the upstream where the Pull Request will be opened.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   release:
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@540bb73a286db90d2f82d337d0adec21d3d54d7b # 2025-03-14
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.1 # 2025-03-17
     with:
       prerelease: false
       release_files: rules_lint-*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,11 @@ jobs:
     permissions:
       id-token: write # Needed to attest provenance
       attestations: write # Needed to attest provenance
+      contents: write # Needed to create release
   publish:
-    name: Publish to BCR
     needs: release
     uses: ./.github/workflows/publish.yaml
     with:
       tag_name: ${{ inputs.tag_name }}
+    permissions:
+      contents: write # allow appending new attestation files to the release


### PR DESCRIPTION
We now use the reusable workflow rather than a configured GitHub App.

https://github.com/bazelbuild/bazel-central-registry/pull/4060 was created by manually triggering the workflow from this PR branch.

---

### Changes are visible to end-users: no
