### PR TITLE
fix(axl): exclude deleted files from formatting

### DIFF
--- a/format/format.axl
+++ b/format/format.axl
@@ -50,7 +50,7 @@ def find_changed_files(out, process, base_ref: str = "origin/main"):
     merge_base = spawn_with_output(out, process
         .command("git").args(["merge-base", "HEAD", base_ref]))
     return spawn_with_output(out, process
-        .command("git").args(["diff", "--name-only", merge_base]))
+        .command("git").args(["diff", "--diff-filter=d", "--name-only", merge_base]))
 
 # buildifier: disable=function-docstring
 def build_formatter(ctx: TaskContext) -> str:


### PR DESCRIPTION
The `format` aspect task uses `git diff --name-only MERGE_BASE` to detect changed files. However, by default, this command returns paths to deleted files. When trying to format these files, of course, the formatter fails.

This PR adds `--diff-filter=d` to the `git diff` command to filter out deleted files.