### PR TITLE
fix: typo `b{r,}andit`

### DIFF
--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -116,7 +116,7 @@ lint_options(
 )
 
 bzl_library(
-    name = "brandit",
+    name = "bandit",
     srcs = ["bandit.bzl"],
     deps = ["//lint/private:lint_aspect"],
 )


### PR DESCRIPTION
Fix a typo introduced in https://github.com/aspect-build/rules_lint/pull/704


---
@TimotheusBachinger Thank you for noticing in the code review!