### PR TITLE
fix(stylelint): Separate fix and report actions so violations are always printed

### DIFF
--- a/lint/stylelint.bzl
+++ b/lint/stylelint.bzl
@@ -168,8 +168,20 @@ def _stylelint_aspect_impl(target, ctx):
         outputs.human.out,
         outputs.human.exit_code,
         options = color_options,
-        patch = getattr(outputs, "patch", None),
     )
+    if ctx.attr._options[LintOptionsInfo].fix:
+        _exit_code = ctx.actions.declare_file(OUTFILE_FORMAT.format(
+            label = target.label.name, mnemonic = _MNEMONIC, suffix = "patch.exit_code"
+        ))
+        stylelint_action(
+            ctx,
+            ctx.executable,
+            files_to_lint,
+            None,
+            _exit_code,
+            options = color_options,
+            patch = outputs.patch,
+        )
 
     raw_machine_report = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "raw_machine_report"))
 


### PR DESCRIPTION
Passing `patch` to the report action caused stylelint to run with `--fix`, silently auto-fixing *without printing any violations*.

Now the report action always runs without `--fix`; when fix mode is active, a dedicated patcher action applies the fixes separately.

---

### Changes are visible to end-users: yes

stylelint users will now see the report in fix mode.

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Run the linter in fix mode, or use `bazel lint ...` on code linted with stylelint. The behavior triggering this patch (no output with `--fix`) is also reproducible without Bazel.

```
/* test.css - intentional stylelint violations */

/* error: selector-class-pattern — no selectors allowed in css files */
.foo {
  /* fixable: color-hex-length — #ff0000 should be #f00 */
  color: #ff0000;

  /* fixable: color-hex-length + color-hex-case — uppercase and not shortened */
  background-color: #AABBCC;

  /* error: color-no-invalid-hex */
  border-color: #gg0000;

  /* error: unit-no-unknown */
  margin: 4unknownpx;

  /* error: property-no-unknown */
  colour: blue;
}
```
and
```
% stylelint test.css 2>&1 | grep problems
✖ 6 problems (6 errors, 0 warnings)
% stylelint --fix test.css 2>&1 | grep problems
✖ 4 problems (4 errors, 0 warnings)
```
going from 6 to 4 with fix, the fixable problems are not reported.