### PR TITLE
fix(clippy): Store exit code to respect errors

### DIFF
--- a/example/src/rust/BUILD.bazel
+++ b/example/src/rust/BUILD.bazel
@@ -74,3 +74,14 @@ rust_binary(
     ],
     deps = [":bad_lib_with_noclippy"],
 )
+
+rust_binary(
+    name = "binary_with_warning_and_error",
+    srcs = ["warning_and_error.rs"],
+    edition = "2021",
+    visibility = [
+        "//src/rust:__pkg__",
+        "//test:__pkg__",
+        "//test/machine_outputs:__pkg__",
+    ],
+)

--- a/example/src/rust/bad_binary.rs
+++ b/example/src/rust/bad_binary.rs
@@ -1,4 +1,7 @@
 fn main() {
-    // Will fail clippy because we could just write println!("Hello World").
-    println!("{}", "Hello World");
+    // Will fail clippy because of the missing comma
+    let _missing_comma = &[
+        -1, -2, -3 // <= no comma here
+        -4, -5, -6
+    ];
 }

--- a/example/src/rust/bad_lib.rs
+++ b/example/src/rust/bad_lib.rs
@@ -1,4 +1,8 @@
 fn bad() {
-    // Will fail clippy because we could just write println!("Hello World").
-    println!("{}", "Hello World");
+    // Will fail clippy because of the missing comma
+    let _missing_comma = &[
+        -1, -2, -3 // <= no comma here
+        -4, -5, -6
+    ];
+
 }

--- a/example/test/BUILD.bazel
+++ b/example/test/BUILD.bazel
@@ -217,6 +217,14 @@ clippy_test(
 )
 
 clippy_test(
+    name = "clippy_binary_with_warning_and_error",
+    srcs = ["//src/rust:binary_with_warning_and_error"],
+    # Expected to fail based on current content of the file.
+    # Normally you'd fix the file instead of tagging this test.
+    tags = ["manual"],
+)
+
+clippy_test(
     name = "clippy_bad_binary_noclippy",
     srcs = ["//src/rust:bad_binary_with_noclippy"],
 )

--- a/example/test/machine_outputs/BUILD.bazel
+++ b/example/test/machine_outputs/BUILD.bazel
@@ -137,17 +137,30 @@ report_test(
 )
 
 machine_clippy_report(
-    name = "machine_clippy_report",
+    name = "machine_clippy_report_bad_lib",
     src = "//src/rust:bad_lib",
 )
 
 # Because the json file from clippy contains multiple messages _not_ in an array, we must take the first element.
 jq_test(
-    name = "clippy_machine_output_test",
-    file1 = ":machine_clippy_report",
-    file2 = ":machine_clippy_report",
-    filter1 = "inputs | first | .code.code",
-    filter2 = "inputs | first | \"dead_code\"",
+    name = "clippy_machine_output_test_bad_lib",
+    file1 = ":machine_clippy_report_bad_lib",
+    file2 = ":machine_clippy_report_bad_lib",
+    filter1 = ".code.code",
+    filter2 = """[inputs] | "dead_code" """,
+)
+
+machine_clippy_report(
+    name = "machine_clippy_report_warning_and_error",
+    src = "//src/rust:binary_with_warning_and_error",
+)
+
+jq_test(
+    name = "clippy_machine_output_test_warning_and_error",
+    file1 = ":machine_clippy_report_warning_and_error",
+    file2 = ":machine_clippy_report_warning_and_error",
+    filter1 = """ [inputs.level] """,
+    filter2 = """[inputs] | ["warning","error"] """,
 )
 
 # FIXME: I'm getting a C++ compile failure on macos

