### PR TITLE
chore: perform 2.0 todos

### DIFF
--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -124,28 +124,6 @@ bzl_library(
     ],
 )
 
-# Aliases introduced in #432 for fear of breaking users.
-# TODO(2.0) remove them
-alias(
-    name = "eslint.workaround_17660",
-    actual = "//lint/js:eslint.workaround_17660",
-)
-
-alias(
-    name = "eslint.compact-formatter",
-    actual = "//lint/js:eslint.compact-formatter",
-)
-
-alias(
-    name = "eslint.stylish-formatter",
-    actual = "//lint/js:eslint.stylish-formatter",
-)
-
-alias(
-    name = "stylelint.compact-formatter",
-    actual = "//lint/js:stylelint.compact-formatter",
-)
-
 bzl_library(
     name = "eslint",
     srcs = ["eslint.bzl"],

--- a/lint/cppcheck.bzl
+++ b/lint/cppcheck.bzl
@@ -131,7 +131,6 @@ def _cppcheck_aspect_impl(target, ctx):
     info = OutputGroupInfo(
         rules_lint_human = info.rules_lint_human,
         rules_lint_machine = info.rules_lint_machine,
-        rules_lint_report = info.rules_lint_report,
         rules_lint_xml = depset([xml_output]),
         _validation = info._validation,
     )

--- a/lint/eslint.bzl
+++ b/lint/eslint.bzl
@@ -257,17 +257,17 @@ def lint_eslint_aspect(binary, configs, rule_kinds = ["js_library", "ts_project"
                 allow_files = True,
             ),
             "_workaround_17660": attr.label(
-                default = "@aspect_rules_lint//lint:eslint.workaround_17660",
+                default = "@aspect_rules_lint//lint/js:eslint.workaround_17660",
                 allow_single_file = True,
                 cfg = "exec",
             ),
             "_compact_formatter": attr.label(
-                default = "@aspect_rules_lint//lint:eslint.compact-formatter",
+                default = "@aspect_rules_lint//lint/js:eslint.compact-formatter",
                 allow_single_file = True,
                 cfg = "exec",
             ),
             "_stylish_formatter": attr.label(
-                default = "@aspect_rules_lint//lint:eslint.stylish-formatter",
+                default = "@aspect_rules_lint//lint/js:eslint.stylish-formatter",
                 allow_single_file = True,
                 cfg = "exec",
             ),

--- a/lint/private/lint_aspect.bzl
+++ b/lint/private/lint_aspect.bzl
@@ -95,9 +95,6 @@ def output_files(mnemonic, target, ctx):
     ), OutputGroupInfo(
         rules_lint_human = depset(human_outputs),
         rules_lint_machine = depset(machine_outputs),
-        # Legacy name used by existing callers.
-        # TODO(2.0): remove
-        rules_lint_report = depset(machine_outputs),
         # Always cause the action to execute, even if the output isn't requested
         _validation = depset([human_out]),
     )
@@ -122,9 +119,6 @@ def patch_and_output_files(*args):
         rules_lint_human = depset(human_outputs),
         rules_lint_machine = depset(machine_outputs),
         rules_lint_patch = depset([patch]),
-        # Legacy name used by existing callers.
-        # TODO(2.0): remove
-        rules_lint_report = depset(machine_outputs),
     )
 
 def filter_srcs(rule):

--- a/lint/stylelint.bzl
+++ b/lint/stylelint.bzl
@@ -213,7 +213,7 @@ def lint_stylelint_aspect(binary, config, rule_kinds = ["css_library"], filegrou
                 allow_files = True,
             ),
             "_compact_formatter": attr.label(
-                default = "@aspect_rules_lint//lint:stylelint.compact-formatter",
+                default = "@aspect_rules_lint//lint/js:stylelint.compact-formatter",
                 allow_single_file = True,
                 cfg = "exec",
             ),


### PR DESCRIPTION
BREAKING CHANGE:

- change `@aspect_rules_lint//lint:eslint.*` to `@aspect_rules_lint//lint/js:eslint.*`
- same for stylelint.compact*
- `rules_lint_report` was renamed to rules_lint_human and rules_lint_machine to disambiguate which output you want