### PR TITLE
Adds cwd target from rules_multitool for linters

### DIFF
--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -19,6 +19,18 @@ alias(
     actual = "@multitool//tools/shellcheck",
 )
 
+# Exposes the "cwd" scripts that run the tools with the working directory set to were bazel is invoked.
+# See https://github.com/bazel-contrib/rules_multitool/blob/91533f6c3d42677d9a33e61dc728c7ce8f398abf/readme.md?plain=1#L90
+alias(
+    name = "ruff_bin_cwd",
+    actual = "@multitool//tools/ruff:cwd",
+)
+
+alias(
+    name = "shellcheck_bin_cwd",
+    actual = "@multitool//tools/shellcheck:cwd",
+)
+
 # Used as a default for vale_aspect#styles
 filegroup(
     name = "empty_styles",


### PR DESCRIPTION
When devs use linting tools outside of bazel they get used to the pattern that the linting bin is aware of it's current working dir. However, bazel run isn't designed for this. To circumvent this rules_multitool exposes a target that is cwd aware. Given that rules_aspect_lint exposes the bin it would be helpful to also expose the cwd endpoint; so that devs that use this for linting can also use the exact same setup to run the linter outside aspects. I.e. by invoking the lint using `bazel run //linterbin -- linter flags`

I suspect this PR is incomplete, but I wanted to submit it to see if the addition is welcome at all. If yes; I can possible expand this to other targets that use rules_multitool.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no
