### PR TITLE
feat: expose --bazel_flag and --bazel_startup_flag in lint and format…

### DIFF
--- a/format/format.axl
+++ b/format/format.axl
@@ -56,13 +56,17 @@ def find_changed_files(out, process, base_ref: str = "origin/main"):
 def build_formatter(ctx: TaskContext) -> str:
     ctx.std.io.stdout.write("Building formatter...\n")
 
+    flags = [
+        "--build_runfile_links",
+        "--noallow_analysis_cache_discard",
+    ]
+    flags.extend(ctx.args.bazel_flag)
+
     build = ctx.bazel.build(
         ctx.args.formatter_target,
         build_events = True,
-        flags = [
-            "--build_runfile_links",
-            "--noallow_analysis_cache_discard",
-        ],
+        flags = flags,
+        startup_flags = list(ctx.args.bazel_startup_flag),
     )
 
     # Find the entrypoint by watching for the named_set_of_files build event.
@@ -115,5 +119,7 @@ format = task(
         "all_files": args.boolean(default = False),
         "base_ref": args.string(default = "origin/main"),
         "formatter_target": args.string(default = "//tools/format"),
+        "bazel_flag": args.string_list(),
+        "bazel_startup_flag": args.string_list(),
     },
 )

--- a/lint/lint.axl
+++ b/lint/lint.axl
@@ -31,8 +31,11 @@ def impl(ctx: TaskContext) -> int:
     # echo > nohup.out; nohup aspect lint ; cat nohup.out
     flags.append("--output_groups=rules_lint_" + (
         "human" if ctx.std.io.stdout.is_tty else "machine"))
+    flags.extend(ctx.args.bazel_flag)
+
     build = ctx.bazel.build(
         flags = flags,
+        startup_flags = list(ctx.args.bazel_startup_flag),
         build_events = True,
         *(ctx.args.targets or ["//..."])
     )
@@ -69,5 +72,7 @@ lint = task(
     args = {
         "fix": args.boolean(),
         "targets": args.positional(minimum = 0),
+        "bazel_flag": args.string_list(),
+        "bazel_startup_flag": args.string_list(),
     },
 )


### PR DESCRIPTION
---
The built-in build and test tasks accept --bazel_flag and --bazel_startup_flag, allowing users to pass additional flags through to the underlying Bazel invocation. The lint and format tasks did not, making it impossible to pass flags
 like --config=ci or --remote_cache without global .bazelrc workarounds.

User-supplied flags are appended after the task's hardcoded flags (e.g. --config=lint, --build_runfile_links) so that Bazel's last-wins semantics allow overrides where appropriate. The implementation matches the pattern used by the
built-in tasks in aspect-cli.

Closes #787

---
Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no, there is no task-specific documentation in this repo
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

aspect lint and aspect format now accept --bazel_flag and --bazel_startup_flag for passing additional flags to the underlying Bazel invocation, matching the built-in build and test tasks.

Test plan

- Manual testing:
  a. aspect lint --bazel_flag=--config=ci //...
  b. aspect format --bazel_flag=--remote_cache=...
  c. Verify flags appear in the Bazel command invocation and do not conflict with hardcoded flags