### PR TITLE
Allow the ruff linter to run on filegroups tagged 'python'

### DIFF
--- a/docs/ruff.md
+++ b/docs/ruff.md
@@ -1,6 +1,6 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
-API for declaring a Ruff lint aspect that visits py_library rules.
+API for declaring a Ruff lint aspect that visits py_library rules and filegroups tagged 'python'.
 
 Typical usage:
 
@@ -80,7 +80,7 @@ Allows the user to select a particular ruff version, rather than get whatever is
 <pre>
 load("@aspect_rules_lint//lint:ruff.bzl", "lint_ruff_aspect")
 
-lint_ruff_aspect(<a href="#lint_ruff_aspect-binary">binary</a>, <a href="#lint_ruff_aspect-configs">configs</a>, <a href="#lint_ruff_aspect-rule_kinds">rule_kinds</a>)
+lint_ruff_aspect(<a href="#lint_ruff_aspect-binary">binary</a>, <a href="#lint_ruff_aspect-configs">configs</a>, <a href="#lint_ruff_aspect-rule_kinds">rule_kinds</a>, <a href="#lint_ruff_aspect-filegroup_tags">filegroup_tags</a>)
 </pre>
 
 A factory function to create a linter aspect.
@@ -89,6 +89,7 @@ Attrs:
     binary: a ruff executable
     configs: ruff config file(s) (`pyproject.toml`, `ruff.toml`, or `.ruff.toml`)
     rule_kinds: which [kinds](https://bazel.build/query/language#kind) of rules should be visited by the aspect
+    filegroup_tags: filegroups tagged with these tags will be visited by the aspect
 
 **PARAMETERS**
 
@@ -98,6 +99,7 @@ Attrs:
 | <a id="lint_ruff_aspect-binary"></a>binary |  <p align="center"> - </p>   |  none |
 | <a id="lint_ruff_aspect-configs"></a>configs |  <p align="center"> - </p>   |  none |
 | <a id="lint_ruff_aspect-rule_kinds"></a>rule_kinds |  <p align="center"> - </p>   |  `["py_binary", "py_library", "py_test"]` |
+| <a id="lint_ruff_aspect-filegroup_tags"></a>filegroup_tags |  <p align="center"> - </p>   |  `["python", "lint-with-ruff"]` |
 
 
 <a id="ruff_action"></a>

--- a/example/src/BUILD.bazel
+++ b/example/src/BUILD.bazel
@@ -66,6 +66,12 @@ py_library(
     srcs = ["unused_import.py"],
 )
 
+filegroup(
+    name = "unused_import_filegroup",
+    srcs = ["unused_import.py"],
+    tags = ["python"],
+)
+
 java_library(
     name = "foo",
     srcs = ["Foo.java"],

--- a/example/src/subdir/BUILD.bazel
+++ b/example/src/subdir/BUILD.bazel
@@ -8,6 +8,12 @@ py_library(
     srcs = ["unused_import.py"],
 )
 
+filegroup(
+    name = "unused_import_filegroup",
+    srcs = ["unused_import.py"],
+    tags = ["python"],
+)
+
 js_library(
     name = "eslint-override",
     srcs = ["index.js"],

--- a/example/test/BUILD.bazel
+++ b/example/test/BUILD.bazel
@@ -52,9 +52,21 @@ py_library(
     srcs = ["generated.py"],
 )
 
+filegroup(
+    name = "generated_py_filegroup",
+    srcs = ["generated.py"],
+    tags = ["lint-with-ruff"],
+)
+
 py_library(
     name = "excluded_py",
     srcs = ["excluded.py"],
+)
+
+filegroup(
+    name = "excluded_py_filegroup",
+    srcs = ["excluded.py"],
+    tags = ["python"],
 )
 
 java_library(
@@ -79,8 +91,18 @@ ruff_test(
 )
 
 ruff_test(
+    name = "ruff_should_ignore_generated_filegroup",
+    srcs = [":generated_py_filegroup"],
+)
+
+ruff_test(
     name = "ruff_should_ignore_excluded",
     srcs = ["excluded_py"],
+)
+
+ruff_test(
+    name = "ruff_should_ignore_excluded_filegroup",
+    srcs = ["excluded_py_filegroup"],
 )
 
 pmd_test(

--- a/example/test/machine_outputs/BUILD.bazel
+++ b/example/test/machine_outputs/BUILD.bazel
@@ -24,6 +24,18 @@ report_test(
     report = "machine_ruff_report",
 )
 
+machine_ruff_report(
+    name = "machine_ruff_filegroup_report",
+    src = "//src:unused_import_filegroup",
+)
+
+report_test(
+    name = "ruff_filegroup_machine_output_test",
+    expected_tool = "Ruff",
+    expected_uri = "src/unused_import.py",
+    report = "machine_ruff_filegroup_report",
+)
+
 machine_shellcheck_report(
     name = "machine_shellcheck_report",
     src = "//src:hello_shell",

--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -1,4 +1,4 @@
-"""API for declaring a Ruff lint aspect that visits py_library rules.
+"""API for declaring a Ruff lint aspect that visits py_library rules and filegroups tagged 'python'.
 
 Typical usage:
 
@@ -157,7 +157,7 @@ def ruff_fix(ctx, executable, srcs, config, patch, stdout, exit_code, env = {}):
 
 # buildifier: disable=function-docstring
 def _ruff_aspect_impl(target, ctx):
-    if not should_visit(ctx.rule, ctx.attr._rule_kinds):
+    if not should_visit(ctx.rule, ctx.attr._rule_kinds, ctx.attr._filegroup_tags):
         return []
 
     files_to_lint = filter_srcs(ctx.rule)
@@ -187,13 +187,14 @@ def _ruff_aspect_impl(target, ctx):
 
     return [info]
 
-def lint_ruff_aspect(binary, configs, rule_kinds = ["py_binary", "py_library", "py_test"]):
+def lint_ruff_aspect(binary, configs, rule_kinds = ["py_binary", "py_library", "py_test"], filegroup_tags = ["python", "lint-with-ruff"]):
     """A factory function to create a linter aspect.
 
     Attrs:
         binary: a ruff executable
         configs: ruff config file(s) (`pyproject.toml`, `ruff.toml`, or `.ruff.toml`)
         rule_kinds: which [kinds](https://bazel.build/query/language#kind) of rules should be visited by the aspect
+        filegroup_tags: filegroups tagged with these tags will be visited by the aspect
     """
 
     # syntax-sugar: allow a single config file in addition to a list
@@ -221,6 +222,9 @@ def lint_ruff_aspect(binary, configs, rule_kinds = ["py_binary", "py_library", "
             "_config_files": attr.label_list(
                 default = configs,
                 allow_files = True,
+            ),
+            "_filegroup_tags": attr.string_list(
+                default = filegroup_tags,
             ),
             "_rule_kinds": attr.string_list(
                 default = rule_kinds,


### PR DESCRIPTION
This is for e.g. pyi files, which can't be in the srcs of a py_* rule. Also added the tag 'lint-with-ruff' for consistency with the vale linter.

Part of https://github.com/aspect-build/rules_lint/issues/559.