### PR TITLE
chore: wire up tools_telemetry

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,6 +12,7 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
 # Minimum version needs 'chore: bump bazel-lib to 2.0 by @alexeagle in #1311'
 # to allow users on bazel-lib 2.0
 bazel_dep(name = "aspect_rules_js", version = "1.40.0")
+bazel_dep(name = "aspect_tools_telemetry", version = "0.2.3")
 bazel_dep(name = "bazel_features", version = "1.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "platforms", version = "0.0.7")
@@ -25,6 +26,9 @@ bazel_dep(name = "rules_proto", version = "6.0.0")
 
 # Needed in the root because we dereference the toolchain in our aspect impl
 bazel_dep(name = "rules_buf", version = "0.1.1")
+
+tel = use_extension("@aspect_tools_telemetry//:extension.bzl", "telemetry")
+use_repo(tel, "aspect_tools_telemetry_report")
 
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
 multitool.hub(lockfile = "//format:multitool.lock.json")

--- a/README.md
+++ b/README.md
@@ -189,3 +189,7 @@ Rulesets for type-checkers:
 
 [aspect workflows]: https://docs.aspect.build/workflows
 [aspect cli]: https://docs.aspect.build/cli
+
+# Telemetry & privacy policy
+
+This ruleset collects limited usage data via [`tools_telemetry`](https://github.com/aspect-build/tools_telemetry), which is reported to Aspect Build Inc and governed by our [privacy policy](https://www.aspect.build/privacy-policy).

--- a/lint/extensions.bzl
+++ b/lint/extensions.bzl
@@ -2,6 +2,7 @@
 
 # buildifier: disable=bzl-visibility
 load("@aspect_bazel_lib//lib/private:extension_utils.bzl", "extension_utils")
+load("@aspect_tools_telemetry_report//:defs.bzl", "TELEMETRY")  # buildifier: disable=load
 load("@bazel_features//:features.bzl", "bazel_features")
 load(
     "//tools/toolchains:register.bzl",


### PR DESCRIPTION
See https://github.com/aspect-build/rules_js/pull/2282, https://github.com/aspect-build/rules_py/pull/612

### Changes are visible to end-users: yes

- Suggested release notes appear below: yes/no

`aspect_tools_telemetry` is now used for coarse grained usage tracking.

### Test plan

- Manual testing (`build ...`) produced a telemetry report.