### PR TITLE
fix: include ts_project(tsconfig) in eslint inputs

### DIFF
--- a/example/tools/lint/linters.bzl
+++ b/example/tools/lint/linters.bzl
@@ -26,7 +26,6 @@ eslint = lint_eslint_aspect(
     # We must also include any other config files we expect eslint to be able to locate, e.g. tsconfigs
     configs = [
         Label("//:eslintrc"),
-        Label("//src:tsconfig"),
     ],
 )
 

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -62,11 +62,17 @@ _MNEMONIC = "AspectRulesLintESLint"
 def _gather_inputs(ctx, srcs, files):
     inputs = copy_files_to_bin_actions(ctx, srcs)
 
+    js_inputs = ctx.attr._config_files + ctx.rule.attr.deps + files
+
+    # Linting of ts targets often requires the tsconfig
+    if hasattr(ctx.rule.attr, "tsconfig"):
+        js_inputs.append(ctx.rule.attr.tsconfig)
+
     # Add the config file along with any deps it has on npm packages
     if "gather_files_from_js_providers" in dir(js_lib_helpers):
         # rules_js 1.x
         js_inputs = js_lib_helpers.gather_files_from_js_providers(
-            ctx.attr._config_files + ctx.rule.attr.deps + files,
+            js_inputs,
             include_transitive_sources = True,
             include_declarations = True,
             include_npm_linked_packages = True,
@@ -74,7 +80,7 @@ def _gather_inputs(ctx, srcs, files):
     else:
         # rules_js 2.x
         js_inputs = js_lib_helpers.gather_files_from_js_infos(
-            ctx.attr._config_files + ctx.rule.attr.deps + files,
+            js_inputs,
             include_sources = True,
             include_transitive_sources = True,
             include_types = True,


### PR DESCRIPTION
eslint plugins often need the tsconfig

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Include `ts_project(tsconfig)` as inputs to eslint aspect.

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:
