### PR TITLE
build: load py_library in example/src/subdir/BUILD.bazel

### DIFF
--- a/example/src/subdir/BUILD.bazel
+++ b/example/src/subdir/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@rules_python//python:defs.bzl", "py_library")
 
 exports_files(["ruff.toml"])
 


### PR DESCRIPTION
Came across this by looking at https://buildkite.com/bazel/bcr-bazel-compatibility-test/builds/492/steps/canvas?sid=019899a2-3956-42b0-91db-b1576ef8e0a2 so we should use the load statement and not rely on native rules

Relates to https://github.com/aspect-build/rules_lint/pull/593