### PR TITLE
Update the docs for all linters

### DIFF
--- a/docs/buf.md
+++ b/docs/buf.md
@@ -5,10 +5,10 @@ API for calling declaring a buf lint aspect.
 Typical usage:
 
 ```
-load("@aspect_rules_lint//lint:buf.bzl", "buf_lint_aspect")
+load("@aspect_rules_lint//lint:buf.bzl", "lint_buf_aspect")
 
-buf = buf_lint_aspect(
-    config = "@@//path/to:buf.yaml",
+buf = lint_buf_aspect(
+    config = Label("//path/to:buf.yaml"),
 )
 ```
 

--- a/docs/checkstyle.md
+++ b/docs/checkstyle.md
@@ -13,18 +13,18 @@ Next, declare a binary target for it, typically in `tools/lint/BUILD.bazel`:
 java_binary(
     name = "checkstyle",
     main_class = "com.puppycrawl.tools.checkstyle.Main",
-    runtime_deps = ["@com_puppycrawl_tools_checkstyle"],
+    runtime_deps = ["@com_puppycrawl_tools_checkstyle//jar"],
 )
 ```
 
 Finally, declare an aspect for it, typically in `tools/lint/linters.bzl`:
 
 ```starlark
-load("@aspect_rules_lint//lint:checkstyle.bzl", "checkstyle_aspect")
+load("@aspect_rules_lint//lint:checkstyle.bzl", "lint_checkstyle_aspect")
 
