### PR TITLE
feat: Improve ty linter

### DIFF
--- a/tools/sarif/sarif.go
+++ b/tools/sarif/sarif.go
@@ -100,6 +100,12 @@ func ToSarifJsonString(label string, mnemonic string, report string) (sarifJsonS
 		}
 	case "AspectRulesLintKeepSorted":
 		fm = []string{`%f:%l:%e:%m`}
+	case "AspectRulesLintTy":
+		fm = []string{
+			`%Eerror%m`,
+			`%C\\ \\ -->\\ %f:%l:%c`,
+			`%-G%.%#`,
+		}
 	default:
 		return "", fmt.Errorf("No format string for linter mnemonic %s from target %s\n", mnemonic, label)
 	}


### PR DESCRIPTION
- Add sarif parsing for ty linting output
- Make colour output configurable
- Pass in extra parameters as a param file instead of directly on the command line

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Add sarif parsing for ty linting output. Make ty linter colour output configurable. Pass ty linter extra parameters as a param file instead of directly on the command line

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Tested locally using the Legacy Aspect CLI