### PR TITLE
Specify `--rcfile` shellcheck option in `_shellcheck_aspect_impl`

### DIFF
--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -80,6 +80,7 @@ def _shellcheck_aspect_impl(target, ctx):
         return [info]
 
     color_options = ["--color"] if ctx.attr._options[LintOptionsInfo].color else []
+    config_options = ["--rcfile", ctx.file._config_file]
 
     # shellcheck does not have a --fix mode that applies fixes for some violations while reporting others.
     # So we must run an action to generate the report separately from an action that writes the human-readable report.
@@ -87,8 +88,8 @@ def _shellcheck_aspect_impl(target, ctx):
         discard_exit_code = ctx.actions.declare_file(_OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "patch_exit_code"))
         shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, outputs.patch, discard_exit_code, ["--format", "diff"])
 
-    shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, outputs.human.out, outputs.human.exit_code, color_options)
-    shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, outputs.machine.out, outputs.machine.exit_code)
+    shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, outputs.human.out, outputs.human.exit_code, color_options + config_options)
+    shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, outputs.machine.out, outputs.machine.exit_code, config_options)
 
     return [info]
 


### PR DESCRIPTION
### Issue
The `.shellcheckrc` file that can be specified through the `config` parameter in [lint_shellcheck_aspect](https://github.com/aspect-build/rules_lint/blob/main/docs/shellcheck.md#lint_shellcheck_aspect) appears to be ignored when it's specified anywhere other than the root of the repository.

I'm not sure if it's a desired design to want the config file at the root, but I decided to add the support for specifying it elsewhere in case it is not.

### Test plan
Manual testing for reproducing:

On `main` (at the root of the repo), move into the `example/` directory:
```
cd example
```

Note that running the `//test:shellcheck` test leads to failure (expected):
```
bazel test //test:shellcheck
```

We can make the test pass by appending these disable directives to the `.shellcheckrc`:
```
disable=SC2063
disable=SC2086
```

However, instead of using the `.shellcheckrc` found at the root of `example/`, let's create a copy of it in `example/tools/lint/`, add those disable directives, and update `lint_shellcheck_aspect` to use that config:
```
cp .shellcheckrc tools/lint
```
```
{
    echo -e "\n"
    echo "# Added to make //test:shellcheck test pass"
    echo "disable=SC2063"
    echo "disable=SC2086"
} >> tools/lint/.shellcheckrc
```

In `example/tools/lint/BUILD.bazel`, append:
```
exports_files(
    [
        ".shellcheckrc",
    ],
    visibility = ["//visibility:public"],
)
```

In `example/tools/lint/linters.bzl`, modify the `config` value in `lint_shellcheck_aspect` invocation to `Label("@//tools/lint:.shellcheckrc")`:
```
shellcheck = lint_shellcheck_aspect(
    binary = "@multitool//tools/shellcheck",
    config = Label("@//tools/lint:.shellcheckrc"),
)
```

Now, if we run the shellcheck test, we will still observe a failure (not expected):
```
bazel test //test:shellcheck
```

This is because the `config` path is ignored.

Applying the changes from this PR (found in `lint/shellcheck.bzl`) makes the test pass as the `config` path is used.