### PR TITLE
fix(lint): Silence empty sarif reports

### DIFF
--- a/lint/lint.axl
+++ b/lint/lint.axl
@@ -48,9 +48,10 @@ def impl(ctx: TaskContext) -> int:
                     ctx.std.io.stderr.write(generated)
                 if file.name.endswith(".report"):
                     report = ctx.std.fs.read_to_string(filepath)
-                    ctx.std.io.stdout.write(report)
-                    if github_output:
-                        ctx.std.fs.write(github_output, "lint-report=" + filepath)
+                    if '"results": [' in report:
+                        ctx.std.io.stdout.write(report)
+                        if github_output:
+                            ctx.std.fs.write(github_output, "lint-report=" + filepath)
                 if file.name.endswith(".patch"):
                     patches.append(file.file.removeprefix("file://"))
                 if file.name.endswith(".exit_code"):


### PR DESCRIPTION
Avoids spamming the machine output with sarif reports with no issues.

Fixes #783 

---

### Changes are visible to end-users: yes/no

Machine linting now doesn't log sarif reports with no issues.

### Test plan

Tested manually against linters vale, ty, ruff and yamlint.