### PR TITLE
refactor: forbid compiling protoc in root repository

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,1 +1,3 @@
+# Nested modules
+docs/
 example/

--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,10 @@
 # https://bazelbuild.slack.com/archives/C014RARENH0/p1691158021917459?thread_ts=1691156601.420349&cid=C014RARENH0
 common --check_direct_dependencies=off
 
+# Don't build protoc from the cc_binary, it's slow and spammy when cache miss
+common --per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT
+common --host_per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT
+
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members
 # This needs to be last statement in this

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
   bazel-test:
     uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v6
     with:
-      folders: '[".", "example"]'
+      folders: '[".", "docs", "example"]'
       # Don't try for Windows support yet.
       exclude_windows: true
       # Root module is bzlmod-only and uses newer stardoc that requires Bazel 7.
@@ -28,7 +28,8 @@ jobs:
       exclude: |
         [
           {"bzlmodEnabled": false, "folder": "."},
-          {"bazelversion": "6.4.0"}
+          {"bzlmodEnabled": false, "folder": "docs"},
+          {"bazelversion": "6.4.0"},
         ]
 
   integration-test:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,11 +24,8 @@ bazel_dep(name = "rules_proto", version = "6.0.0")
 
 # Needed in the root because we dereference the toolchain in our aspect impl
 bazel_dep(name = "rules_buf", version = "0.1.1")
-bazel_dep(name = "toolchains_protoc", version = "0.2.1")
 
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
 multitool.hub(lockfile = "//format:multitool.lock.json")
 multitool.hub(lockfile = "//lint:multitool.lock.json")
 use_repo(multitool, "multitool")
-
-bazel_dep(name = "stardoc", version = "0.7.0", dev_dependency = True, repo_name = "io_bazel_stardoc")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,1 +1,0 @@
-# Marker that this folder is the root of a Bazel workspace

--- a/docs/.bazelversion
+++ b/docs/.bazelversion
@@ -1,0 +1,1 @@
+../.bazelversion

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -4,77 +4,77 @@ load("@aspect_bazel_lib//lib:docs.bzl", "stardoc_with_diff_test", "update_docs")
 
 stardoc_with_diff_test(
     name = "lint_test",
-    bzl_library_target = "//lint:lint_test",
+    bzl_library_target = "@aspect_rules_lint//lint:lint_test",
 )
 
 stardoc_with_diff_test(
     name = "buf",
-    bzl_library_target = "//lint:buf",
+    bzl_library_target = "@aspect_rules_lint//lint:buf",
 )
 
 stardoc_with_diff_test(
     name = "eslint",
-    bzl_library_target = "//lint:eslint",
+    bzl_library_target = "@aspect_rules_lint//lint:eslint",
 )
 
 stardoc_with_diff_test(
     name = "flake8",
-    bzl_library_target = "//lint:flake8",
+    bzl_library_target = "@aspect_rules_lint//lint:flake8",
 )
 
 stardoc_with_diff_test(
     name = "keep_sorted",
-    bzl_library_target = "//lint:keep_sorted",
+    bzl_library_target = "@aspect_rules_lint//lint:keep_sorted",
 )
 
 stardoc_with_diff_test(
     name = "pmd",
-    bzl_library_target = "//lint:pmd",
+    bzl_library_target = "@aspect_rules_lint//lint:pmd",
 )
 
 stardoc_with_diff_test(
     name = "checkstyle",
-    bzl_library_target = "//lint:checkstyle",
+    bzl_library_target = "@aspect_rules_lint//lint:checkstyle",
 )
 
 stardoc_with_diff_test(
     name = "spotbugs",
-    bzl_library_target = "//lint:spotbugs",
+    bzl_library_target = "@aspect_rules_lint//lint:spotbugs",
 )
 
 stardoc_with_diff_test(
     name = "format",
-    bzl_library_target = "//format:defs",
+    bzl_library_target = "@aspect_rules_lint//format:defs",
 )
 
 stardoc_with_diff_test(
     name = "stylelint",
-    bzl_library_target = "//lint:stylelint",
+    bzl_library_target = "@aspect_rules_lint//lint:stylelint",
 )
 
 stardoc_with_diff_test(
     name = "ruff",
-    bzl_library_target = "//lint:ruff",
+    bzl_library_target = "@aspect_rules_lint//lint:ruff",
 )
 
 stardoc_with_diff_test(
     name = "shellcheck",
-    bzl_library_target = "//lint:shellcheck",
+    bzl_library_target = "@aspect_rules_lint//lint:shellcheck",
 )
 
 stardoc_with_diff_test(
     name = "vale",
-    bzl_library_target = "//lint:vale",
+    bzl_library_target = "@aspect_rules_lint//lint:vale",
 )
 
 stardoc_with_diff_test(
     name = "ktlint",
-    bzl_library_target = "//lint:ktlint",
+    bzl_library_target = "@aspect_rules_lint//lint:ktlint",
 )
 
 stardoc_with_diff_test(
     name = "clang-tidy",
-    bzl_library_target = "//lint:clang_tidy",
+    bzl_library_target = "@aspect_rules_lint//lint:clang_tidy",
 )
 
 update_docs(name = "update")

--- a/docs/MODULE.bazel
+++ b/docs/MODULE.bazel
@@ -1,0 +1,9 @@
+bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")
+bazel_dep(name = "aspect_rules_lint", version = "0.0.0")
+
+bazel_dep(name = "stardoc", version = "0.7.0", dev_dependency = True, repo_name = "io_bazel_stardoc")
+
+local_path_override(
+    module_name = "aspect_rules_lint",
+    path = "..",
+)


### PR DESCRIPTION
Isolate stardoc in a new sub-module.

I cannot withstand slow releases due to stardoc having a bug (https://github.com/bazelbuild/stardoc/pull/243)

See also https://blog.aspect.build/experiment-with-buf-and-starlark-docgen for a more ambitious idea of discarding it completely.