### PR TITLE
fix: declare human outputs as validation outputs

### DIFF
--- a/docs/linting.md
+++ b/docs/linting.md
@@ -82,7 +82,6 @@ Add at least the following to the command-line or to your `.bazelrc` file to cau
 
 ```
 --aspects=//tools/lint:linters.bzl%eslint  # replace with your linter
---output_groups=rules_lint_human
 --@aspect_rules_lint//lint:fail_on_violation
 ```
 

--- a/example/lint.sh
+++ b/example/lint.sh
@@ -42,14 +42,10 @@ fi
 
 # NB: perhaps --remote_download_toplevel is needed as well with remote execution?
 args+=(
-	# Allow lints of code that fails some validation action
-	# See https://github.com/aspect-build/rules_ts/pull/574#issuecomment-2073632879
-	"--norun_validations"
 	"--build_event_json_file=$buildevents"
 	# Required for the buf allow_comment_ignores option to work properly
 	# See https://github.com/bufbuild/rules_buf/issues/64#issuecomment-2125324929
 	"--experimental_proto_descriptor_sets_include_source_info"
-	"--output_groups=rules_lint_human"
 	"--remote_download_regex='.*AspectRulesLint.*'"
 )
 
@@ -60,6 +56,12 @@ if [ $1 == "--fail-on-violation" ]; then
 		"--keep_going"
 	)
 	shift
+else
+	args+=(
+		# Allow lints of code that fails some validation action
+		# See https://github.com/aspect-build/rules_ts/pull/574#issuecomment-2073632879
+		"--norun_validations"
+	)
 fi
 
 # Allow a `--fix` option on the command-line.
@@ -70,6 +72,7 @@ if [ $1 == "--fix" ]; then
 	fix="patch"
 	args+=(
 		"--@aspect_rules_lint//lint:fix"
+		# Trigger the fixer actions to run by requesting the patch outputs
 		"--output_groups=rules_lint_patch"
 	)
 	shift

--- a/lint/private/lint_aspect.bzl
+++ b/lint/private/lint_aspect.bzl
@@ -93,6 +93,8 @@ def output_files(mnemonic, target, ctx):
         # Legacy name used by existing callers.
         # TODO(2.0): remove
         rules_lint_report = depset(machine_outputs),
+        # Always cause the action to execute, even if the output isn't requested
+        _validation = depset([human_out]),
     )
 
 def patch_file(mnemonic, target, ctx):


### PR DESCRIPTION
Simplifies the command-line needed to trigger linters, so that lint actions run without having to add the --output_groups=rules_lint_human.

Have noticed a couple folks trip over that requirement, and it's trivial to avoid.

/cc @calliecameron since it's removing a doc line you were forced to add :)

TESTED:

```
example % bazel build --@aspect_rules_lint//lint:fail_on_violation --aspects=//tools/lint:linters.bzl%ruff src:unused_import
INFO: Analyzed target //src:unused_import (0 packages loaded, 0 targets configured).
ERROR: /Users/alexeagle/Projects/rules_lint/example/src/BUILD.bazel:64:11: Linting //src:unused_import with Ruff failed: (Exit 1): bash failed: error executing AspectRulesLintRuff command (from target //src:unused_import) /bin/bash -c ... (remaining 5 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
src/unused_import.py:13:8: F401 [*] `os` imported but unused
   |
11 | # Found 1 error.
12 | # [*] 1 potentially fixable with the --fix option.
13 | import os
   |        ^^ F401
14 |
15 | # Another lint violation, which is not auto-fixable.
   |
   = help: Remove unused import: `os`

src/unused_import.py:17:7: F521 `.format` call has invalid format string: Single '{' encountered in format string
   |
15 | # Another lint violation, which is not auto-fixable.
16 | # When running with `--fix` this one should be reported and lint should exit 1.
17 | print("{".format("something"))
   |       ^^^^^^^^^^^^^^^^^^^^^^^ F521
   |

Found 2 errors.
[*] 1 fixable with the `--fix` option.
Aspect //tools/lint:linters.bzl%ruff of //src:unused_import failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.185s, Critical Path: 0.05s
INFO: 2 processes: 2 internal.
ERROR: Build did NOT complete successfully
```