### PR TITLE
Writing patch file incorrectly buffers

### DIFF
--- a/lint/private/patcher.mjs
+++ b/lint/private/patcher.mjs
@@ -81,8 +81,9 @@ async function main(args, sandbox) {
     console.error(ret.error);
     process.exit(1);
   }
+  
 
-  const diffOut = fs.createWriteStream(config.output);
+  const diffOut = fs.openSync(config.output, "w");
   const diffBin = process.env["DIFF_BIN"]
     ? path.join(process.env["JS_BINARY__RUNFILES"], process.env["DIFF_BIN"])
     : "diff";
@@ -101,7 +102,7 @@ async function main(args, sandbox) {
       }
     );
     debug(results.stdout);
-    diffOut.write(results.stdout);
+    fs.writeSync(diffOut, results.stdout);
     if (results.error) {
       console.error(results.error);
     }


### PR DESCRIPTION
the write of writeStream in fs has buffer and needs a callback to know when it's done.

I seem to be experiencing cases where the patch file is empty. The simple fix was to move this to the sync variant.

fixes #510
