### PR TITLE
fix(buf): set error severity in SARIF output for buf lint violations

### DIFF
--- a/tools/sarif/sarif.go
+++ b/tools/sarif/sarif.go
@@ -68,7 +68,8 @@ func ToSarifJsonString(label string, mnemonic string, report string) (sarifJsonS
 		}
 	case "AspectRulesLintBuf":
 		fm = []string{
-			`--buf-plugin_out: %f:%l:%c:%m`,
+			`%E--buf-plugin_out: %f:%l:%c:%m`,
+			`%-Z%r`,
 		}
 	case "AspectRulesLintVale":
 		fm = []string{`%f:%l:%c:%m`}


### PR DESCRIPTION
The buf errorformat string was missing the %E prefix, so the SARIF output did not include "level": "error" for buf lint violations. This caused violations to default to warning severity, which meant they were not treated as failures by CI systems that check the SARIF level.

This matches the pattern already used by the Ruff and Ty linters.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Test plan

- Manual testing; please provide instructions so we can reproduce: this fixed enforcement via Aspect Workflows in our internal repo.

Suggested release notes:
set error severity in SARIF output for buf lint violations