### PR TITLE
feat(vale): Allow for usage of template

### DIFF
--- a/lint/vale.bzl
+++ b/lint/vale.bzl
@@ -78,8 +78,7 @@ def vale_action(ctx, executable, srcs, styles, config, stdout, exit_code = None,
         stdout: output file containing stdout of Vale
         exit_code: output file containing Vale exit code.
             If None, then fail the build when Vale exits non-zero.
-        template: an optional template file to use for the Vale command.
-        output: the value for the --output flag
+        output: the value for the --output flag. May be a string like 'line', 'JSON', 'CLI', or a File of a template to use: https://vale.sh/docs/templates
         env: environment variables for vale
     """
     inputs = srcs + [config]
@@ -95,9 +94,9 @@ def vale_action(ctx, executable, srcs, styles, config, stdout, exit_code = None,
     args = ctx.actions.args()
     args.add_all(srcs)
     args.add_all(["--config", config])
-    if template:
-        inputs.append(template)
-        args.add_all(["--output", template.path])
+    if type(output) == File:
+        inputs.append(output)
+        args.add_all(["--output", output.path])
     else:
         args.add_all(["--output", output])
     outputs = [stdout]


### PR DESCRIPTION
Related to issue: #775 

Adds support for templates with the vale lint action
---

### Changes are visible to end-users: yes/no

Doesn't break anything, and the function documentation has been updated.

Release note:
Vale added support for templates

### Test plan

Manually tested with template 

```
{{- /* Keep track of our various counts */ -}}
{{- $e := 0 -}}
{{- $w := 0 -}}
{{- $s := 0 -}}
{{- $f := 0 -}}

{{- range .Files -}}
  {{- $f = add1 $f -}}
  {{- $path := .Path -}} {{/* Capture path to use inside the nested loop */}}

  {{- range .Alerts -}}
    {{- /* Logic for severity color and counters */ -}}
    {{- $sevColor := "" -}}
    {{- if eq .Severity "error" -}}
        {{- $sevColor = .Severity | red -}}
        {{- $e = add1 $e -}}
    {{- else if eq .Severity "warning" -}}
        {{- $sevColor = .Severity | yellow -}}
        {{- $w = add1 $w -}}
    {{- else -}}
        {{- $sevColor = .Severity | blue -}}
        {{- $s = add1 $s -}}
    {{- end -}}

    {{- /* The Output Line */ -}}
    {{- printf "%s:%d:%d" $path .Line (index .Span 0) | underline -}}
    {{- printf " %s %s (%s)" $sevColor .Message .Check | indent 2 -}}
    {{- "\n" -}}
  {{- end -}}
{{- end -}}

{{- /* Summary */ -}}
{{- $e}} {{"errors" | red}}, {{$w}} {{"warnings" | yellow}} and {{$s}} {{"suggestions" | blue}} in {{$f}} {{$f | int | plural "file" "files"}}.
```