### PR TITLE
feat: vale linter visits 'markdown' rules

### DIFF
--- a/lint/vale.bzl
+++ b/lint/vale.bzl
@@ -143,7 +143,7 @@ def _vale_aspect_impl(target, ctx):
 # Users might want to try https://github.com/dwtj/dwtj_rules_markdown but we expect many won't
 # want to take that dependency.
 # So allow a filegroup(tags=["markdown"]) as an alternative rule to host the srcs.
-def lint_vale_aspect(binary, config, styles = Label("//lint:empty_styles"), rule_kinds = ["markdown_library"], filegroup_tags = ["markdown", "lint-with-vale"]):
+def lint_vale_aspect(binary, config, styles = Label("//lint:empty_styles"), rule_kinds = ["markdown", "markdown_library"], filegroup_tags = ["markdown", "lint-with-vale"]):
     """A factory function to create a linter aspect."""
     return aspect(
         implementation = _vale_aspect_impl,


### PR DESCRIPTION
A "library" is a stretch for a group of markdown files. 'markdown' is just as good, and is already in use in a ruleset I'm contributing to: https://github.com/jacobshirley/rules_docs/blob/v0.2.0/examples/typescript/BUILD#L7-L16

See https://github.com/jacobshirley/rules_docs/commit/9a2ccdf26abcbc4bf663a9e1bb7c347c8fdea849

FYI @jacobshirley
