### PR TITLE
fix: combine copts and cxxopts for improved compiler argument handling

### DIFF
--- a/lint/clang_tidy.bzl
+++ b/lint/clang_tidy.bzl
@@ -262,7 +262,7 @@ def _get_args(ctx, compilation_context, srcs):
 def _get_compiler_args(ctx, compilation_context, srcs):
     # add args specified by the toolchain, on the command line and rule copts
     args = []
-    rule_flags = ctx.rule.attr.copts if hasattr(ctx.rule.attr, "copts") else []
+    rule_flags = list(getattr(ctx.rule.attr, "copts", [])) + list(getattr(ctx.rule.attr, "cxxopts", []))
     sources_are_cxx = _is_cxx(srcs[0])
     if (sources_are_cxx):
         user_flags = ctx.fragments.cpp.cxxopts + ctx.fragments.cpp.copts


### PR DESCRIPTION
This pull request updates how compiler flags are collected in the `_get_compiler_args` function. The change ensures that both `copts` and `cxxopts` attributes are included when gathering rule-specific flags.

* Now, both `copts` and `cxxopts` attributes are combined and used as rule flags in the `_get_compiler_args` function in `lint/clang_tidy.bzl`.