### PR TITLE
fix: wire `base_ref` through as a task argument in format task (#781)

### DIFF
--- a/format/format.axl
+++ b/format/format.axl
@@ -94,7 +94,7 @@ def impl(ctx: TaskContext) -> int:
 
     format_args = []
     if not ctx.args.all_files:
-        changed_files = find_changed_files(out, ctx.std.process)
+        changed_files = find_changed_files(out, ctx.std.process, ctx.args.base_ref)
         out.write("Formatting changed files:\n%s\n" % changed_files)
         format_args = changed_files.split("\n")
 
@@ -113,6 +113,7 @@ format = task(
     implementation = impl,
     args = {
         "all_files": args.boolean(default = False),
+        "base_ref": args.string(default = "origin/main"),
         "formatter_target": args.string(default = "//tools/format"),
     },
 )


### PR DESCRIPTION
---
find_changed_files() accepts a base_ref parameter (defaulting to "origin/main"), but impl() never passed it through, and it wasn't exposed as a task arg. This wires ctx.args.base_ref into the find_changed_files() call and adds
base_ref to the task's args dict so users can customize the diff base.

Fixes #781

---
Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Users can now pass --base_ref to the format task to control which branch is used as the merge base when determining changed files. For example: aspect format --base_ref=origin/develop. The default remains origin/main.

Test plan

- Manual testing; please provide instructions so we can reproduce:

Run aspect format with no flags and verify it still diffs against origin/main. Then run aspect format --base_ref=<other-branch> and verify it diffs against the specified branch instead. Tested manually against our repo targeting
different branches.