### PR TITLE
build: load py_library in example/test/BUILD.bazel

### DIFF
--- a/example/test/BUILD.bazel
+++ b/example/test/BUILD.bazel
@@ -3,6 +3,7 @@
 load("@aspect_rules_lint//format:defs.bzl", "format_test")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_shell//shell:sh_library.bzl", "sh_library")
 load("//tools/lint:linters.bzl", "checkstyle_test", "eslint_test", "flake8_test", "pmd_test", "ruff_test", "shellcheck_test")
 


### PR DESCRIPTION
Came across this by looking at https://buildkite.com/bazel/bcr-bazel-compatibility-test/builds/492/steps/canvas?sid=019899a2-3956-42b0-91db-b1576ef8e0a2 so we should use the load statement and not rely on native rules