### PR TITLE
fix(format): Handle successfuly folders name which contain spaces

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -166,7 +166,7 @@ function ls-files {
 
         # TODO: determine which staged changes we should format; avoid formatting unstaged changes
         # TODO: try to format only modified regions of the file (where supported)
-        files=$(git ls-files -t --cached --modified --other --exclude-standard "${patterns[@]}" "${patterns[@]/#/*/}" | grep -v ^S | cut -f2 -d' ' | {
+        files=$(git ls-files -t --cached --modified --other --exclude-standard "${patterns[@]}" "${patterns[@]/#/*/}" | grep -v ^S | cut -f2- -d' ' | {
           grep -vE \
             "^$(git ls-files --deleted)$" \
           || true;

--- a/format/test/ls-files_test.sh
+++ b/format/test/ls-files_test.sh
@@ -73,6 +73,18 @@ css=$(ls-files CSS)
     exit 1
 }
 
+# should not fail when folder name contains spaces
+mkdir -p "complex-structure/folder with space"
+touch "complex-structure/folder with space/src.go"
+go=$(ls-files Go)
+expected='complex-structure/folder with space/src.go
+more.go
+src.go'
+[[ "$go" == "$expected" ]] || {
+    echo >&2 -e "expected ls-files to return complex-structure/folder with space/src.go more.go src.go, was\n$go"
+    exit 1
+}
+
 # patterns should match filenames
 go=$(ls-files Go src.go)
 [[ "$go" == "src.go" ]] || {


### PR DESCRIPTION
Fixing format which doesn't handle properly folders names with spaces. When format is executed it fails since the folder is not found because it cuts name with spaces thus it's not complete folder name.

Example of folder: `complex_folder/{{ cookiecutter.name }}/src.go`

---

### Test plan

- New test cases added
