### PR TITLE
fix(ruff): suppress noisy 'All checks passed!' on success

### DIFF
--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -80,7 +80,7 @@ def ruff_action(ctx, executable, srcs, config, stdout, exit_code = None, env = {
     inputs = srcs + config
     if patch != None:
         # Use run_patcher for fix mode
-        args_list = ["check", "--fix", "--force-exclude"] + [s.path for s in srcs]
+        args_list = ["check", "--fix", "--force-exclude", "--quiet"] + [s.path for s in srcs]
         run_patcher(
             ctx,
             ctx.executable,
@@ -101,6 +101,7 @@ def ruff_action(ctx, executable, srcs, config, stdout, exit_code = None, env = {
         args = ctx.actions.args()
         args.add("check")
         args.add("--force-exclude")
+        args.add("--quiet")
         args.add_all(srcs)
 
         if exit_code:


### PR DESCRIPTION
## Summary
- Adds `--quiet` flag to all `ruff check` invocations (both lint and fix mode)
- Suppresses the "All checks passed!" stderr message that floods CI output for every target
- `--quiet` still prints diagnostics, just nothing else — so actual lint errors are unaffected

Fixes #753

## Test plan
- [x] `//test:ruff_should_ignore_generated` — PASSED
- [x] `//test:ruff_should_ignore_generated_filegroup` — PASSED
- [x] `//test:ruff_should_ignore_excluded` — PASSED
- [x] `//test:ruff_machine_output_test` — PASSED (SARIF output unaffected)
- [x] `//test:ruff_pyi_machine_output_test` — PASSED (SARIF output unaffected)
- [x] `bazel build --config=lint --output_groups=rules_lint_human //src:all` — success
- [x] `bazel build --config=lint --output_groups=rules_lint_patch --@aspect_rules_lint//lint:fix //src:all` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)