### PR TITLE
fix: bump protobuf to 33.4 since Bazel 9 will do that anyway

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,7 @@ common --config=ruleset
 
 # Don't build protoc from the cc_binary, it's slow and spammy when cache miss
 common --incompatible_enable_proto_toolchain_resolution
+common --@protobuf//bazel/toolchains:prefer_prebuilt_protoc
 common --per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT
 common --host_per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT
 

--- a/.bcr/patches/go_dev_deps.patch
+++ b/.bcr/patches/go_dev_deps.patch
@@ -1,11 +1,5 @@
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -34,7 +34,7 @@ use_repo(multitool, "multitool")
- 
- # To allow /tools to be built from source
- # NOTE: when publishing to BCR, we patch this to be True, as we publish pre-built binaries with our releases.
+@@ -10,1 +10,1 @@
 -IS_RELEASE = False
 +IS_RELEASE = True
- 
- bazel_dep(
-     name = "toolchains_protoc",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,9 @@ module(
     compatibility_level = 1,
 )
 
+# NOTE: when publishing to BCR, we patch this to be True, as we publish pre-built binaries with our releases.
+IS_RELEASE = False
+
 # We don't actually depend directly on aspect_bazel_lib, but we do require this
 # version be used transitively so that it doesn't produce conflicting actions
 # with the bazel_lib module we use.
@@ -35,7 +38,7 @@ bazel_dep(name = "rules_java", version = "7.0.6")
 bazel_dep(name = "rules_rust", version = "0.67.0")
 
 # Needed in the root because we dereference ProtoInfo in our aspect impl
-bazel_dep(name = "rules_proto", version = "6.0.0")
+bazel_dep(name = "rules_proto", version = "7.1.0")
 
 # Needed in the root because we dereference PyInfo in our ty aspect impl
 bazel_dep(name = "rules_python", version = "0.26.0")
@@ -60,20 +63,9 @@ register_toolchains("@sarif_parser_toolchains//:all")
 ####### Dev dependencies ########
 
 bazel_dep(name = "bazelrc-preset.bzl", version = "1.1.0", dev_dependency = True)
+bazel_dep(name = "protobuf", version = "33.4", dev_dependency = True)
 
 # To allow /tools to be built from source
-# NOTE: when publishing to BCR, we patch this to be True, as we publish pre-built binaries with our releases.
-IS_RELEASE = False
-
-bazel_dep(
-    name = "toolchains_protoc",
-    version = "0.6.0",
-    dev_dependency = IS_RELEASE,
-)
-
-protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc", dev_dependency = IS_RELEASE)
-protoc.toolchain(version = "v32.0")
-
 bazel_dep(
     name = "gazelle",
     version = "0.43.0",


### PR DESCRIPTION
Fixes CI that went red on release of bazel 9 rc5