### PR TITLE
chore: remove old nodejs pinning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,6 @@
 # but we don't want to run the other hooks on commit messages
 default_stages: [commit]
 
-# Use a slightly older version of node by default
-# as the default uses a very new version of GLIBC
-default_language_version:
-  node: 16.18.0
-
 repos:
   # Check formatting and lint for starlark code
   - repo: https://github.com/keith/pre-commit-buildifier


### PR DESCRIPTION
This was here since the initial commit to the repo 2y ago

https://github.com/aspect-build/rules_lint/commit/2dc443fa549a092fe09d05f202c223ad33bbbc08
and I imagine it's no longer needed.

Fixes #588
