### PR TITLE
fixes #630 multitool update lock file to update gofumpt

### DIFF
--- a/format/multitool.lock.json
+++ b/format/multitool.lock.json
@@ -4,36 +4,36 @@
     "binaries": [
       {
         "kind": "file",
-        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.8.0/gofumpt_v0.8.0_linux_arm64",
-        "sha256": "787c1d3d4d20e6fe2b0bf06a5a913ac0f50343dbf9a71540724a2b8092a0e6ca",
+        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.9.1/gofumpt_v0.9.1_linux_arm64",
+        "sha256": "cb0bddd2ea3dbdc292bb1b527c6806143a1e57653bc5be9ac1c9228fbbc43135",
         "os": "linux",
         "cpu": "arm64"
       },
       {
         "kind": "file",
-        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.8.0/gofumpt_v0.8.0_linux_amd64",
-        "sha256": "11604bbaf7321abcc2fca2c6a37b7e9198bb1e76e5a86f297c07201e8ab1fda9",
+        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.9.1/gofumpt_v0.9.1_linux_amd64",
+        "sha256": "a616c867ca92f63017500502b7d0b490dfe5bcbcaa265659a1b50620ad63de5c",
         "os": "linux",
         "cpu": "x86_64"
       },
       {
         "kind": "file",
-        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.8.0/gofumpt_v0.8.0_darwin_arm64",
-        "sha256": "7e66e92b7a67d1d12839ab030fb7ae38e5e2273474af3762e67bc7fe9471fcd9",
+        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.9.1/gofumpt_v0.9.1_darwin_arm64",
+        "sha256": "3821782c96d1c322c0ba6c0e7078b897e29997bdd14be5fa8cf9821ee14b3845",
         "os": "macos",
         "cpu": "arm64"
       },
       {
         "kind": "file",
-        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.8.0/gofumpt_v0.8.0_darwin_amd64",
-        "sha256": "0dda6600cf263b703a5ad93e792b06180c36afdee9638617a91dd552f2c6fb3e",
+        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.9.1/gofumpt_v0.9.1_darwin_amd64",
+        "sha256": "62a54abe6488062fa79fbb56b44436c1d68805a9b7ce314a3fbfa37d9c17dc52",
         "os": "macos",
         "cpu": "x86_64"
       },
       {
         "kind": "file",
-        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.8.0/gofumpt_v0.8.0_windows_amd64.exe",
-        "sha256": "6d25310f322080af6de8193617d78495b356a5ede65fde6d5d0e4bcdfff1f2a4",
+        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.9.1/gofumpt_v0.9.1_windows_amd64.exe",
+        "sha256": "1514d3b5fe2767aade67e84bb765b0c41cdabb2aeb013cd233724db70b5197e3",
         "os": "windows",
         "cpu": "x86_64"
       }


### PR DESCRIPTION
#630 raised based on inconsistent lint behavior for go in current version.
Multitool upgrade bumped gofumpt from `0.8.0` to `0.9.1`

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
