### PR TITLE
fix: Include pyi for ty linting

### DIFF
--- a/examples/python/MODULE.bazel
+++ b/examples/python/MODULE.bazel
@@ -1,9 +1,9 @@
 "Bazel dependencies for Python formatting and linting example"
 
 bazel_dep(name = "aspect_rules_lint")
-bazel_dep(name = "aspect_rules_py", version = "1.6.6")
-bazel_dep(name = "bazel_skylib", version = "1.8.2")
-bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "aspect_rules_py", version = "1.8.4")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "1.8.1")
 bazel_dep(name = "rules_uv", version = "0.88.0")
 
 local_path_override(


### PR DESCRIPTION
* Include verbosity for `ty` checker when `LintOptionsInfo.debug` is enabled
* Use `--project` or `--config-file` when forwarding `pyproject.toml` for project, otherwise assume a `ty.toml` file. `ty` will implicitly assume to use `ty.toml` if found in path and why some folks haven't noticed this as an error. See https://docs.astral.sh/ty/reference/cli/#ty-check for details on `project` and `config-file`.
* Include `pyi` files for `ty` to pick up interface stub files.  

---


### Test plan

- Manual testing; please provide instructions so we can reproduce: 

```cd examples/python/ && bazel test //...```

Seems `//test:ruff_pyi_machine_output_test.uri` is actively failing on `main`