### PR TITLE
fix(ruff): ruff sarif report

### DIFF
--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -103,6 +103,8 @@ def ruff_action(ctx, executable, srcs, config, stdout, exit_code = None, env = {
         args.add("--force-exclude")
         args.add("--quiet")
         args.add_all(srcs)
+        if not env.get("FORCE_COLOR"):
+            args.add("--output-format=concise")
 
         if exit_code:
             command = "{ruff} $@ >{stdout}; echo $? >" + exit_code.path


### PR DESCRIPTION
Fixes: #802

Makes ruff report sarif output when run in non-TTY terminal mode.
Another fix would maybe have been to change tools/sarif.go, but this at least solves the issue.