### PR TITLE
feat: Add cue as linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Linters which are not language-specific:
 | Language               | Formatter                 | Linter(s)                        |
 | ---------------------- | ------------------------- | -------------------------------- |
 | C / C++                | [clang-format]            | [clang-tidy] or [cppcheck]       |
+| CUE                    | [cue fmt]                 |                                  |
 | Cuda                   | [clang-format]            |                                  |
 | CSS, Less, Sass        | [Prettier]                | [Stylelint]                      |
 | Go                     | [gofmt] or [gofumpt]      |                                  |
@@ -94,6 +95,7 @@ Linters which are not language-specific:
 [taplo]: https://taplo.tamasfe.dev/
 [clang-format]: https://clang.llvm.org/docs/ClangFormat.html
 [clang-tidy]: https://clang.llvm.org/extra/clang-tidy/
+[cue fmt]: https://cuelang.org/docs/reference/command/cue-help-fmt/
 [cppcheck]: https://www.cppcheck.com/
 [vale]: https://vale.sh/
 [yamlfmt]: https://github.com/google/yamlfmt

--- a/example/src/hello.cue
+++ b/example/src/hello.cue
@@ -1,0 +1,13 @@
+// Intentionally poorly formatted CUE file
+package hello
+
+#Person: {
+name:    string
+age:     int
+email?:  string
+}
+
+people: [...#Person] & [
+{name: "Alice",age: 30},
+{name: "Bob",age: 25,email: "bob@example.com"},
+]

--- a/example/tools/format/BUILD.bazel
+++ b/example/tools/format/BUILD.bazel
@@ -98,6 +98,7 @@ format_multirun(
     # Disable when using WORKSPACE due to rules_dotnet only supporting Bzlmod
     csharp = "@paket.main//csharpier/tools:csharpier" if bzlmod_is_enabled() else None,
     css = ":prettier",
+    cue = "@aspect_rules_lint//format:cue",
     cuda = "@llvm_toolchain_llvm//:bin/clang-format",
     # Disable when using WORKSPACE due to rules_dotnet only supporting Bzlmod
     fsharp = "@paket.main//fantomas/tools:fantomas" if bzlmod_is_enabled() else None,

--- a/format/multitool.lock.json
+++ b/format/multitool.lock.json
@@ -1,5 +1,49 @@
 {
   "$schema": "https://raw.githubusercontent.com/theoremlp/rules_multitool/main/lockfile.schema.json",
+  "cue": {
+    "binaries": [
+      {
+        "kind": "archive",
+        "url": "https://github.com/cue-lang/cue/releases/download/v0.15.1/cue_v0.15.1_linux_arm64.tar.gz",
+        "file": "cue",
+        "sha256": "6bb80ec3262c7cedf898a21e9e9481c86da54488f144788b1fa0a5dc01879a0b",
+        "os": "linux",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/cue-lang/cue/releases/download/v0.15.1/cue_v0.15.1_linux_amd64.tar.gz",
+        "file": "cue",
+        "sha256": "aa282261245e9ab0d65b17ec3c7207f5231600106f7b26fc0c2e158b3937ca3f",
+        "os": "linux",
+        "cpu": "x86_64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/cue-lang/cue/releases/download/v0.15.1/cue_v0.15.1_darwin_arm64.tar.gz",
+        "file": "cue",
+        "sha256": "9ee183ec8686675a0aea24f9f5cfb64235ee4e7583e8e771432a0bf58e64411a",
+        "os": "macos",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/cue-lang/cue/releases/download/v0.15.1/cue_v0.15.1_darwin_amd64.tar.gz",
+        "file": "cue",
+        "sha256": "e761c85f060283d7c52b0b80e3ae57b569a0c4e7f7029bdbf38d7f079b2128bc",
+        "os": "macos",
+        "cpu": "x86_64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/cue-lang/cue/releases/download/v0.15.1/cue_v0.15.1_windows_amd64.zip",
+        "file": "cue.exe",
+        "sha256": "516fa080c1af12578ff76a4165cc7bf14ad9bbe5d9724a0c07553860d038885e",
+        "os": "windows",
+        "cpu": "x86_64"
+      }
+    ]
+  },
   "gofumpt": {
     "binaries": [
       {

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -117,6 +117,7 @@ function ls-files {
     case "$language" in
       'C') patterns=('*.c' '*.cats' '*.h' '*.idc') ;;
       'C++') patterns=('*.cpp' '*.c++' '*.cc' '*.cp' '*.cppm' '*.cxx' '*.h' '*.h++' '*.hh' '*.hpp' '*.hxx' '*.inc' '*.inl' '*.ino' '*.ipp' '*.ixx' '*.re' '*.tcc' '*.tpp' '*.txx') ;;
+      'CUE') patterns=('*.cue') ;;
       'Cuda') patterns=('*.cu' '*.cuh') ;;
       'C#') patterns=('*.cs' '*.cshtml') ;;
       'CSS') patterns=('*.css') ;;

