### PR TITLE
refactor(sarif): minor clean ups in sarif tool

### DIFF
--- a/tools/sarif/cmd/sarif/main.go
+++ b/tools/sarif/cmd/sarif/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/aspect-build/rules_lint/tools/sarif"
@@ -24,7 +23,7 @@ func main() {
 	}
 
 	// Read the lint report
-	report, err := ioutil.ReadFile(*inFile)
+	report, err := os.ReadFile(*inFile)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reading input file: %v\n", err)
 		os.Exit(1)
@@ -38,7 +37,7 @@ func main() {
 	}
 
 	// Write the SARIF JSON to output file
-	if err := ioutil.WriteFile(*outFile, []byte(sarifJsonString), 0644); err != nil {
+	if err := os.WriteFile(*outFile, []byte(sarifJsonString), 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "Error writing output file: %v\n", err)
 		os.Exit(1)
 	}

--- a/tools/sarif/sarif.go
+++ b/tools/sarif/sarif.go
@@ -30,12 +30,6 @@ import (
 	"github.com/reviewdog/reviewdog/parser"
 )
 
-type testStruct struct {
-	label    string
-	mnemonic string
-	report   string
-}
-
 func mnemonicPrettyName(mnemonic string) string {
 	return strings.Replace(mnemonic, "AspectRulesLint", "", 1)
 }
@@ -48,8 +42,7 @@ func ToSarifJsonString(label string, mnemonic string, report string) (sarifJsonS
 	}
 
 	if len(mnemonic) == 0 {
-		fmt.Sprintf("Undefined linter mnemonic for target %s\n", label)
-		return "", nil
+		return "", fmt.Errorf("Undefined linter mnemonic for target %s\n", label)
 	}
 
 	var fm []string
@@ -64,7 +57,7 @@ func ToSarifJsonString(label string, mnemonic string, report string) (sarifJsonS
 	case "AspectRulesLintPMD":
 		// TODO: upstream to https://github.com/reviewdog/errorformat/issues/62
 		fm = []string{`%f:%l:\\t%m`}
-  case "AspectRulesLintPylint":
+	case "AspectRulesLintPylint":
 		fm = []string{`%f:%l:%c: %m`}
 	case "AspectRulesLintRuff":
 		fm = []string{
@@ -106,7 +99,7 @@ func ToSarifJsonString(label string, mnemonic string, report string) (sarifJsonS
 			`%I%f:%l:%c: [info] %m`,
 		}
 	default:
-		fmt.Sprintf("No format string for linter mnemonic %s from target %s\n", mnemonic, label)
+		return "", fmt.Errorf("No format string for linter mnemonic %s from target %s\n", mnemonic, label)
 	}
 
 	if len(fm) == 0 {
@@ -169,7 +162,7 @@ func determineRelativePath(path string, label string) string {
 	}
 	relative_path := re.FindSubmatch([]byte(path))
 
-	if relative_path != nil && len(relative_path) == 2 {
+	if len(relative_path) == 2 {
 		return string(relative_path[1])
 	}
 


### PR DESCRIPTION
This PR includes a few minor cleanups of the Go SARIF processor in `//tools/sarif`. There is one user-visible change:

Currently, if you pass a missing or unknown mnemonic to the tool, it is silently accepted and produces an empty SARIF report. There are error messages included in the implementation, but they are no-ops: they simply call `fmt.Sprintf` to render a string which is then ignored.

This PR changes these to be errors that are surfaced up to the tool so you get build failures rather than producing empty SARIF reports.

I'm not sure if this has any user-visible impact or if it's purely a correctness improvement to the existing code.

Aside from that, some other minor cleanups:
* Remove unused structs
* Replace use of deprecated methods in `ioutil` with modern replacements
* Remove unnecessary nil check on slice

### Changes are visible to end-users: yes/no

Maybe. See above about improvements to error handling.

### Test plan

Tested locally against our repo with `local_path_override`.