### PR TITLE
fix: argument list too long

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -179,15 +179,15 @@ function ls-files {
         # TODO: determine which staged changes we should format; avoid formatting unstaged changes
         # TODO: try to format only modified regions of the file (where supported)
         files=$(git ls-files -t --cached --modified --other --exclude-standard "${patterns[@]}" "${patterns[@]/#/*/}" | grep -v ^S | cut -f2- -d' ' | {
-          grep -vE \
-            "^$(git ls-files --deleted)$" \
+          grep -vFxf \
+            <(git ls-files --deleted) \
           || true;
         })
 
         if [ -n "$shebang_re" ]; then
             for candidate in $(git ls-files -t --cached --modified --other --exclude-standard | grep -v ^S | cut -f2- -d' ' | grep -v '\.' | {
-                grep -vE \
-                "^$(git ls-files --deleted)$" \
+                grep -vFxf \
+                <(git ls-files --deleted) \
                 || true;
             }); do
                 [ -f "$candidate" ] || continue


### PR DESCRIPTION
This patch passes the file list using process substitution instead of inline to avoid "argument list too long" errors with many deleted files.

---

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:

fixes the error in our repo