### PR TITLE
fix(sarif): pass full label to sarif tool

### DIFF
--- a/lint/private/lint_aspect.bzl
+++ b/lint/private/lint_aspect.bzl
@@ -234,7 +234,7 @@ def parse_to_sarif_action(ctx, mnemonic, raw_machine_report, sarif_out):
     args = ctx.actions.args()
     args.add("-in", raw_machine_report.path)
     args.add("-out", sarif_out.path)
-    args.add("-label", ctx.label.name)
+    args.add("-label", ctx.label)
     args.add("-mnemonic", mnemonic)
 
     ctx.actions.run(


### PR DESCRIPTION
The SARIF processor has logic in `determineRelativePath` to produce source-relative paths from absolute paths. This logic depends on parsing the `--label` flag to identify the containing Bazel package.

However, `parse_to_sarif_action` only passes `ctx.label.name` as the value for `--label` which excludes the package name. This short-circuits the logic to produce proper paths. This PR updates the argument to `ctx.label` which passes full label names.

I detected this when testing #711, which produces SARIF output paths of the form `../../../2700/execroot/_main/jvm/com/foo/Foo.scala` for a target `//jvm/com/foo:foo`. With this patch applied, it produces the expected output `jvm/com/foo/Foo.scala`.

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested Release Notes

- Fixed a bug in SARIF output processing which may have produced incorrect file paths in reports.

### Test plan

Tested manually. There should probably be end-to-end tests for this as well. However, the tests cases in `sarif_test.go` all use absolute Bazel labels which this PR plumbs `parse_to_sarif_action` to provide.