### PR TITLE
chore: clean up exclusion list in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,9 +76,6 @@ jobs:
         include:
           - folder: format
         exclude:
-          # FIXME: these two are hanging; why?
-          - folder: examples/java
-          - folder: examples/shell
           # FIXME: these two are failing, diagnose.
           - folder: examples/python
           - folder: examples/cpp


### PR DESCRIPTION
Removed commented out folders from exclusion list in CI workflow.

Fixes #698
