### PR TITLE
Add cppcheck lint aspect [WIP]

### DIFF
--- a/example/.aspect/cli/config.yaml
+++ b/example/.aspect/cli/config.yaml
@@ -1,14 +1,3 @@
 lint:
   aspects:
-    - //tools/lint:linters.bzl%eslint
-    - //tools/lint:linters.bzl%buf
-    - //tools/lint:linters.bzl%flake8
-    - //tools/lint:linters.bzl%ktlint
-    - //tools/lint:linters.bzl%pmd
-    - //tools/lint:linters.bzl%stylelint
-    - //tools/lint:linters.bzl%ruff
-    - //tools/lint:linters.bzl%vale
-    - //tools/lint:linters.bzl%checkstyle
-    - //tools/lint:linters.bzl%clang_tidy
-    - //tools/lint:linters.bzl%spotbugs
-    - //tools/lint:linters.bzl%keep_sorted
+    - //tools/lint:linters.bzl%cppcheck

--- a/example/tools/lint/BUILD.bazel
+++ b/example/tools/lint/BUILD.bazel
@@ -104,3 +104,8 @@ native_binary(
     ),
     out = "clang_tidy",
 )
+
+sh_binary(
+    name = "cppcheck",
+    srcs = ["cppcheck_wrapper.sh"],
+)

--- a/example/tools/lint/cppcheck_wrapper.sh
+++ b/example/tools/lint/cppcheck_wrapper.sh
@@ -1,0 +1,4 @@
+~/.local/bin/cppcheckpremium/cppcheck \
+    --check-level=exhaustive \
+    --enable=warning,style,performance,portability,information \
+    "$@"

--- a/example/tools/lint/linters.bzl
+++ b/example/tools/lint/linters.bzl
@@ -3,6 +3,7 @@
 load("@aspect_rules_lint//lint:buf.bzl", "lint_buf_aspect")
 load("@aspect_rules_lint//lint:checkstyle.bzl", "lint_checkstyle_aspect")
 load("@aspect_rules_lint//lint:clang_tidy.bzl", "lint_clang_tidy_aspect")
+load("@aspect_rules_lint//lint:cppcheck.bzl", "lint_cppcheck_aspect")
 load("@aspect_rules_lint//lint:eslint.bzl", "lint_eslint_aspect")
 load("@aspect_rules_lint//lint:flake8.bzl", "lint_flake8_aspect")
 load("@aspect_rules_lint//lint:keep_sorted.bzl", "lint_keep_sorted_aspect")
@@ -101,6 +102,12 @@ clang_tidy = lint_clang_tidy_aspect(
 )
 
 clang_tidy_test = lint_test(aspect = clang_tidy)
+
+cppcheck = lint_cppcheck_aspect(
+    binary = Label("//tools/lint:cppcheck"),
+    verbose = True,
+)
+cppcheck_test = lint_test(aspect = cppcheck)
 
 # an example of setting up a different clang-tidy aspect with different
 # options. This one uses a single global clang-tidy file

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -269,3 +269,8 @@ sh_binary(
     name = "clang_tidy_wrapper",
     srcs = ["clang_tidy_wrapper.bash"],
 )
+
+sh_binary(
+    name = "cppcheck_wrapper",
+    srcs = ["cppcheck_wrapper.bash"],
+)

