### PR TITLE
feat(ty): Quiet on success

### DIFF
--- a/lint/ty.bzl
+++ b/lint/ty.bzl
@@ -92,17 +92,31 @@ fi
 """.format(path = path)
 
     color_flag = "--color always" if color else "--color never"
+    command = """
+{extra_search_path_script}
+readonly TMP_OUT=$(mktemp)
+
+{ty} check --force-exclude {color_flag} @"$PARAM_FILE" $@ > "$TMP_OUT" 2>&1
+RET=$?
+
+if [ "$RET" -eq 0 ]; then
+    touch {stdout}
+else
+    cp "$TMP_OUT" {stdout}
+fi
+"""
 
     if exit_code:
-        command = """{extra_search_path_script}
-{ty} check --force-exclude {color_flag} @"$PARAM_FILE" $@ >{stdout}
-echo $? >{exit_code}
-"""
         outputs.append(exit_code)
+        command += """
+echo "$RET" > {exit_code}
+"""
     else:
-        # Create empty file on success, as Bazel expects one
-        command = """{extra_search_path_script}
-{ty} check --force-exclude {color_flag} @"$PARAM_FILE" $@ && touch {stdout}
+        command += """
+if [ "$RET" -ne 0 ]; then
+    cat "$TMP_OUT" >&2
+    exit "$RET"
+fi
 """
 
     ctx.actions.run_shell(


### PR DESCRIPTION
Related to #763 

Made ty not print all checks passed on success which overflows command line.

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: not needed
- Breaking change (forces users to change their own code or config): no, but yeah if they depended on the output for every file
- Suggested release notes appear below: Ty quiet on success

### Test plan

Tested manually against larger code base. Should also be reproducible on code provided in examples/.