### PR TITLE
fix(clippy): Respect fail_on_violation

### DIFF
--- a/examples/rust/test/BUILD
+++ b/examples/rust/test/BUILD
@@ -12,9 +12,10 @@ clippy_test(
 clippy_test(
     name = "clippy_ok_binary_with_bad_dep",
     srcs = ["//src:ok_binary_with_bad_dep"],
+    # TODO: This test is supposed to fail, why does it pass?
     # Expected to fail based on current content of the file.
     # Normally you'd fix the file instead of tagging this test.
-    tags = ["manual"],
+    # tags = ["manual"],
 )
 
 clippy_test(

--- a/lint/rust/process_wrapper_wrapper.bash
+++ b/lint/rust/process_wrapper_wrapper.bash
@@ -44,6 +44,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+
 # Ensure that _some_ command is left
 if [[ ${#cmd[@]} -eq 0 ]]; then
   echo "Error: no command to execute" >&2


### PR DESCRIPTION
Depends on #715

Before, the process_wrapper_wrapper just ignored the flag, and exited 0 on all cases . Now, if a user wants to fail on violation, we:
- Print the human output to stderr.
- Exit with the same exit code as the rules_rust process_wrapper exited.

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Manual testing; please provide instructions so we can reproduce: `(cd examples/rust && bazel build //src:bad_lib --config=lint --output_groups=rules_lint_human --output_groups=rules_lint_machine --spawn_strategy=local --@aspect_rules_lint//lint
:fail_on_violation --sandbox_debug --verbose_failures)`

As far as I could see, there are no tests for `fail_on_violation`.
