### PR TITLE
feat: Add notes to results for shellcheck

### DIFF
--- a/tools/sarif/sarif.go
+++ b/tools/sarif/sarif.go
@@ -91,6 +91,7 @@ func ToSarifJsonString(label string, mnemonic string, report string) (sarifJsonS
 			`%AIn\ %f\ line\ %l:`,
 			`%C%.%#(%trror):\ %m%Z`,
 			`%C%.%#(%tarning):\ %m%Z`,
+			`%C%.%#(%tnfo):\ %m%Z`,
 			`%C%.%#`,
 		}
 	case "AspectRulesLintStylelint":


### PR DESCRIPTION
Shellcheck fails with error code 1 if notes are found. This leads to empty results and invisible fails.
This is solved by adding notes to the results in each run.

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

