### PR TITLE
group srcs into filegroup to handle special char filename

### DIFF
--- a/example/tools/format/(special_char)/[square]/hello.ts
+++ b/example/tools/format/(special_char)/[square]/hello.ts
@@ -1,0 +1,1 @@
+export const hello = "hello";

--- a/example/tools/format/BUILD.bazel
+++ b/example/tools/format/BUILD.bazel
@@ -122,3 +122,11 @@ format_test(
     # swift = ":swiftformat",
     workspace = "//:.shellcheckrc",  # A file in the workspace root, where the no_sandbox mode will run the formatter
 )
+
+format_test(
+    name = "format_js_test",
+    srcs = [
+        "(special_char)/[square]/hello.ts",
+    ],
+    javascript = ":prettier",
+)

--- a/format/defs.bzl
+++ b/format/defs.bzl
@@ -161,8 +161,12 @@ def format_test(name, srcs = None, workspace = None, no_sandbox = False, disable
     for lang, toolname, tool_label, target_name in _tools_loop(name, kwargs):
         attrs = _format_attr_factory(target_name, lang, toolname, tool_label, "test", disable_git_attribute_checks)
         if srcs:
-            attrs["data"] = [tool_label] + srcs
-            attrs["args"] = ["$(location {})".format(i) for i in srcs]
+            native.filegroup(
+                name = name + "_srcs",
+                srcs = srcs,
+            )
+            attrs["data"] = [tool_label, name + "_srcs"]
+            attrs["args"] = ["$(locations {})".format(name + "_srcs")]
         else:
             attrs["data"] = [tool_label, workspace]
             attrs["env"]["WORKSPACE"] = "$(location {})".format(workspace)


### PR DESCRIPTION
Some filenames can contain special chars, especially things like Nextjs app router file where they use `()` and `[]` to do grouping and wildcard.
Group `srcs` into a filegroup since `$(location <filename>)` won't work.

---

### Changes are visible to end-users: no

### Test plan

- New test cases added
