### PR TITLE
chore: manual mirror external releases

### DIFF
--- a/format/multitool.lock.json
+++ b/format/multitool.lock.json
@@ -4,36 +4,36 @@
     "binaries": [
       {
         "kind": "file",
-        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.9.1/gofumpt_v0.9.1_linux_arm64",
-        "sha256": "cb0bddd2ea3dbdc292bb1b527c6806143a1e57653bc5be9ac1c9228fbbc43135",
+        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.9.2/gofumpt_v0.9.2_linux_arm64",
+        "sha256": "5acaa5a554050f55fc81ef02a8b0d14ab6b3c058a84513885286dc52d3451645",
         "os": "linux",
         "cpu": "arm64"
       },
       {
         "kind": "file",
-        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.9.1/gofumpt_v0.9.1_linux_amd64",
-        "sha256": "a616c867ca92f63017500502b7d0b490dfe5bcbcaa265659a1b50620ad63de5c",
+        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.9.2/gofumpt_v0.9.2_linux_amd64",
+        "sha256": "72cf61b12fef91eab6df6db4a4284f30616b5ead330112e28a1fa1cb15e57339",
         "os": "linux",
         "cpu": "x86_64"
       },
       {
         "kind": "file",
-        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.9.1/gofumpt_v0.9.1_darwin_arm64",
-        "sha256": "3821782c96d1c322c0ba6c0e7078b897e29997bdd14be5fa8cf9821ee14b3845",
+        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.9.2/gofumpt_v0.9.2_darwin_arm64",
+        "sha256": "c241fb742599a6cb0563d7377f59def65d451b23dd718dbc6ddf4ab5e695e8f1",
         "os": "macos",
         "cpu": "arm64"
       },
       {
         "kind": "file",
-        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.9.1/gofumpt_v0.9.1_darwin_amd64",
-        "sha256": "62a54abe6488062fa79fbb56b44436c1d68805a9b7ce314a3fbfa37d9c17dc52",
+        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.9.2/gofumpt_v0.9.2_darwin_amd64",
+        "sha256": "4172b912ec514038605f334fef9ed7b3f12ca3e40024cb0a622eab3073a55e57",
         "os": "macos",
         "cpu": "x86_64"
       },
       {
         "kind": "file",
-        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.9.1/gofumpt_v0.9.1_windows_amd64.exe",
-        "sha256": "1514d3b5fe2767aade67e84bb765b0c41cdabb2aeb013cd233724db70b5197e3",
+        "url": "https://github.com/mvdan/gofumpt/releases/download/v0.9.2/gofumpt_v0.9.2_windows_amd64.exe",
+        "sha256": "067236b55a8ef4547ddc7d78fbb7a38169de15bab02a1763cde6a132c59dd35c",
         "os": "windows",
         "cpu": "x86_64"
       }
@@ -43,41 +43,41 @@
     "binaries": [
       {
         "kind": "archive",
-        "url": "https://github.com/google/go-jsonnet/releases/download/v0.20.0/go-jsonnet_0.20.0_Linux_arm64.tar.gz",
+        "url": "https://github.com/google/go-jsonnet/releases/download/v0.21.0/go-jsonnet_Linux_arm64.tar.gz",
         "file": "jsonnetfmt",
-        "sha256": "49fbc99c91dcd2be53fa856307de3b8708c91dc5c74740714fdf9317957322e0",
+        "sha256": "4a263da605dbe2edb99529f495266211062fac476789f2119408bc223338f1d6",
         "os": "linux",
         "cpu": "arm64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/google/go-jsonnet/releases/download/v0.20.0/go-jsonnet_0.20.0_Linux_x86_64.tar.gz",
+        "url": "https://github.com/google/go-jsonnet/releases/download/v0.21.0/go-jsonnet_Linux_x86_64.tar.gz",
         "file": "jsonnetfmt",
-        "sha256": "a137c5e969609c3995c4d05817a247cfef8a92760c5306c3ad7df0355dd62970",
+        "sha256": "ad3181fde77726b02d17eb4e72687020bf2cb35b9336cdeaaca4783c7ff104f7",
         "os": "linux",
         "cpu": "x86_64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/google/go-jsonnet/releases/download/v0.20.0/go-jsonnet_0.20.0_Darwin_arm64.tar.gz",
+        "url": "https://github.com/google/go-jsonnet/releases/download/v0.21.0/go-jsonnet_Darwin_arm64.tar.gz",
         "file": "jsonnetfmt",
-        "sha256": "a15a699a58eb172c6d91f4cbddf3681095a649008628e0cfd84f564db4244ee3",
+        "sha256": "398189a264e31a2c1316eed8ee6308306a221fd10b72f405def0100d295efeac",
         "os": "macos",
         "cpu": "arm64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/google/go-jsonnet/releases/download/v0.20.0/go-jsonnet_0.20.0_Darwin_x86_64.tar.gz",
+        "url": "https://github.com/google/go-jsonnet/releases/download/v0.21.0/go-jsonnet_Darwin_x86_64.tar.gz",
         "file": "jsonnetfmt",
-        "sha256": "76901637f60589bb9bf91b3481d4aecbc31efcd35ca99ae72bcb510b00270ad9",
+        "sha256": "a6cee4b381d2319fa807d7a7bf8a4ecf2d0cca64e2bcd53eeaa575ce1f7689a4",
         "os": "macos",
         "cpu": "x86_64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/google/go-jsonnet/releases/download/v0.20.0/go-jsonnet_0.20.0_Windows_x86_64.tar.gz",
+        "url": "https://github.com/google/go-jsonnet/releases/download/v0.21.0/go-jsonnet_Windows_x86_64.tar.gz",
         "file": "jsonnetfmt.exe",
-        "sha256": "82440a646a8d29487a243afc880db245f612a205d3eccbb900bc76d7a4049ad1",
+        "sha256": "81d71a287ee5dfd0860831eeac281a7327ce8876d5fe9a8b7e19726dbbc0ce4f",
         "os": "windows",
         "cpu": "x86_64"
       }
@@ -170,41 +170,41 @@
     "binaries": [
       {
         "kind": "archive",
-        "url": "https://github.com/google/yamlfmt/releases/download/v0.17.2/yamlfmt_0.17.2_Linux_arm64.tar.gz",
+        "url": "https://github.com/google/yamlfmt/releases/download/v0.20.0/yamlfmt_0.20.0_Linux_arm64.tar.gz",
         "file": "yamlfmt",
-        "sha256": "1785b9751af9dca10a8a3e51ee2f6f3aa64564610dcc994d98421e28d02b56b5",
+        "sha256": "26e2461caf96286c7958701acebce52089ce109645c20b5675496385c09f120a",
         "os": "linux",
         "cpu": "arm64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/google/yamlfmt/releases/download/v0.17.2/yamlfmt_0.17.2_Linux_x86_64.tar.gz",
+        "url": "https://github.com/google/yamlfmt/releases/download/v0.20.0/yamlfmt_0.20.0_Linux_x86_64.tar.gz",
         "file": "yamlfmt",
-        "sha256": "b114115b6804cfd203195d222558e4feb38e311fffb590c4e13642fa21bd0e37",
+        "sha256": "b652b39aa91a3b54347f948a06dc95e422b245f7f068adc898acfafa91376e17",
         "os": "linux",
         "cpu": "x86_64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/google/yamlfmt/releases/download/v0.17.2/yamlfmt_0.17.2_Darwin_arm64.tar.gz",
+        "url": "https://github.com/google/yamlfmt/releases/download/v0.20.0/yamlfmt_0.20.0_Darwin_arm64.tar.gz",
         "file": "yamlfmt",
-        "sha256": "94bd3fb3a2c66bdab77b58cd91bece9e4a8a28a33cb4e0fe241e6220548f69dd",
+        "sha256": "356fbf3c385f8e1211b4d8a40f73acc45fc44080a19f4b4181695a308b61998e",
         "os": "macos",
         "cpu": "arm64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/google/yamlfmt/releases/download/v0.17.2/yamlfmt_0.17.2_Darwin_x86_64.tar.gz",
+        "url": "https://github.com/google/yamlfmt/releases/download/v0.20.0/yamlfmt_0.20.0_Darwin_x86_64.tar.gz",
         "file": "yamlfmt",
-        "sha256": "e806fe1013e601788e762dc7e54858b0bb4bdc828c5b4c95125db67cd997ac30",
+        "sha256": "e6ece4924f026c87f65171a9681970b296e21d9cada48da0efddb676f51205eb",
         "os": "macos",
         "cpu": "x86_64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/google/yamlfmt/releases/download/v0.17.2/yamlfmt_0.17.2_Windows_x86_64.tar.gz",
+        "url": "https://github.com/google/yamlfmt/releases/download/v0.20.0/yamlfmt_0.20.0_Windows_x86_64.tar.gz",
         "file": "yamlfmt.exe",
-        "sha256": "fc6fd9328f62d7880c1eda1889f9eba39f42c6317761c23c27771349ba601513",
+        "sha256": "1809775aa51d2594cc9945af13170c6fea482242a5b5a9139c1c22080d143496",
         "os": "windows",
         "cpu": "x86_64"
       }


### PR DESCRIPTION
Because of github action is still broken, there is a manual update.

This has also adapted to the changes of artifact name in https://github.com/google/go-jsonnet/releases/tag/v0.21.0