### PR TITLE
chore: fix release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,9 @@ on:
       tag_name:
         required: true
         type: string
+    secrets:
+      publish_token:
+        required: true
   # In case of problems, let release engineers retry by manually dispatching
   # the workflow from the GitHub UI
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,21 +20,20 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  id-token: write # Needed to attest provenance
+  attestations: write # Needed to attest provenance
+  contents: write # Needed to create release
+
 jobs:
   release:
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.1 # 2025-03-17
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.1.0 # 2025-03-17
     with:
       prerelease: false
       release_files: rules_lint-*.tar.gz
       tag_name: ${{ inputs.tag_name }}
-    permissions:
-      id-token: write # Needed to attest provenance
-      attestations: write # Needed to attest provenance
-      contents: write # Needed to create release
   publish:
     needs: release
     uses: ./.github/workflows/publish.yaml
     with:
       tag_name: ${{ inputs.tag_name }}
-    permissions:
-      contents: write # allow appending new attestation files to the release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,5 @@ jobs:
     uses: ./.github/workflows/publish.yaml
     with:
       tag_name: ${{ inputs.tag_name }}
+    secrets:
+      publish_token: ${{ secrets.PUBLISH_TOKEN }}


### PR DESCRIPTION
Appu found that the slsa-verifier hard-codes the usual semver pattern vX.Y.Z. I was too cute using a shorter one that looks like a GitHub actions major/minor.

Also fix permissions and secret.