### PR TITLE
Change close to work with fs sync methods

### DIFF
--- a/lint/private/patcher.mjs
+++ b/lint/private/patcher.mjs
@@ -108,7 +108,7 @@ async function main(args, sandbox) {
     }
   }
 
-  diffOut.close();
+  fs.closeSync(diffOut);
 
   return ret.status;
 }


### PR DESCRIPTION
openSync returns an fd and not an object so the call to `close` on it causes a failure.
Change to according closeSync call

fixes #524