### PR TITLE
Document where to find mypy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,34 +29,34 @@ Linters which are not language-specific:
 
 - [keep-sorted]
 
-| Language               | Formatter                 | Linter(s)                        |
-| ---------------------- | ------------------------- | -------------------------------- |
-| C / C++                | [clang-format]            | [clang-tidy]                     |
-| Cuda                   | [clang-format]            |                                  |
-| CSS, Less, Sass        | [Prettier]                | [Stylelint]                      |
-| Go                     | [gofmt] or [gofumpt]      |                                  |
-| Gherkin                | [prettier-plugin-gherkin] |                                  |
-| GraphQL                | [Prettier]                |                                  |
-| HCL (Hashicorp Config) | [terraform] fmt           |                                  |
-| HTML                   | [Prettier]                |                                  |
-| JSON                   | [Prettier]                |                                  |
-| Java                   | [google-java-format]      | [pmd] , [Checkstyle], [Spotbugs] |
-| JavaScript             | [Prettier]                | [ESLint]                         |
-| Jsonnet                | [jsonnetfmt]              |                                  |
-| Kotlin                 | [ktfmt]                   | [ktlint]                         |
-| Markdown               | [Prettier]                | [Vale]                           |
-| Protocol Buffer        | [buf]                     | [buf lint]                       |
-| Python                 | [ruff]                    | [flake8], [ruff]                 |
-| Rust                   | [rustfmt]                 |                                  |
-| SQL                    | [prettier-plugin-sql]     |                                  |
-| Scala                  | [scalafmt]                |                                  |
-| Shell                  | [shfmt]                   | [shellcheck]                     |
-| Starlark               | [Buildifier]              |                                  |
-| Swift                  | [SwiftFormat] (1)         |                                  |
-| TSX                    | [Prettier]                | [ESLint]                         |
-| TypeScript             | [Prettier]                | [ESLint]                         |
-| YAML                   | [yamlfmt]                 |                                  |
-| XML                    | [prettier/plugin-xml]     |                                  |
+| Language               | Formatter                 | Linter(s)                        | Type checkers (in other repos) |
+| ---------------------- | ------------------------- | -------------------------------- | ------------------------------ |
+| C / C++                | [clang-format]            | [clang-tidy]                     |                                |
+| Cuda                   | [clang-format]            |                                  |                                |
+| CSS, Less, Sass        | [Prettier]                | [Stylelint]                      |                                |
+| Go                     | [gofmt] or [gofumpt]      |                                  |                                |
+| Gherkin                | [prettier-plugin-gherkin] |                                  |                                |
+| GraphQL                | [Prettier]                |                                  |                                |
+| HCL (Hashicorp Config) | [terraform] fmt           |                                  |                                |
+| HTML                   | [Prettier]                |                                  |                                |
+| JSON                   | [Prettier]                |                                  |                                |
+| Java                   | [google-java-format]      | [pmd] , [Checkstyle], [Spotbugs] |                                |
+| JavaScript             | [Prettier]                | [ESLint]                         |                                |
+| Jsonnet                | [jsonnetfmt]              |                                  |                                |
+| Kotlin                 | [ktfmt]                   | [ktlint]                         |                                |
+| Markdown               | [Prettier]                | [Vale]                           |                                |
+| Protocol Buffer        | [buf]                     | [buf lint]                       |                                |
+| Python                 | [ruff]                    | [flake8], [ruff]                 | [mypy]                         |
+| Rust                   | [rustfmt]                 |                                  |                                |
+| SQL                    | [prettier-plugin-sql]     |                                  |                                |
+| Scala                  | [scalafmt]                |                                  |                                |
+| Shell                  | [shfmt]                   | [shellcheck]                     |                                |
+| Starlark               | [Buildifier]              |                                  |                                |
+| Swift                  | [SwiftFormat] (1)         |                                  |                                |
+| TSX                    | [Prettier]                | [ESLint]                         |                                |
+| TypeScript             | [Prettier]                | [ESLint]                         |                                |
+| YAML                   | [yamlfmt]                 |                                  |                                |
+| XML                    | [prettier/plugin-xml]     |                                  |                                |
 
 [prettier]: https://prettier.io
 [google-java-format]: https://github.com/google/google-java-format
@@ -89,6 +89,7 @@ Linters which are not language-specific:
 [yamlfmt]: https://github.com/google/yamlfmt
 [rustfmt]: https://rust-lang.github.io/rustfmt
 [stylelint]: https://stylelint.io
+[mypy]: https://github.com/theoremlp/rules_mypy
 
 1. Non-hermetic: requires that a swift toolchain is installed on the machine.
    See https://github.com/bazelbuild/rules_swift#1-install-swift


### PR DESCRIPTION
Document where to find mypy. Since type checkers are commonly used alongside linters and formatters, it's helpful to link to them, even when they're in other repos.

Fixes https://github.com/aspect-build/rules_lint/issues/552.
