### PR TITLE
chore: fix markdown parsing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Linters which are not language-specific:
 [ruff]: https://docs.astral.sh/ruff/
 [shellcheck]: https://www.shellcheck.net/
 [shfmt]: https://github.com/mvdan/sh
-[taplo] : https://taplo.tamasfe.dev/
+[taplo]: https://taplo.tamasfe.dev/
 [clang-format]: https://clang.llvm.org/docs/ClangFormat.html
 [clang-tidy]: https://clang.llvm.org/extra/clang-tidy/
 [vale]: https://vale.sh/


### PR DESCRIPTION
A simple typo broke the parsing and rendering of the tools table