--- a/lint/cppcheck.bzl
+++ b/lint/cppcheck.bzl
@@ -1,0 +1,182 @@
+"""API for calling declaring a cppcheck lint aspect.
+
+"""
+
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OPTIONAL_SARIF_PARSER_TOOLCHAIN", "OUTFILE_FORMAT", "noop_lint_action", "output_files", "parse_to_sarif_action", "patch_and_output_files")
+
+_MNEMONIC = "AspectRulesLintCppCheck"
+
+def _gather_inputs(ctx, compilation_context, srcs):
+    inputs = srcs
+    return depset(inputs, transitive = [compilation_context.headers])
+
+# taken over from clang_tidy.bzl
+def _is_source(file):
+    permitted_source_types = [
+        "c",
+        "cc",
+        "cpp",
+        "cxx",
+        "c++",
+        "C",
+    ]
+    return (file.is_source and file.extension in permitted_source_types)
+
+# taken over from clang_tidy.bzl
+# modification of filter_srcs in lint_aspect.bzl that filters out header files
+def _filter_srcs(rule):
+    # some rules can return a CcInfo without having a srcs attribute
+    if not hasattr(rule.attr, "srcs"):
+        return []
+    if "lint-genfiles" in rule.attr.tags:
+        return rule.files.srcs
+    else:
+        return [s for s in rule.files.srcs if _is_source(s)]
+
+def _prefixed(list, prefix):
+    array = []
+    for arg in list:
+        array.append("{} {}".format(prefix, arg))
+    return array
+
+def _get_compiler_args(compilation_context):
+    # add includes
+    args = []
+    args.extend(_prefixed(compilation_context.framework_includes.to_list(), "-I"))
+    args.extend(_prefixed(compilation_context.includes.to_list(), "-I"))
+    args.extend(_prefixed(compilation_context.quote_includes.to_list(), "-I"))
+    args.extend(_prefixed(compilation_context.system_includes.to_list(), "-I"))
+    args.extend(_prefixed(compilation_context.external_includes.to_list(), "-I"))
+    return args
+
+def cppcheck_action(ctx, compilation_context, executable, srcs, stdout, exit_code):
+    """Create a Bazel Action that spawns a cppcheck process.
+
+    Args:
+        ctx: an action context OR aspect context
+        compilation_context: from target
+        executable: struct with a cppcheck field
+        srcs: file objects to lint
+        stdout: output file containing the stdout or --output-file of cppcheck
+        exit_code: output file containing the exit code of cppcheck.
+            If None, then fail the build when cppcheck exits non-zero.
+    """
+
+    outputs = [stdout]
+    env = {}
+    env["CPPCHECK__STDOUT_STDERR_OUTPUT_FILE"] = stdout.path
+
+    if exit_code:
+        env["CPPCHECK__EXIT_CODE_OUTPUT_FILE"] = exit_code.path
+        outputs.append(exit_code)
+
+    env["CPPCHECK__VERBOSE"] = "1" if ctx.attr._verbose else ""
+
+    cppcheck_args = []
+
+    # cppcheck shall fail with exit code != 0 if issues found
+    cppcheck_args.append("--error-exitcode=31")
+
+    # add include paths
+    cppcheck_args.extend(_get_compiler_args(compilation_context))
+
+    # if ctx.attr._verbose:
+    #     print("  Found {} source files to lint".format(len(srcs)))
+    for f in srcs:
+        # if ctx.attr._verbose:
+        #     print("    {}".format(f.short_path))
+        cppcheck_args.append(f.short_path)
+
+    ctx.actions.run_shell(
+        inputs = _gather_inputs(ctx, compilation_context, srcs),
+        outputs = outputs,
+        tools = [executable._cppcheck_wrapper, executable._cppcheck, find_cpp_toolchain(ctx).all_files],
+        command = executable._cppcheck_wrapper.path + " $@",
+        arguments = [executable._cppcheck.path] + cppcheck_args,
+        env = env,
+        mnemonic = _MNEMONIC,
+        progress_message = "Linting %{label} with cppcheck",
+    )
+    
+
+def _cppcheck_aspect_impl(target, ctx):
+    if not CcInfo in target:
+        return []
+
+    # if ctx.attr._verbose:
+    #     print("Linting C++ target {}".format(target.label))
+
+    files_to_lint = _filter_srcs(ctx.rule)
+    compilation_context = target[CcInfo].compilation_context
+    if hasattr(ctx.rule.attr, "implementation_deps"):
+        compilation_context = cc_common.merge_compilation_contexts(
+            compilation_contexts = [compilation_context] +
+                                   [implementation_dep[CcInfo].compilation_context for implementation_dep in ctx.rule.attr.implementation_deps],
+        )
+
+    outputs, info = output_files(_MNEMONIC, target, ctx)
+
+    if len(files_to_lint) == 0:
+        noop_lint_action(ctx, outputs)
+        return [info]
+
+    cppcheck_action(ctx, compilation_context, ctx.executable, files_to_lint, outputs.human.out, outputs.human.exit_code)
+
+    # report:
+    raw_machine_report = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "raw_machine_report"))
+    cppcheck_action(ctx, compilation_context, ctx.executable, files_to_lint, raw_machine_report, outputs.machine.exit_code)
+    parse_to_sarif_action(ctx, _MNEMONIC, raw_machine_report, outputs.machine.out)
+
+    return [info]
+
+def lint_cppcheck_aspect(binary, verbose = False):
+    """A factory function to create a linter aspect.
+
+    Args:
+        binary: the cppcheck binary, typically a rule like
+
+            ```starlark
+            native_binary(
+                name = "cppcheck",
+                src = "cppcheck.exe"
+                out = "cppcheck",
+            )
+            ```
+        verbose: print debug messages including clang-tidy command lines being invoked.
+    """
+
+    return aspect(
+        implementation = _cppcheck_aspect_impl,
+        attrs = {
+            "_options": attr.label(
+                default = "//lint:options",
+                providers = [LintOptionsInfo],
+            ),
+            "_verbose": attr.bool(
+                default = verbose,
+            ),
+            "_cppcheck": attr.label(
+                default = binary,
+                executable = True,
+                cfg = "exec",
+            ),
+            "_cppcheck_wrapper": attr.label(
+                default = Label("@aspect_rules_lint//lint:cppcheck_wrapper"),
+                executable = True,
+                cfg = "exec",
+            ),
+            "_patcher": attr.label(
+                default = "@aspect_rules_lint//lint/private:patcher",
+                executable = True,
+                cfg = "exec",
+            ),
+            "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+        },
+        toolchains = [
+            OPTIONAL_SARIF_PARSER_TOOLCHAIN,
+            "@bazel_tools//tools/cpp:toolchain_type",
+        ],
+        fragments = ["cpp"],
+    )

--- a/lint/cppcheck_wrapper.bash
+++ b/lint/cppcheck_wrapper.bash
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# This is a wrapper for cppcheck which gives us control over error handling
+# Usage: cppcheck_wrapper.bash <cppcheck-path> <args>
+#
+# Controls:
+# - CPPCHECK__VERBOSE: If set, be verbose
+# - CPPCHECK__STDOUT_STDERR_OUTPUT_FILE: If set, write stdout and stderr to this file
+# - CPPCHECK__EXIT_CODE_OUTPUT_FILE: If set, write the highest exit code 
+# to this file and return success
+
+# First arg is cppcheck path
+cppcheck=$1
+shift
+
+if [[ -n $CPPCHECK__STDOUT_STDERR_OUTPUT_FILE ]]; then
+    # Create the file if it doesn't exist
+    touch $CPPCHECK__STDOUT_STDERR_OUTPUT_FILE
+    # Clear the file if it does exist
+    > $CPPCHECK__STDOUT_STDERR_OUTPUT_FILE
+    if [[ -n $CPPCHECK__VERBOSE ]]; then
+        echo "Output > ${CPPCHECK__STDOUT_STDERR_OUTPUT_FILE}"
+    fi
+fi
+if [[ -n $CPPCHECK__EXIT_CODE_OUTPUT_FILE ]]; then
+    if [[ -n $CPPCHECK__VERBOSE ]]; then
+        echo "Exit Code -> ${CPPCHECK__EXIT_CODE_OUTPUT_FILE}"
+    fi
+fi
+
+if [[ -n $CPPCHECK__STDOUT_STDERR_OUTPUT_FILE ]]; then
+    out_file=$CPPCHECK__STDOUT_STDERR_OUTPUT_FILE
+else
+    out_file=$(mktemp)
+fi
+# include stderr in output file; it contains some of the diagnostics
+command="$cppcheck $@ $file > $out_file 2>&1"
+if [[ -n $CPPCHECK__VERBOSE ]]; then
+    echo "$@"
+    echo "cwd: " `pwd`
+    echo $command
+fi
+eval $command
+exit_code=$?
+if [ $exit_code -eq 1 ] && [ -s $out_file ]; then
+    echo "Error: " $exit_code
+    echo "Something went wrong when running cppcheck. Maybe license file missing?"
+fi
+cat $out_file
+
+if [[ -z $CPPCHECK__STDOUT_STDERR_OUTPUT_FILE ]]; then
+    rm $out_file
+fi
+# if CPPCHECK__EXIT_CODE_FILE is set, write the max exit code to that file and return success
+if [[ -n $CPPCHECK__EXIT_CODE_OUTPUT_FILE ]]; then
+    if [[ -n $CPPCHECK__VERBOSE ]]; then  
+        echo "echo $exit_code > $CPPCHECK__EXIT_CODE_OUTPUT_FILE"
+        echo "exit 0"
+    fi
+    echo $exit_code > $CPPCHECK__EXIT_CODE_OUTPUT_FILE
+    exit 0
+fi
+
+if [[ -n $CPPCHECK__VERBOSE ]]; then
+    echo exit $exit_code
+fi
+
+exit $exit_code


### PR DESCRIPTION
<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

Add `cppcheck` as `lint` aspect as per https://github.com/aspect-build/rules_lint/issues/569

Local test: `cd example && bazel lint //src:hello_cc`
This is WIP.
Open points:
- [ ] Where to get `cppcheck`?
- [ ] config files are not really supported
- [ ] Test cases

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