--- a/lint/clippy.bzl
+++ b/lint/clippy.bzl
@@ -40,11 +40,6 @@ clippy = lint_clippy_aspect(
 Now your targets will be linted with clippy.
 If you wish a target to be excluded from linting, you can give them the `noclippy` tag.
 
-Please note that, for now all clippy warnings are considered failures.
-This is because rules_rust will fail the entire execution if there's even one error,
-so we need to limit the reports to just warnings so that we can continue the target execution and generate useful output files.
-Because we limit all errors to warnings, we must consider every warning as an error.
-
 Please watch issue https://github.com/aspect-build/rules_lint/issues/385 for updates on this behavior.
 """
 
@@ -52,33 +47,6 @@ load("@rules_rust//rust:defs.bzl", "rust_clippy_action", "rust_common")
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OPTIONAL_SARIF_PARSER_TOOLCHAIN", "OUTFILE_FORMAT", "filter_srcs", "noop_lint_action", "output_files", "parse_to_sarif_action", "patch_and_output_files", "should_visit")
 
 _MNEMONIC = "AspectRulesLintClippy"
-
-def _marker_to_exit_code(ctx, marker, output, exit_code):
-    """Write 0 to exit_code if marker exists and the output is empty, fail otherwise.
-
-    rules_rust won't write the exit code to the success_marker, so we assert that it exists and write the exit code ourselves.
-    If there is a success marker but the output is not empty, we mark it as a failure.
-    If there is no success marker, the action has failed anyway.
-
-    Please note that all clippy warnings are considered failures.
-
-    Args:
-        ctx (ctx): The rule or aspect context. Must have access to `ctx.actions.run_shell`
-        marker (File): A file that will only exist if the action has succeeded
-        exit_code (File): A file that will be written with the exit code 0 if marker exists
-    """
-    ctx.actions.run_shell(
-        outputs = [exit_code],
-        inputs = [marker, output],
-        arguments = [exit_code.path, output.path],
-        command = """
-            if [ -s $2 ]; then
-                echo '1' > $1
-            else
-                echo '0' > $1
-            fi
-        """,
-    )
 
 # buildifier: disable=function-docstring
 def _clippy_aspect_impl(target, ctx):
@@ -102,13 +70,17 @@ def _clippy_aspect_impl(target, ctx):
         noop_lint_action(ctx, outputs)
         return [info]
 
-    extra_options = []
+    extra_options = [
+        # If we don't pass any clippy options, rules_rust will (rightly) default to -Dwarnings, which turns all warnings into errors.
+        # They do this to force Bazel to re-run targets on failures.
+        # However, we don't need to do that because we keep track of output files and exit codes separately.
+        "-Wwarnings",
+    ]
     # FIXME: Implement support for --fix mode. Clippy has a --fix flag, but our patcher doesn't currently support running an action through a macro.
     #        We have to either
     #           (1) modify the patcher so that it can run an action through a macro, or
     #           (2) modify rules_rust so that it gives us a struct with a command line we can run it with the patcher.
 
-    human_success_indicator = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "human_success_indicator"))
     rust_clippy_action.action(
         ctx,
         clippy_executable = clippy_bin,
@@ -116,13 +88,12 @@ def _clippy_aspect_impl(target, ctx):
         crate_info = crate_info,
         config = ctx.file._config_file,
         output = outputs.human.out,
-        success_marker = human_success_indicator,
-        cap_at_warnings = True,  # We don't want to crash the process if there are clippy errors, we just want to report them.
+        exit_code_file = outputs.human.exit_code,
+        forward_clippy_exit_code = False,  # We don't want to crash the process if there are clippy errors, we just want to report them.
+        cap_at_warnings = False,
         extra_clippy_flags = extra_options,
     )
-    _marker_to_exit_code(ctx, human_success_indicator, outputs.human.out, outputs.human.exit_code)
 
-    machine_success_indicator = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "machine_success_indicator"))
     rust_clippy_action.action(
         ctx,
         clippy_executable = clippy_bin,
@@ -130,12 +101,12 @@ def _clippy_aspect_impl(target, ctx):
         crate_info = crate_info,
         config = ctx.file._config_file,
         output = outputs.machine.out,
-        success_marker = machine_success_indicator,
-        cap_at_warnings = True,
+        exit_code_file = outputs.machine.exit_code,
+        forward_clippy_exit_code = False,  # We don't want to crash the process if there are clippy errors, we just want to report them.
+        cap_at_warnings = False,
         extra_clippy_flags = extra_options,
         error_format = "json",
     )
-    _marker_to_exit_code(ctx, machine_success_indicator, outputs.machine.out, outputs.machine.exit_code)
 
     # FIXME: Rustc only gives us JSON output, which we can't turn into SARIF yet.
     # clippy uses rustc's IO format, which doesn't have a SARIF output mode built in,


### PR DESCRIPTION
Depends on https://github.com/bazelbuild/rules_rust/pull/3772, and is a step towards #385  .

Store the exit code for clippy in a file instead of trying to guess it from the success marker.
This means that we no longer have to pass `cap_at_warning=True`, and we can properly report errors as errors without crashing the entire run.

### Changes are visible to end-users: yes. They are now able to see errors as errors instead of warnings.

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- New test cases added: Added a new machine_outputs test case that checks that both warnings and errors are produced.
