### PR TITLE
chore: Format '*.MODULE.bazel' files

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -138,7 +138,7 @@ function ls-files {
       'SCSS') patterns=('*.scss') ;;
       'Scala') patterns=('*.scala' '*.kojo' '*.sbt' '*.sc') ;;
       'Shell') patterns=('.bash_aliases' '.bash_functions' '.bash_history' '.bash_logout' '.bash_profile' '.bashrc' '.cshrc' '.flaskenv' '.kshrc' '.login' '.profile' '.zlogin' '.zlogout' '.zprofile' '.zshenv' '.zshrc' '9fs' 'PKGBUILD' 'bash_aliases' 'bash_logout' 'bash_profile' 'bashrc' 'cshrc' 'gradlew' 'kshrc' 'login' 'man' 'profile' 'zlogin' 'zlogout' 'zprofile' 'zshenv' 'zshrc' '*.sh' '*.bash' '*.bats' '*.cgi' '*.command' '*.fcgi' '*.ksh' '*.sh.in' '*.tmux' '*.tool' '*.trigger' '*.zsh' '*.zsh-theme') ;;
-      'Starlark') patterns=('BUCK' 'BUILD' 'BUILD.bazel' 'MODULE.bazel' 'Tiltfile' 'WORKSPACE' 'WORKSPACE.bazel' '*.bzl' '*.star') ;;
+      'Starlark') patterns=('BUCK' 'BUILD' 'BUILD.bazel' 'MODULE.bazel' '*.MODULE.bazel' 'Tiltfile' 'WORKSPACE' 'WORKSPACE.bazel' '*.bzl' '*.star') ;;
       'Swift') patterns=('*.swift') ;;
       'TSX') patterns=('*.tsx') ;;
       'TypeScript') patterns=('*.ts' '*.cts' '*.mts') ;;


### PR DESCRIPTION
To format https://bazel.build/rules/lib/globals/module#include files.

<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

This change also include a new file pattern for starlark file discovery: `*.MODULE.bazel`, which is for included files as documented by https://bazel.build/rules/lib/globals/module#include

### Test plan

<!-- Delete any which do not apply -->

- Manual testing; please provide instructions so we can reproduce:

We have been using this patch for a while.