### PR TITLE
Revert "refactor: simplify devDep patching"

### DIFF
--- a/.bcr/patches/go_dev_deps.patch
+++ b/.bcr/patches/go_dev_deps.patch
@@ -1,0 +1,11 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -34,7 +34,7 @@ use_repo(multitool, "multitool")
+ 
+ # To allow /tools to be built from source
+ # NOTE: when publishing to BCR, we patch this to be True, as we publish pre-built binaries with our releases.
+-IS_RELEASE = False
++IS_RELEASE = True
+ 
+ bazel_dep(
+     name = "toolchains_protoc",

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-docs/*.md          linguist-generated=true
-docs/linting.md    linguist-generated=false
+docs/*.md linguist-generated=true
+docs/linting.md linguist-generated=false
 docs/formatting.md linguist-generated=false
 
 #################################
@@ -8,5 +8,4 @@ docs/formatting.md linguist-generated=false
 #################################
 
 # Substitution for the _VERSION_PRIVATE placeholder
-MODULE.bazel      export-subst
 tools/version.bzl export-subst

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,12 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
+  bcr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify bcr patches
+        run: patch --dry-run -p1 --fuzz 0 < .bcr/patches/*.patch
   integration-test:
     runs-on: ubuntu-latest
     steps:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -39,11 +39,8 @@ register_toolchains("@sarif_parser_toolchains//:all")
 ####### Dev dependencies ########
 
 # To allow /tools to be built from source
-# NB: this is stamped by git archive, see .gitattributes
-_VERSION_PRIVATE = "$Format:%(describe:tags=true)$"
-
-# If the version is like v1.2.3 but NOT like v2.0.3-7-g57bfe2c1, then there are pre-built binaries
-IS_RELEASE = _VERSION_PRIVATE.startswith("v") and _VERSION_PRIVATE.find("g") < 0
+# NOTE: when publishing to BCR, we patch this to be True, as we publish pre-built binaries with our releases.
+IS_RELEASE = False
 
 bazel_dep(
     name = "toolchains_protoc",


### PR DESCRIPTION
Reverts aspect-build/rules_lint#543

I forgot that the export-subst can only perform a substitution in a single file, for whatever reason...