-checkstyle = checkstyle_aspect(
-    binary = "@@//tools/lint:checkstyle",
-    config = ["@@//:checkstyle.xml"],
+checkstyle = lint_checkstyle_aspect(
+    binary = Label("//tools/lint:checkstyle"),
+    config = Label("//:checkstyle.xml"),
 )
 ```
 

--- a/docs/clang-tidy.md
+++ b/docs/clang-tidy.md
@@ -33,8 +33,8 @@ Finally, create the linter aspect, typically in `tools/lint/linters.bzl`:
 load("@aspect_rules_lint//lint:clang_tidy.bzl", "lint_clang_tidy_aspect")
 
 clang_tidy = lint_clang_tidy_aspect(
-    binary = "@@//path/to:clang-tidy",
-    configs = "@@//path/to:.clang-tidy",
+    binary = Label("//path/to:clang-tidy"),
+    configs = [Label("//path/to:.clang-tidy")],
 )
 ```
 

--- a/docs/eslint.md
+++ b/docs/eslint.md
@@ -19,11 +19,11 @@ Finally, create the linter aspect, typically in `tools/lint/linters.bzl`:
 load("@aspect_rules_lint//lint:eslint.bzl", "lint_eslint_aspect")
 
 eslint = lint_eslint_aspect(
-    binary = "@@//tools/lint:eslint",
+    binary = Label("//tools/lint:eslint"),
     # We trust that eslint will locate the correct configuration file for a given source file.
     # See https://eslint.org/docs/latest/use/configure/configuration-files#cascading-and-hierarchy
     configs = [
-        "@@//:eslintrc",
+        Label("//:eslintrc"),
         ...
     ],
 )

--- a/docs/flake8.md
+++ b/docs/flake8.md
@@ -22,8 +22,8 @@ Finally, create the linter aspect, typically in `tools/lint/linters.bzl`:
 load("@aspect_rules_lint//lint:flake8.bzl", "lint_flake8_aspect")
 
 flake8 = lint_flake8_aspect(
-    binary = "@@//tools/lint:flake8",
-    config = "@@//:.flake8",
+    binary = Label("//tools/lint:flake8"),
+    config = Label("//:.flake8"),
 )
 ```
 

--- a/docs/keep_sorted.md
+++ b/docs/keep_sorted.md
@@ -21,7 +21,7 @@ Finally, create the linter aspect, typically in `tools/lint/linters.bzl`:
 load("@aspect_rules_lint//lint:keep_sorted.bzl", "lint_keep_sorted_aspect")
 
 keep_sorted = lint_keep_sorted_aspect(
-    binary = "@com_github_google_keep_sorted//:keep-sorted",
+    binary = Label("@com_github_google_keep_sorted//:keep-sorted"),
 )
 ```
 

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -18,14 +18,14 @@ http_file(
 Then, create the linter aspect, typically in `tools/lint/linters.bzl`:
 
 ```starlark
-load("@aspect_rules_lint//lint:ktlint.bzl", "ktlint_aspect")
+load("@aspect_rules_lint//lint:ktlint.bzl", "lint_ktlint_aspect")
 
-ktlint = ktlint_aspect(
-    binary = "@@com_github_pinterest_ktlint//file",
+ktlint = lint_ktlint_aspect(
+    binary = Label("@com_github_pinterest_ktlint//file"),
     # rules can be enabled/disabled from with this file
-    editorconfig = "@@//:.editorconfig",
+    editorconfig = Label("//:.editorconfig"),
     # a baseline file with exceptions for violations
-    baseline_file = "@@//:.ktlint-baseline.xml",
+    baseline_file = Label("//:.ktlint-baseline.xml"),
 )
 ```
 
@@ -38,14 +38,14 @@ java_binary(
     ...
 )
 
-ktlint = ktlint_aspect(
-    binary = "@@com_github_pinterest_ktlint//file",
+ktlint = lint_ktlint_aspect(
+    binary = Label("@com_github_pinterest_ktlint//file"),
     # rules can be enabled/disabled from with this file
-    editorconfig = "@@//:.editorconfig",
+    editorconfig = Label("//:.editorconfig"),
     # a baseline file with exceptions for violations
-    baseline_file = "@@//:.ktlint-baseline.xml",
+    baseline_file = Label("//:.ktlint-baseline.xml"),
     # Run your custom ktlint ruleset on top of standard rules
-    ruleset_jar = "@@//:my_ktlint_custom_ruleset_deploy.jar",
+    ruleset_jar = Label("//:my_ktlint_custom_ruleset_deploy.jar"),
 )
 ```
 

--- a/docs/lint_test.md
+++ b/docs/lint_test.md
@@ -10,11 +10,11 @@ For example, with `flake8`:
 
 ```starlark
 load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
-load("@aspect_rules_lint//lint:flake8.bzl", "flake8_aspect")
+load("@aspect_rules_lint//lint:flake8.bzl", "lint_flake8_aspect")
 
-flake8 = flake8_aspect(
-    binary = "@@//:flake8",
-    config = "@@//:.flake8",
+flake8 = lint_flake8_aspect(
+    binary = Label("//:flake8"),
+    config = Label("//:.flake8"),
 )
 
 flake8_test = lint_test(aspect = flake8)

--- a/docs/pmd.md
+++ b/docs/pmd.md
@@ -20,11 +20,11 @@ java_binary(
 Finally, declare an aspect for it, typically in `tools/lint/linters.bzl`:
 
 ```starlark
-load("@aspect_rules_lint//lint:pmd.bzl", "pmd_aspect")
+load("@aspect_rules_lint//lint:pmd.bzl", "lint_pmd_aspect")
 
-pmd = pmd_aspect(
-    binary = "@@//tools/lint:pmd",
-    rulesets = ["@@//:pmd.xml"],
+pmd = lint_pmd_aspect(
+    binary = Label("//tools/lint:pmd"),
+    rulesets = [Label("//:pmd.xml")],
 )
 ```
 

--- a/docs/spotbugs.md
+++ b/docs/spotbugs.md
@@ -25,8 +25,8 @@ Finally, declare an aspect for it, typically in `tools/lint/linters.bzl`:
 load("@aspect_rules_lint//lint:spotbugs.bzl", "lint_spotbugs_aspect")
 
 spotbugs = lint_spotbugs_aspect(
-    binary = "@@//tools/lint:spotbugs",
-    exclude_filter = "@@//:spotbugs-exclude.xml",
+    binary = Label("//tools/lint:spotbugs"),
+    exclude_filter = Label("//:spotbugs-exclude.xml"),
 )
 
 ```

--- a/docs/stylelint.md
+++ b/docs/stylelint.md
@@ -31,8 +31,8 @@ Then declare the linter aspect, typically in `tools/lint/linters.bzl`:
 ```starlark
 load("@aspect_rules_lint//lint:stylelint.bzl", "lint_stylelint_aspect")
 stylelint = lint_stylelint_aspect(
-    binary = "@@//tools/lint:stylelint",
-    config = "@@//:stylelintrc",
+    binary = Label("//tools/lint:stylelint"),
+    config = Label("//:stylelintrc"),
 )
 ```
 

--- a/docs/vale.md
+++ b/docs/vale.md
@@ -51,15 +51,15 @@ See the example in rules_lint for a fully-working vale setup.
 ## Usage
 
 ```starlark
-load("@aspect_rules_lint//lint:vale.bzl", "vale_aspect")
+load("@aspect_rules_lint//lint:vale.bzl", "lint_vale_aspect")
 
-vale = vale_aspect(
-    binary = "@@//tools/lint:vale",
+vale = lint_vale_aspect(
+    binary = Label("//tools/lint:vale"),
     # A copy_to_bin rule that places the .vale.ini file into bazel-bin
-    config = "@@//:.vale_ini",
+    config = Label("//:.vale_ini"),
     # Optional.
     # A copy_to_directory rule that "installs" custom styles together into a single folder
-    styles = "@@//tools/lint:vale_styles",
+    styles = Label("//tools/lint:vale_styles"),
 )
 ```
 

--- a/example/tools/lint/linters.bzl
+++ b/example/tools/lint/linters.bzl
@@ -16,45 +16,45 @@ load("@aspect_rules_lint//lint:stylelint.bzl", "lint_stylelint_aspect")
 load("@aspect_rules_lint//lint:vale.bzl", "lint_vale_aspect")
 
 buf = lint_buf_aspect(
-    config = Label("@//:buf.yaml"),
+    config = Label("//:buf.yaml"),
 )
 
 eslint = lint_eslint_aspect(
-    binary = Label("@//tools/lint:eslint"),
+    binary = Label("//tools/lint:eslint"),
     # ESLint will resolve the configuration file by looking in the working directory first.
     # See https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file-resolution
     # We must also include any other config files we expect eslint to be able to locate, e.g. tsconfigs
     configs = [
-        Label("@//:eslintrc"),
-        Label("@//src:tsconfig"),
+        Label("//:eslintrc"),
+        Label("//src:tsconfig"),
     ],
 )
 
 eslint_test = lint_test(aspect = eslint)
 
 stylelint = lint_stylelint_aspect(
-    binary = Label("@//tools/lint:stylelint"),
-    config = Label("@//:stylelintrc"),
+    binary = Label("//tools/lint:stylelint"),
+    config = Label("//:stylelintrc"),
 )
 
 flake8 = lint_flake8_aspect(
-    binary = Label("@//tools/lint:flake8"),
-    config = Label("@//:.flake8"),
+    binary = Label("//tools/lint:flake8"),
+    config = Label("//:.flake8"),
 )
 
 flake8_test = lint_test(aspect = flake8)
 
 pmd = lint_pmd_aspect(
-    binary = Label("@//tools/lint:pmd"),
-    rulesets = [Label("@//:pmd.xml")],
+    binary = Label("//tools/lint:pmd"),
+    rulesets = [Label("//:pmd.xml")],
 )
 
 pmd_test = lint_test(aspect = pmd)
 
 checkstyle = lint_checkstyle_aspect(
-    binary = Label("@//tools/lint:checkstyle"),
-    config = Label("@//:checkstyle.xml"),
-    data = [Label("@//:checkstyle-suppressions.xml")],
+    binary = Label("//tools/lint:checkstyle"),
+    config = Label("//:checkstyle.xml"),
+    data = [Label("//:checkstyle-suppressions.xml")],
 )
 
 checkstyle_test = lint_test(aspect = checkstyle)
@@ -77,24 +77,24 @@ shellcheck = lint_shellcheck_aspect(
 shellcheck_test = lint_test(aspect = shellcheck)
 
 vale = lint_vale_aspect(
-    binary = Label("@//tools/lint:vale"),
-    config = Label("@//:.vale.ini"),
-    styles = Label("@//tools/lint:vale_styles"),
+    binary = Label("//tools/lint:vale"),
+    config = Label("//:.vale.ini"),
+    styles = Label("//tools/lint:vale_styles"),
 )
 
 ktlint = lint_ktlint_aspect(
     binary = Label("@com_github_pinterest_ktlint//file"),
-    editorconfig = Label("@//:.editorconfig"),
-    baseline_file = Label("@//:ktlint-baseline.xml"),
+    editorconfig = Label("//:.editorconfig"),
+    baseline_file = Label("//:ktlint-baseline.xml"),
 )
 
 ktlint_test = lint_test(aspect = ktlint)
 
 clang_tidy = lint_clang_tidy_aspect(
-    binary = "@@//tools/lint:clang_tidy",
+    binary = Label("//tools/lint:clang_tidy"),
     configs = [
-        "@@//:.clang-tidy",
-        "@@//src/cpp/lib:get/.clang-tidy",
+        Label("//:.clang-tidy"),
+        Label("//src/cpp/lib:get/.clang-tidy"),
     ],
     lint_target_headers = True,
     angle_includes_are_system = False,
@@ -114,8 +114,8 @@ clang_tidy_global_config = lint_clang_tidy_aspect(
 )
 
 spotbugs = lint_spotbugs_aspect(
-    binary = Label("@//tools/lint:spotbugs"),
-    exclude_filter = Label("@//:spotbugs-exclude.xml"),
+    binary = Label("//tools/lint:spotbugs"),
+    exclude_filter = Label("//:spotbugs-exclude.xml"),
 )
 
 spotbugs_test = lint_test(aspect = spotbugs)

--- a/lint/README.md
+++ b/lint/README.md
@@ -55,7 +55,7 @@ Add these three things:
    The simple lint.sh also relies on the report output filenames containing `AspectRulesLint`, which comes from
    the convention that `AspectRulesLint` is the prefix for all rules_lint linter action mnemonics.
 
-3. A `my_linter_aspect` factory function. This is a higher-order function that returns an aspect.
+3. A `lint_my_linter_aspect` factory function. This is a higher-order function that returns an aspect.
    This pattern allows us to capture arguments like labels and toolchains which aren't legal
    in public aspect attributes.
 

--- a/lint/buf.bzl
+++ b/lint/buf.bzl
@@ -3,10 +3,10 @@
 Typical usage:
 
 ```
-load("@aspect_rules_lint//lint:buf.bzl", "buf_lint_aspect")
+load("@aspect_rules_lint//lint:buf.bzl", "lint_buf_aspect")
 
-buf = buf_lint_aspect(
-    config = "@@//path/to:buf.yaml",
+buf = lint_buf_aspect(
+    config = Label("//path/to:buf.yaml"),
 )
 ```
 

--- a/lint/checkstyle.bzl
+++ b/lint/checkstyle.bzl
@@ -11,18 +11,18 @@ Next, declare a binary target for it, typically in `tools/lint/BUILD.bazel`:
 java_binary(
     name = "checkstyle",
     main_class = "com.puppycrawl.tools.checkstyle.Main",
-    runtime_deps = ["@com_puppycrawl_tools_checkstyle"],
+    runtime_deps = ["@com_puppycrawl_tools_checkstyle//jar"],
 )
 ```
 
 Finally, declare an aspect for it, typically in `tools/lint/linters.bzl`:
 
 ```starlark
-load("@aspect_rules_lint//lint:checkstyle.bzl", "checkstyle_aspect")
+load("@aspect_rules_lint//lint:checkstyle.bzl", "lint_checkstyle_aspect")
 
-checkstyle = checkstyle_aspect(
-    binary = "@@//tools/lint:checkstyle",
-    config = ["@@//:checkstyle.xml"],
+checkstyle = lint_checkstyle_aspect(
+    binary = Label("//tools/lint:checkstyle"),
+    config = Label("//:checkstyle.xml"),
 )
 ```
 """

--- a/lint/clang_tidy.bzl
+++ b/lint/clang_tidy.bzl
@@ -31,8 +31,8 @@ Finally, create the linter aspect, typically in `tools/lint/linters.bzl`:
 load("@aspect_rules_lint//lint:clang_tidy.bzl", "lint_clang_tidy_aspect")
 
 clang_tidy = lint_clang_tidy_aspect(
-    binary = "@@//path/to:clang-tidy",
-    configs = "@@//path/to:.clang-tidy",
+    binary = Label("//path/to:clang-tidy"),
+    configs = [Label("//path/to:.clang-tidy")],
 )
 ```
 """

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -17,11 +17,11 @@ Finally, create the linter aspect, typically in `tools/lint/linters.bzl`:
 load("@aspect_rules_lint//lint:eslint.bzl", "lint_eslint_aspect")
 
 eslint = lint_eslint_aspect(
-    binary = "@@//tools/lint:eslint",
+    binary = Label("//tools/lint:eslint"),
     # We trust that eslint will locate the correct configuration file for a given source file.
     # See https://eslint.org/docs/latest/use/configure/configuration-files#cascading-and-hierarchy
     configs = [
-        "@@//:eslintrc",
+        Label("//:eslintrc"),
         ...
     ],
 )

--- a/lint/flake8.bzl
+++ b/lint/flake8.bzl
@@ -20,8 +20,8 @@ Finally, create the linter aspect, typically in `tools/lint/linters.bzl`:
 load("@aspect_rules_lint//lint:flake8.bzl", "lint_flake8_aspect")
 
 flake8 = lint_flake8_aspect(
-    binary = "@@//tools/lint:flake8",
-    config = "@@//:.flake8",
+    binary = Label("//tools/lint:flake8"),
+    config = Label("//:.flake8"),
 )
 ```
 """

--- a/lint/keep_sorted.bzl
+++ b/lint/keep_sorted.bzl
@@ -19,7 +19,7 @@ Finally, create the linter aspect, typically in `tools/lint/linters.bzl`:
 load("@aspect_rules_lint//lint:keep_sorted.bzl", "lint_keep_sorted_aspect")
 
 keep_sorted = lint_keep_sorted_aspect(
-    binary = "@com_github_google_keep_sorted//:keep-sorted",
+    binary = Label("@com_github_google_keep_sorted//:keep-sorted"),
 )
 ```
 

--- a/lint/ktlint.bzl
+++ b/lint/ktlint.bzl
@@ -16,14 +16,14 @@ http_file(
 Then, create the linter aspect, typically in `tools/lint/linters.bzl`:
 
 ```starlark
-load("@aspect_rules_lint//lint:ktlint.bzl", "ktlint_aspect")
+load("@aspect_rules_lint//lint:ktlint.bzl", "lint_ktlint_aspect")
 
-ktlint = ktlint_aspect(
-    binary = "@@com_github_pinterest_ktlint//file",
+ktlint = lint_ktlint_aspect(
+    binary = Label("@com_github_pinterest_ktlint//file"),
     # rules can be enabled/disabled from with this file
-    editorconfig = "@@//:.editorconfig",
+    editorconfig = Label("//:.editorconfig"),
     # a baseline file with exceptions for violations
-    baseline_file = "@@//:.ktlint-baseline.xml",
+    baseline_file = Label("//:.ktlint-baseline.xml"),
 )
 ```
 
@@ -36,14 +36,14 @@ java_binary(
     ...
 )
 
-ktlint = ktlint_aspect(
-    binary = "@@com_github_pinterest_ktlint//file",
+ktlint = lint_ktlint_aspect(
+    binary = Label("@com_github_pinterest_ktlint//file"),
     # rules can be enabled/disabled from with this file
-    editorconfig = "@@//:.editorconfig",
+    editorconfig = Label("//:.editorconfig"),
     # a baseline file with exceptions for violations
-    baseline_file = "@@//:.ktlint-baseline.xml",
+    baseline_file = Label("//:.ktlint-baseline.xml"),
     # Run your custom ktlint ruleset on top of standard rules
-    ruleset_jar = "@@//:my_ktlint_custom_ruleset_deploy.jar",
+    ruleset_jar = Label("//:my_ktlint_custom_ruleset_deploy.jar"),
 )
 ```
 

--- a/lint/lint_test.bzl
+++ b/lint/lint_test.bzl
@@ -8,11 +8,11 @@ For example, with `flake8`:
 
 ```starlark
 load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
-load("@aspect_rules_lint//lint:flake8.bzl", "flake8_aspect")
+load("@aspect_rules_lint//lint:flake8.bzl", "lint_flake8_aspect")
 
-flake8 = flake8_aspect(
-    binary = "@@//:flake8",
-    config = "@@//:.flake8",
+flake8 = lint_flake8_aspect(
+    binary = Label("//:flake8"),
+    config = Label("//:.flake8"),
 )
 
 flake8_test = lint_test(aspect = flake8)

--- a/lint/pmd.bzl
+++ b/lint/pmd.bzl
@@ -18,11 +18,11 @@ java_binary(
 Finally, declare an aspect for it, typically in `tools/lint/linters.bzl`:
 
 ```starlark
-load("@aspect_rules_lint//lint:pmd.bzl", "pmd_aspect")
+load("@aspect_rules_lint//lint:pmd.bzl", "lint_pmd_aspect")
 
-pmd = pmd_aspect(
-    binary = "@@//tools/lint:pmd",
-    rulesets = ["@@//:pmd.xml"],
+pmd = lint_pmd_aspect(
+    binary = Label("//tools/lint:pmd"),
+    rulesets = [Label("//:pmd.xml")],
 )
 ```
 """

--- a/lint/spotbugs.bzl
+++ b/lint/spotbugs.bzl
@@ -23,8 +23,8 @@ Finally, declare an aspect for it, typically in `tools/lint/linters.bzl`:
 load("@aspect_rules_lint//lint:spotbugs.bzl", "lint_spotbugs_aspect")
 
 spotbugs = lint_spotbugs_aspect(
-    binary = "@@//tools/lint:spotbugs",
-    exclude_filter = "@@//:spotbugs-exclude.xml",
+    binary = Label("//tools/lint:spotbugs"),
+    exclude_filter = Label("//:spotbugs-exclude.xml"),
 )
 
 ```

--- a/lint/stylelint.bzl
+++ b/lint/stylelint.bzl
@@ -29,8 +29,8 @@ Then declare the linter aspect, typically in `tools/lint/linters.bzl`:
 ```starlark
 load("@aspect_rules_lint//lint:stylelint.bzl", "lint_stylelint_aspect")
 stylelint = lint_stylelint_aspect(
-    binary = "@@//tools/lint:stylelint",
-    config = "@@//:stylelintrc",
+    binary = Label("//tools/lint:stylelint"),
+    config = Label("//:stylelintrc"),
 )
 ```
 

--- a/lint/vale.bzl
+++ b/lint/vale.bzl
@@ -49,15 +49,15 @@ See the example in rules_lint for a fully-working vale setup.
 ## Usage
 
 ```starlark
-load("@aspect_rules_lint//lint:vale.bzl", "vale_aspect")
+load("@aspect_rules_lint//lint:vale.bzl", "lint_vale_aspect")
 
-vale = vale_aspect(
-    binary = "@@//tools/lint:vale",
+vale = lint_vale_aspect(
+    binary = Label("//tools/lint:vale"),
     # A copy_to_bin rule that places the .vale.ini file into bazel-bin
-    config = "@@//:.vale_ini",
+    config = Label("//:.vale_ini"),
     # Optional.
     # A copy_to_directory rule that "installs" custom styles together into a single folder
-    styles = "@@//tools/lint:vale_styles",
+    styles = Label("//tools/lint:vale_styles"),
 )
 ```
 """


### PR DESCRIPTION
Docs now match the actual usage and the examples, and use `Label` instead of `@@`. This is done for all linters except ruff and shellcheck, which are already being done in https://github.com/aspect-build/rules_lint/pull/563.

Part of https://github.com/aspect-build/rules_lint/issues/551.