### PR TITLE
clang-tidy emit action per file to lint and merge stdout and error codes

### DIFF
--- a/example/src/cpp/main/BUILD
+++ b/example/src/cpp/main/BUILD
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
-
+load("//tools/lint:linters.bzl", "clang_tidy_test")
 cc_library(
     name = "hello-greet",
     srcs = ["hello-greet.cc"],
@@ -15,6 +15,11 @@ cc_binary(
         ":hello-greet",
         "//src/cpp/lib:hello-time",
     ],
+)
+
+clang_tidy_test(
+    name = "hello-world-clang-tidy-test",
+    srcs = ["hello-world"],
 )
 
 cc_library(


### PR DESCRIPTION
Some cc_library/binary targets may contain 10+ files listed in sources and as clang-tidy runs single threaded, this can lead 
to long running linting actions. This PR emits a clang-tidy action per source file, so they can be parallelised locally/remotely. The stdout/stderror is merged in unspecified order according to the order of the srcs using a simple 
concatenation. The exit_code of the individual action, is merged by sorting them numerically and selecting the highest number. 

I did also consider making the splitting optional, in case we are unsure of the impact of this change. Let me know if i should do that. 

I also considered updated the progress message to use the source file short path instead, but decided to leave it out here. Currently the progress message will be the same for each individual action and makes it harder to see which source file is being linted.

### Test plan

- Covered by existing test cases
- Manual testing was also done, both in our own bazel repo and in the examples folder. It has only been tested on linux, so there could be issues with the behaviour of `sort` and `head` on macOS. 
