### PR TITLE
feat(clippy): allow passing custom clippy flags

### DIFF
--- a/lint/clippy.bzl
+++ b/lint/clippy.bzl
@@ -213,7 +213,7 @@ def lint_clippy_aspect(config, rule_kinds = DEFAULT_RULE_KINDS, clippy_flags = [
     Args:
         config (File): Label of the desired Clippy configuration file to use. Reference: https://doc.rust-lang.org/clippy/configuration.html
         rule_kinds (List[str]): List of rule kinds to lint. Defaults to {default_rule_kinds}.
-        clippy_flags (List[str]): Extra clippy/rustc lint flags (e.g. `-Dwarnings`, `-Aclippy::style`) appended after the default `-Wwarnings`.
+        clippy_flags (List[str]): Extra clippy/rustc lint flags (e.g. `-Dwarnings`, `-Aclippy::style`).
     """.format(default_rule_kinds = DEFAULT_RULE_KINDS)
     attrs = {
         "_options": attr.label(


### PR DESCRIPTION
Add clippy_flags to lint_clippy_aspect(...) and append them to the default -Wwarnings flags forwarded to rules_rust.

This enables passing arbitrary clippy/rustc lint flags, for example:

lint_clippy_aspect(config = "//:clippy.toml", clippy_flags = ["-Dwarnings"])

which elevates warnings to errors.