### PR TITLE
chore(deps): Bump tools_telemetry

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
 # Minimum version needs 'chore: bump bazel-lib to 2.0 by @alexeagle in #1311'
 # to allow users on bazel-lib 2.0
 bazel_dep(name = "aspect_rules_js", version = "1.40.0")
-bazel_dep(name = "aspect_tools_telemetry", version = "0.2.3")
+bazel_dep(name = "aspect_tools_telemetry", version = "0.2.5")
 bazel_dep(name = "bazel_features", version = "1.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "platforms", version = "0.0.7")


### PR DESCRIPTION
Bump `tools_telemetry` to pick up a more robust and less sensitive project identification strategy.

### Changes are visible to end-users: no

### Test plan

N/A.