### PR TITLE
fix: Mark sarif toolchain repo rule as reproducible

### DIFF
--- a/tools/toolchains/sarif_parser_toolchain.bzl
+++ b/tools/toolchains/sarif_parser_toolchain.bzl
@@ -144,6 +144,12 @@ sarif_parser_toolchain(name = "sarif_parser_toolchain", bin = "{0}", visibility 
     # Base BUILD file for this repository
     rctx.file("BUILD.bazel", build_content)
 
+    # Bazel <8.3.0 lacks rctx.repo_metadata
+    if not hasattr(rctx, "repo_metadata"):
+        return None
+
+    return rctx.repo_metadata(reproducible = True)
+
 sarif_parser_platform_repo = repository_rule(
     implementation = _sarif_parser_platform_repo_impl,
     doc = "Fetch external tools needed for sarif_parser toolchain",


### PR DESCRIPTION
This allows the content produced by the repo rule to be fetched from the remote repo contents cache.