### PR TITLE
Add aliases for built-in linters

### DIFF
--- a/docs/ruff.md
+++ b/docs/ruff.md
@@ -4,22 +4,14 @@ API for declaring a Ruff lint aspect that visits py_{binary|library|test} rules.
 
 Typical usage:
 
-Ruff is provided as a built-in tool by rules_lint. To use the built-in version, first add a dependency on rules_multitool to MODULE.bazel:
-
-```starlark
-bazel_dep(name = "rules_multitool", version = <desired version>)
-
-multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
-use_repo(multitool, "multitool")
-```
-
-Then create the linter aspect, typically in `tools/lint/linters.bzl`:
+Ruff is provided as a built-in tool by rules_lint. To use the built-in version,
+create the linter aspect, typically in `tools/lint/linters.bzl`:
 
 ```starlark
 load("@aspect_rules_lint//lint:ruff.bzl", "lint_ruff_aspect")
 
 ruff = lint_ruff_aspect(
-    binary = "@multitool//tools/ruff",
+    binary = Label("@aspect_rules_lint//lint:ruff_bin",
     configs = [Label("//:.ruff.toml")],
 )
 ```

--- a/docs/shellcheck.md
+++ b/docs/shellcheck.md
@@ -4,22 +4,14 @@ API for declaring a shellcheck lint aspect that visits sh_{binary|library|test} 
 
 Typical usage:
 
-Shellcheck is provided as a built-in tool by rules_lint. To use the built-in version, first add a dependency on rules_multitool to MODULE.bazel:
-
-```starlark
-bazel_dep(name = "rules_multitool", version = <desired version>)
-
-multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
-use_repo(multitool, "multitool")
-```
-
-Then create the linter aspect, typically in `tools/lint/linters.bzl`:
+Shellcheck is provided as a built-in tool by rules_lint. To use the built-in version,
+create the linter aspect, typically in `tools/lint/linters.bzl`:
 
 ```starlark
 load("@aspect_rules_lint//lint:shellcheck.bzl", "lint_shellcheck_aspect")
 
 shellcheck = lint_shellcheck_aspect(
-    binary = "@multitool//tools/shellcheck",
+    binary = Label("@aspect_rules_lint//lint:shellcheck_bin",
     config = Label("//:.shellcheckrc"),
 )
 ```

--- a/example/tools/lint/linters.bzl
+++ b/example/tools/lint/linters.bzl
@@ -60,7 +60,7 @@ checkstyle = lint_checkstyle_aspect(
 checkstyle_test = lint_test(aspect = checkstyle)
 
 ruff = lint_ruff_aspect(
-    binary = "@multitool//tools/ruff",
+    binary = Label("@aspect_rules_lint//lint:ruff_bin"),
     configs = [
         Label("@//:.ruff.toml"),
         Label("@//src/subdir:ruff.toml"),
@@ -70,7 +70,7 @@ ruff = lint_ruff_aspect(
 ruff_test = lint_test(aspect = ruff)
 
 shellcheck = lint_shellcheck_aspect(
-    binary = "@multitool//tools/shellcheck",
+    binary = Label("@aspect_rules_lint//lint:shellcheck_bin"),
     config = Label("@//:.shellcheckrc"),
 )
 

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -7,6 +7,17 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files(glob(["*.bzl"]) + ["lint_test.sh"])
 
+# Aliases for the built-in linters
+alias(
+    name = "ruff_bin",
+    actual = "@multitool//tools/ruff",
+)
+
+alias(
+    name = "shellcheck_bin",
+    actual = "@multitool//tools/shellcheck",
+)
+
 # Used as a default for vale_aspect#styles
 filegroup(
     name = "empty_styles",

--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -2,22 +2,14 @@
 
 Typical usage:
 
-Ruff is provided as a built-in tool by rules_lint. To use the built-in version, first add a dependency on rules_multitool to MODULE.bazel:
-
-```starlark
-bazel_dep(name = "rules_multitool", version = <desired version>)
-
-multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
-use_repo(multitool, "multitool")
-```
-
-Then create the linter aspect, typically in `tools/lint/linters.bzl`:
+Ruff is provided as a built-in tool by rules_lint. To use the built-in version,
+create the linter aspect, typically in `tools/lint/linters.bzl`:
 
 ```starlark
 load("@aspect_rules_lint//lint:ruff.bzl", "lint_ruff_aspect")
 
 ruff = lint_ruff_aspect(
-    binary = "@multitool//tools/ruff",
+    binary = Label("@aspect_rules_lint//lint:ruff_bin",
     configs = [Label("//:.ruff.toml")],
 )
 ```

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -2,22 +2,14 @@
 
 Typical usage:
 
-Shellcheck is provided as a built-in tool by rules_lint. To use the built-in version, first add a dependency on rules_multitool to MODULE.bazel:
-
-```starlark
-bazel_dep(name = "rules_multitool", version = <desired version>)
-
-multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
-use_repo(multitool, "multitool")
-```
-
-Then create the linter aspect, typically in `tools/lint/linters.bzl`:
+Shellcheck is provided as a built-in tool by rules_lint. To use the built-in version,
+create the linter aspect, typically in `tools/lint/linters.bzl`:
 
 ```starlark
 load("@aspect_rules_lint//lint:shellcheck.bzl", "lint_shellcheck_aspect")
 
 shellcheck = lint_shellcheck_aspect(
-    binary = "@multitool//tools/shellcheck",
+    binary = Label("@aspect_rules_lint//lint:shellcheck_bin",
     config = Label("//:.shellcheckrc"),
 )
 ```


### PR DESCRIPTION
These are equivalent to the aliases for the built-in formatters, and allow use of these linters without having to use confusing relative repo names that appear to be relative to the user's module, but are actually relative to rules_lint.

Ideally the aliases would be `ruff` and `shellcheck`, but those names are taken by bzl_libraries, hence the 'bin' suffix.

Part of https://github.com/aspect-build/rules_lint/issues/551.