### PR TITLE
fix: when pushing a tag, use the ref_name as the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,11 @@ jobs:
     with:
       prerelease: false
       release_files: rules_lint-*.tar.gz
-      tag_name: ${{ inputs.tag_name }}
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
   publish:
     needs: release
     uses: ./.github/workflows/publish.yaml
     with:
-      tag_name: ${{ inputs.tag_name }}
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
     secrets:
       publish_token: ${{ secrets.PUBLISH_TOKEN }}


### PR DESCRIPTION
Fixes publish failure in https://github.com/aspect-build/rules_lint/actions/runs/14410748994/job/40417851773
