### PR TITLE
fix: spotbugs exitcode

### DIFF
--- a/lint/spotbugs.bzl
+++ b/lint/spotbugs.bzl
@@ -68,6 +68,7 @@ def spotbugs_action(ctx, executable, srcs, target, exclude_filter, stdout, exit_
         args.add_all(["-auxclasspath", ":".join(classpath_paths)])
     
     args.add_all(["-exclude", exclude_filter.path])
+    args.add_all(["-exitcode"])
 
     if exit_code:
         command = "{SPOTBUGS} $@ >{stdout}; echo $? > " + exit_code.path


### PR DESCRIPTION
spotbugs didn't return the right exitcode to bazel lint when there are violations. Add -exitcode flag to fix it.

Test: 
```
Failed case:
bazel lint //examples:examples-lib
Lint results for //examples:examples-lib:
.....
M V EI2: new io.security.Access.java may expose internal representation by storing an externally mutable object into Access.accessRules  At Access.java:[line 45]
.....
$ echo $?                                             
113
```

succeed case:
```
bazel lint  //examples:examples-lib
INFO: Invocation ID: ab914925-3fa7-4ccc-92db-2f370255c3e1
INFO: Analyzed target  //examples:examples-lib (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Aspect //tools/lint:linters.bzl%spotbugs of//examples:examples-lib up-to-date:
  bazel-bin/examples/examples-lib.AspectRulesLintCSpotbugs.out
  bazel-bin/examples/examples-lib.AspectRulesLintCSpotbugs.out.exit_code
INFO: Elapsed time: 4.061s, Critical Path: 3.81s
INFO: 2 processes: 1 internal, 1 darwin-sandbox.
INFO: Build completed successfully, 2 total actions
$ echo $?                                             
0
```