--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -8,6 +8,7 @@ TOOLS = {
     "Markdown": "prettier",
     # NB: includes LESS and SASS
     "CSS": "prettier",
+    "CUE": "cue-fmt",
     "GraphQL": "prettier",
     "HTML": "prettier",
     "Python": "ruff",
@@ -37,6 +38,7 @@ TOOLS = {
 
 # Provided to make install more convenient
 BUILTIN_TOOL_LABELS = {
+    "CUE": "@multitool//tools/cue",
     "Jsonnet": "@multitool//tools/jsonnetfmt",
     "Go": "@multitool//tools/gofumpt",
     "Shell": "@multitool//tools/shfmt",
@@ -48,6 +50,7 @@ BUILTIN_TOOL_LABELS = {
 # Flags to pass each tool's CLI when running in check mode
 CHECK_FLAGS = {
     "buildifier": "-mode=check",
+    "cue-fmt": "fmt --check",
     "swiftformat": "--lint",
     "prettier": "--check",
     "ruff": "format --check --force-exclude --diff",
@@ -71,6 +74,7 @@ CHECK_FLAGS = {
 # Flags to pass each tool when running in default mode
 FIX_FLAGS = {
     "buildifier": "-mode=fix",
+    "cue-fmt": "fmt",
     "djlint": "--format-css --format-js --reformat",
     "swiftformat": "",
     "prettier": "--write",

--- a/format/test/BUILD.bazel
+++ b/format/test/BUILD.bazel
@@ -41,6 +41,7 @@ format_multirun(
     cc = ":mock_clang-format.sh",
     csharp = ":mock_csharpier.sh",
     css = ":mock_prettier.sh",
+    cue = ":mock_cue-fmt.sh",
     cuda = ":mock_clang-format.sh",
     fsharp = ":mock_fantomas.sh",
     gherkin = ":mock_prettier.sh",

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -65,6 +65,13 @@ bats_load_library "bats-assert"
     assert_output --partial "+ prettier --write example/src/hello.scss"
 }
 
+@test "should run cue fmt on CUE" {
+    run bazel run //format/test:format_CUE_with_cue-fmt
+    assert_success
+
+    assert_output --partial "+ cue-fmt fmt example/src/hello.cue"
+}
+
 @test "should run prettier on HTML" {
     run bazel run //format/test:format_HTML_with_prettier
     assert_success


### PR DESCRIPTION
  ---
Adds CUE language support for formatting using cue fmt. This follows the same pattern as existing formatters - adds the tool to multitool.lock.json (v0.15.1), wires up file patterns and flags, and includes an example file.

This code was written with AI assistance using Anthropic's Opus 4.5 model.

  ---
  Changes are visible to end-users: yes

  - Searched for relevant documentation and updated as needed: yes
  - Breaking change (forces users to change their own code or config): no
  - Suggested release notes appear below: yes

  Release notes: Added cue fmt as a formatter for CUE files.

  Test plan

  - New test cases added
  - Manual testing: bazel run //format/test:format_CUE_with_cue-fmt

  ---

Closes #676 