### PR TITLE
Fix two different crashes in the new clippy integration

### DIFF
--- a/lint/clippy.bzl
+++ b/lint/clippy.bzl
@@ -54,7 +54,7 @@ load("//lint/private:patcher_action.bzl", "patcher_attrs", "run_patcher")
 
 _MNEMONIC = "AspectRulesLintClippy"
 
-def _parse_wrapper_output_into_files(ctx, outputs, raw_process_wrapper_wrapper_output, fail_on_violation):
+def _parse_wrapper_output_into_files(ctx, outputs, raw_process_wrapper_wrapper_output):
     arguments = [
         raw_process_wrapper_wrapper_output.path,
         outputs.human.out.path,
@@ -64,6 +64,17 @@ def _parse_wrapper_output_into_files(ctx, outputs, raw_process_wrapper_wrapper_o
     ]
     command = """
 exit_code=$(head -n 1 $1)
+if [ "$exit_code" -eq 0 ]; then
+    # clippy exits with 0 (no error) with `-Wwarnings` (`-Dwarnings` is required
+    # to treat warnings as errors.  However, we want `fail_on_violation` to fail
+    # the build in case of warnings, too.
+    # We thus have to explicitly search for warnings in clippy's output message.
+    warning_count="$(grep -m1 -oP '\\d+(?= warnings emitted)' "$1")"
+    if [ -n "$warning_count" ] && [ "$warning_count" -ne 0 ]; then
+        exit_code=1
+    fi
+fi
+
 output=$(tail -n +2 $1)
 if [[ "${output}" != "" ]]; then
     echo "${output}" > $2
@@ -72,20 +83,16 @@ else
 fi
 """
 
-    if fail_on_violation:
-        command += """
-echo "${output}" >&2
-exit "${exit_code}"
-"""
-    else:
-        command += """
-echo "${exit_code}" > $3
-echo "${exit_code}" > $4
-"""
+    if outputs.human.exit_code and outputs.machine.exit_code:
         arguments.append(outputs.human.exit_code.path)
         arguments.append(outputs.machine.exit_code.path)
         outs.append(outputs.human.exit_code)
         outs.append(outputs.machine.exit_code)
+        command += """
+echo "${exit_code}" > $3
+echo "${exit_code}" > $4
+echo "${output}" >&2
+"""
 
     ctx.actions.run_shell(
         command = command,
@@ -134,8 +141,6 @@ def _clippy_aspect_impl(target, ctx):
         "-Wwarnings",
     ]
 
-    fail_on_violation = ctx.attr._options[LintOptionsInfo].fail_on_violation
-
     raw_output = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "raw_process_wrapper_wrapper_output_human"), sibling = sibling)
     raw_rustc_json_diagnostics = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "rustc_json_diagnostics"), sibling = sibling)
     raw_output = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "raw_process_wrapper_wrapper_output_human"), sibling = sibling)
@@ -152,7 +157,7 @@ def _clippy_aspect_impl(target, ctx):
         clippy_diagnostics_file = raw_rustc_json_diagnostics,
     )
 
-    _parse_wrapper_output_into_files(ctx, outputs, raw_output, fail_on_violation)
+    _parse_wrapper_output_into_files(ctx, outputs, raw_output)
     _parse_to_sarif_action(ctx, raw_rustc_json_diagnostics, outputs.machine.out)
 
     if patch_file != None:


### PR DESCRIPTION
This fixes two bugs producing crashes in the recent clippy (rust) integration,
* https://github.com/aspect-build/rules_lint/pull/731
* https://github.com/aspect-build/rules_lint/pull/724

---

Even with these patches, `fail_on_violation` doesn't work reliably in our repo.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce: tested in work repo