### PR TITLE
feat: Format toml with taplo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Linters which are not language-specific:
 | Shell                  | [shfmt]                   | [shellcheck]                     |
 | Starlark               | [Buildifier]              |                                  |
 | Swift                  | [SwiftFormat] (1)         |                                  |
+| TOML                   | [taplo]                   |                                  |
 | TSX                    | [Prettier]                | [ESLint]                         |
 | TypeScript             | [Prettier]                | [ESLint]                         |
 | YAML                   | [yamlfmt]                 |                                  |
@@ -83,6 +84,7 @@ Linters which are not language-specific:
 [ruff]: https://docs.astral.sh/ruff/
 [shellcheck]: https://www.shellcheck.net/
 [shfmt]: https://github.com/mvdan/sh
+[taplo] : https://taplo.tamasfe.dev/
 [clang-format]: https://clang.llvm.org/docs/ClangFormat.html
 [clang-tidy]: https://clang.llvm.org/extra/clang-tidy/
 [vale]: https://vale.sh/

--- a/docs/format.md
+++ b/docs/format.md
@@ -23,8 +23,8 @@ See the example/tools/format/BUILD file in this repo for full examples of declar
 load("@aspect_rules_lint//format:defs.bzl", "languages")
 
 languages(<a href="#languages-name">name</a>, <a href="#languages-c">c</a>, <a href="#languages-cc">cc</a>, <a href="#languages-css">css</a>, <a href="#languages-cuda">cuda</a>, <a href="#languages-gherkin">gherkin</a>, <a href="#languages-go">go</a>, <a href="#languages-graphql">graphql</a>, <a href="#languages-html">html</a>, <a href="#languages-java">java</a>, <a href="#languages-javascript">javascript</a>, <a href="#languages-jsonnet">jsonnet</a>, <a href="#languages-kotlin">kotlin</a>,
-          <a href="#languages-markdown">markdown</a>, <a href="#languages-protocol_buffer">protocol_buffer</a>, <a href="#languages-python">python</a>, <a href="#languages-rust">rust</a>, <a href="#languages-scala">scala</a>, <a href="#languages-shell">shell</a>, <a href="#languages-sql">sql</a>, <a href="#languages-starlark">starlark</a>, <a href="#languages-swift">swift</a>, <a href="#languages-terraform">terraform</a>, <a href="#languages-xml">xml</a>,
-          <a href="#languages-yaml">yaml</a>)
+          <a href="#languages-markdown">markdown</a>, <a href="#languages-protocol_buffer">protocol_buffer</a>, <a href="#languages-python">python</a>, <a href="#languages-rust">rust</a>, <a href="#languages-scala">scala</a>, <a href="#languages-shell">shell</a>, <a href="#languages-sql">sql</a>, <a href="#languages-starlark">starlark</a>, <a href="#languages-swift">swift</a>, <a href="#languages-terraform">terraform</a>,
+          <a href="#languages-toml">toml</a>, <a href="#languages-xml">xml</a>, <a href="#languages-yaml">yaml</a>)
 </pre>
 
 Language attributes that may be passed to [format_multirun](#format_multirun) or [format_test](#format_test).
@@ -67,6 +67,7 @@ Some languages have dialects:
 | <a id="languages-starlark"></a>starlark |  a `buildifier` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="languages-swift"></a>swift |  a `swiftformat` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="languages-terraform"></a>terraform |  a `terraform-fmt` binary, or any other tool that has a matching command-line interface. Use `@aspect_rules_lint//format:terraform` to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="languages-toml"></a>toml |  a `taplo` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="languages-xml"></a>xml |  a `prettier` binary, or any other tool that has a matching command-line interface.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="languages-yaml"></a>yaml |  a `yamlfmt` binary, or any other tool that has a matching command-line interface. Use `@aspect_rules_lint//format:yamlfmt` to choose the built-in tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 

--- a/example/MODULE.bazel
+++ b/example/MODULE.bazel
@@ -1,5 +1,7 @@
 "Bazel dependencies"
 
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
 bazel_dep(name = "aspect_rules_lint", version = "0.0.0")
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
 bazel_dep(name = "aspect_rules_js", version = "2.0.0")
@@ -25,6 +27,14 @@ bazel_dep(name = "gazelle", version = "0.41.0")
 local_path_override(
     module_name = "aspect_rules_lint",
     path = "..",
+)
+
+http_file(
+    name = "taplo",
+    sha256 = "8fe196b894ccf9072f98d4e1013a180306e17d244830b03986ee5e8eabeb6156",
+    urls = [
+        "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-x86_64.gz",
+    ],
 )
 
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext")

--- a/example/WORKSPACE.bazel
+++ b/example/WORKSPACE.bazel
@@ -4,13 +4,21 @@ local_repository(
     path = "..",
 )
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 http_archive(
     name = "rules_python",
     sha256 = "9d04041ac92a0985e344235f5d946f71ac543f1b1565f2cdbc9a2aaee8adf55b",
     strip_prefix = "rules_python-0.26.0",
     url = "https://github.com/bazelbuild/rules_python/releases/download/0.26.0/rules_python-0.26.0.tar.gz",
+)
+
+http_file(
+    name = "taplo",
+    sha256 = "8fe196b894ccf9072f98d4e1013a180306e17d244830b03986ee5e8eabeb6156",
+    urls = [
+        "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-x86_64.gz",
+    ],
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")

--- a/example/src/BUILD.bazel
+++ b/example/src/BUILD.bazel
@@ -25,6 +25,12 @@ filegroup(
     tags = ["markdown"],
 )
 
+filegroup(
+    name = "toml",
+    srcs = ["hello.toml"],
+    tags = ["toml"],
+)
+
 ts_project(
     name = "ts_dep",
     srcs = ["file-dep.ts"],

--- a/example/src/hello.toml
+++ b/example/src/hello.toml
@@ -1,0 +1,6 @@
+[pif]
+key="value"
+[pif.paf]
+list=["a", "b",
+"c"]
+

--- a/example/tools/format/BUILD.bazel
+++ b/example/tools/format/BUILD.bazel
@@ -4,6 +4,7 @@ This is in its own package because it has so many loading-time symbols,
 we don't want to trigger eager fetches of these for builds that don't want to run format.
 """
 
+load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 load("@aspect_rules_lint//format:defs.bzl", "format_multirun", "format_test")
 load("@npm//:prettier/package_json.bzl", prettier = "bin")
 load("@rules_java//java:defs.bzl", "java_binary")
@@ -63,6 +64,26 @@ java_binary(
     runtime_deps = ["@maven//:org_scalameta_scalafmt_cli_2_13"],
 )
 
+genrule(
+    name = "taplo",
+    srcs = ["@taplo//file"],
+    outs = ["taplo_bin"],
+    cmd = "gunzip -c $< > $@",
+    executable = True,
+)
+
+expand_template(
+    name = "taplo_wrapper",
+    out = "taplo_wrapper.sh",
+    data = [":taplo_bin"],
+    is_executable = True,
+    substitutions = {"{taplo_bin}": "$(execpath :taplo_bin)"},
+    template = [
+        "#!/bin/sh",
+        'exec env RUST_LOG=warn "./{taplo_bin}" "$@"',
+    ],
+)
+
 format_multirun(
     name = "format",
     c = "@llvm_toolchain_llvm//:bin/clang-format",
@@ -93,6 +114,7 @@ format_multirun(
     starlark = "@buildifier_prebuilt//:buildifier",
     swift = ":swiftformat",
     terraform = "@aspect_rules_lint//format:terraform",
+    toml = ":taplo_wrapper",
     visibility = ["//:__subpackages__"],
     xml = ":prettier",
     yaml = "@aspect_rules_lint//format:yamlfmt",

--- a/format/private/filter.jq
+++ b/format/private/filter.jq
@@ -23,6 +23,7 @@ with_entries(select(.key | IN(
     "SQL",
     "Starlark",
     "Swift",
+    "TOML",
     "TSX",
     "TypeScript"
 )))

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -152,6 +152,7 @@ function ls-files {
       # TODO: we should probably use https://terragrunt.gruntwork.io/docs/reference/cli-options/#hclfmt instead
       # which does support the entire HCL language FWICT
       'Terraform') patterns=('*.tf' '*.tfvars') ;;
+      'TOML') patterns=('*.toml') ;;
 
       *)
         echo >&2 "Internal error: unknown language $language"

--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -13,6 +13,7 @@ TOOLS = {
     "Starlark": "buildifier",
     "Jsonnet": "jsonnetfmt",
     "Terraform": "terraform-fmt",
+    "TOML": "taplo",
     "Kotlin": "ktfmt",
     "Java": "java-format",
     "Scala": "scalafmt",
@@ -51,6 +52,7 @@ CHECK_FLAGS = {
     "ktfmt": "--set-exit-if-changed --dry-run",
     "gofmt": "-l",
     "buf": "format -d --exit-code --disable-symlinks",
+    "taplo": "format --check --diff",
     "terraform-fmt": "fmt -check -diff",
     "jsonnetfmt": "--test",
     "scalafmt": "--test --respect-project-filters",
@@ -74,6 +76,7 @@ FIX_FLAGS = {
     "ktfmt": "",
     "gofmt": "-w",
     "buf": "format --write --disable-symlinks",
+    "taplo": "format",
     "terraform-fmt": "fmt",
     "jsonnetfmt": "--in-place",
     # Force exclusions in the configuration file to be honored even when file paths are supplied

--- a/format/test/BUILD.bazel
+++ b/format/test/BUILD.bazel
@@ -58,6 +58,7 @@ format_multirun(
     swift = ":mock_swiftformat.sh",
     # TODO: this attribute should be renamed to hcl
     terraform = ":mock_terraform-fmt.sh",
+    toml = ":mock_taplo.sh",
     xml = ":mock_prettier.sh",
     yaml = ":mock_yamlfmt.sh",
 )

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -84,6 +84,13 @@ bats_load_library "bats-assert"
     assert_output --partial "+ ruff format --force-exclude example/src/subdir/unused_import.py"
 }
 
+@test "should run taplo on TOML" {
+    run bazel run //format/test:format_TOML_with_taplo
+    assert_success
+
+    assert_output --partial '+ taplo format _typos.toml example/.ruff.toml example/src/hello.toml example/src/subdir/ruff.toml'
+}
+
 @test "should run terraform fmt on HCL" {
     run bazel run //format/test:format_Terraform_with_terraform-fmt
     assert_success


### PR DESCRIPTION
This patch adds formatting for [TOML](https://toml.io/en/) files. TOML is often used to configure various tooling and languages
(for example, `.ruff.toml`, `pyproject.toml`, `Cargo.toml`).

I chose to use [taplo](https://taplo.tamasfe.dev/) directly as the formatter, although my first attempt used [prettier-plugin-toml](https://www.npmjs.com/package/prettier-plugin-toml). My company isn't very js-focused so that obtaining `taplo` directly is much simpler than going over `prettier`.

`taplo` has some linting features, not implemented here, as we don't use them where I work and I don't know them.

---

### Changes are visible to end-users: yes, new formatter! 😊

- Searched for relevant documentation and updated as needed: yes (`README.md`)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- New test cases added
- I also readily patched our own repo with this change and let `bazel run format` run. It did reformat some of our `toml` files.
