### PR TITLE
Improve support of hemertic toolchains with the clang tidy linter

### DIFF
--- a/docs/clang-tidy.md
+++ b/docs/clang-tidy.md
@@ -38,6 +38,17 @@ clang_tidy = lint_clang_tidy_aspect(
 )
 ```
 
+or, to register the gcc install dir from an hermetic toolchain,
+
+```
+clang_tidy = lint_clang_tidy_aspect(
+    binary = Label("//path/to:clang-tidy"),
+    configs = [Label("//path/to:.clang-tidy")],
+    gcc_install_dir = [Label("@hermetic_cc_repo//:gcc_install_dir")],
+    deps = [Label("@hermetic_cc_repo//:content_of_gcc_install_dir")],
+)
+```
+
 <a id="clang_tidy_action"></a>
 
 ## clang_tidy_action

--- a/lint/clang_tidy.bzl
+++ b/lint/clang_tidy.bzl
@@ -51,6 +51,8 @@ def _gather_inputs(ctx, compilation_context, srcs):
     inputs = srcs + ctx.files._configs
     if (any(ctx.files._global_config)):
         inputs.append(ctx.files._global_config[0])
+    for dep in ctx.files._deps:
+        inputs.append(dep)
     return depset(inputs, transitive = [compilation_context.headers])
 
 def _toolchain_env(ctx, user_flags, action_name = ACTION_NAMES.cpp_compile):
@@ -423,6 +425,7 @@ def lint_clang_tidy_aspect(
         configs = [],
         global_config = [],
         gcc_install_dir = [],
+        deps = [],
         header_filter = "",
         lint_target_headers = False,
         angle_includes_are_system = True,
@@ -444,6 +447,7 @@ def lint_clang_tidy_aspect(
             files which may be used for formatting fixes.
         global_config: label of a single global .clang-tidy file to pass to clang-tidy on the command line. This
             will cause clang-tidy to ignore any other config files in the source directories.
+        deps: labels of additional dependencies used during the clang-tidy run.
         gcc_install_dir: optional, label of a `Directory` from the skylib library pointing to the gcc install
             directory.  The argument is passed to the underlying clang as `--gcc-install-dir`.
         header_filter: optional, set to a posix regex to supply to clang-tidy with the -header-filter option
@@ -473,6 +477,9 @@ def lint_clang_tidy_aspect(
             "_global_config": attr.label_list(
                 default = global_config,
                 allow_files = True,
+            ),
+            "_deps": attr.label_list(
+                default = deps,
             ),
             "_gcc_install_dir": attr.label_list(
                 default = gcc_install_dir,

--- a/lint/clang_tidy.bzl
+++ b/lint/clang_tidy.bzl
@@ -37,6 +37,7 @@ clang_tidy = lint_clang_tidy_aspect(
 ```
 """
 
+load("@bazel_skylib//rules/directory:providers.bzl", "DirectoryInfo")
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OPTIONAL_SARIF_PARSER_TOOLCHAIN", "OUTFILE_FORMAT", "noop_lint_action", "output_files", "parse_to_sarif_action", "patch_and_output_files")
@@ -262,6 +263,14 @@ def _get_args(ctx, compilation_context, srcs):
 def _get_compiler_args(ctx, compilation_context, srcs):
     # add args specified by the toolchain, on the command line and rule copts
     args = []
+
+    if ctx.attr._gcc_install_dir:
+        gcc_install_dir = ctx.attr._gcc_install_dir[0].files.to_list()
+        if len(gcc_install_dir) > 1:
+            fail("gcc_install_dir must contain at most one directory")
+        for dir in gcc_install_dir:
+            args.append("--gcc-install-dir=" + dir.path)
+
     rule_flags = ctx.rule.attr.copts if hasattr(ctx.rule.attr, "copts") else []
     sources_are_cxx = _is_cxx(srcs[0])
     if (sources_are_cxx):
@@ -409,7 +418,15 @@ def _clang_tidy_aspect_impl(target, ctx):
     parse_to_sarif_action(ctx, _MNEMONIC, raw_machine_report, outputs.machine.out)
     return [info]
 
-def lint_clang_tidy_aspect(binary, configs = [], global_config = [], header_filter = "", lint_target_headers = False, angle_includes_are_system = True, verbose = False):
+def lint_clang_tidy_aspect(
+        binary,
+        configs = [],
+        global_config = [],
+        gcc_install_dir = [],
+        header_filter = "",
+        lint_target_headers = False,
+        angle_includes_are_system = True,
+        verbose = False):
     """A factory function to create a linter aspect.
 
     Args:
@@ -427,6 +444,8 @@ def lint_clang_tidy_aspect(binary, configs = [], global_config = [], header_filt
             files which may be used for formatting fixes.
         global_config: label of a single global .clang-tidy file to pass to clang-tidy on the command line. This
             will cause clang-tidy to ignore any other config files in the source directories.
+        gcc_install_dir: optional, label of a `Directory` from the skylib library pointing to the gcc install
+            directory.  The argument is passed to the underlying clang as `--gcc-install-dir`.
         header_filter: optional, set to a posix regex to supply to clang-tidy with the -header-filter option
         lint_target_headers: optional, set to True to pass a pattern that includes all headers with the target's
             directory prefix. This crude control may include headers from the linted target in the results. If
@@ -454,6 +473,10 @@ def lint_clang_tidy_aspect(binary, configs = [], global_config = [], header_filt
             "_global_config": attr.label_list(
                 default = global_config,
                 allow_files = True,
+            ),
+            "_gcc_install_dir": attr.label_list(
+                default = gcc_install_dir,
+                providers = [DirectoryInfo],
             ),
             "_lint_target_headers": attr.bool(
                 default = lint_target_headers,


### PR DESCRIPTION
The changes are more detailed in the commit messages.

In short, this adds two optional arguments to the linter:
 * `gcc-install-dir` arg to prevent `clang-tidy` to use a gcc intallation from the host.
 * `deps` lets users actually provide the headers and files from an hermetic toolchain registered elsewhere using the `rules_cc` API.

both options were lifted from https://github.com/erenon/bazel_clang_tidy

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

Would require registering an hermetic gcc toolchain, which is not trivial.

But manually:
* register hermetic gcc toolchain (based on `x86-64--glibc--stable-2024.05-1.tar.xz` from https://bootlin.com/ for example, see also https://github.com/bazelbuild/rules_cc/tree/main/examples/rule_based_toolchain/toolchains/gcc)
* set `gcc_install_dir` and `deps` arguments to the label defined as follows (using the bootlin toolchain)
```
directory(
    name = "x86_64-buildroot-linux-gnu",
    srcs = ["lib/gcc/x86_64-buildroot-linux-gnu/13.3.0"],
)
```
* make sure that `clang-tidy` now uses the hermetic headers.