### PR TITLE
build: load py_library in example/src/BUILD.bazel

### DIFF
--- a/example/src/BUILD.bazel
+++ b/example/src/BUILD.bazel
@@ -4,6 +4,7 @@ load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_shell//shell:sh_library.bzl", "sh_library")
 load("//tools/lint:linters.bzl", "eslint_test")
 


### PR DESCRIPTION
Came across this by looking at https://buildkite.com/bazel/bcr-bazel-compatibility-test/builds/492/steps/canvas?sid=019899a2-3956-42b0-91db-b1576ef8e0a2 so we should use the load statement and not rely on native rules

Relates to https://github.com/aspect-build/rules_lint/pull/593