### PR TITLE
fix(ty): improve generated file handling

### DIFF
--- a/examples/python/BUILD
+++ b/examples/python/BUILD
@@ -36,3 +36,16 @@ pip_compile(
     requirements_in = "pyproject.toml",
     requirements_txt = "requirements.txt",
 )
+
+
+write_file(
+    name = "root_py_code_generator",
+    out = "generated.py",
+    content = ["import os"],
+)
+
+py_library(name = "root_generated",
+           srcs = ["//:generated.py"],
+           imports = ["."],
+           visibility = ["//visibility:public"],
+)

--- a/examples/python/BUILD
+++ b/examples/python/BUILD
@@ -36,4 +36,3 @@ pip_compile(
     requirements_in = "pyproject.toml",
     requirements_txt = "requirements.txt",
 )
-

--- a/examples/python/BUILD
+++ b/examples/python/BUILD
@@ -37,15 +37,3 @@ pip_compile(
     requirements_txt = "requirements.txt",
 )
 
-
-write_file(
-    name = "root_py_code_generator",
-    out = "generated.py",
-    content = ["import os"],
-)
-
-py_library(name = "root_generated",
-           srcs = ["//:generated.py"],
-           imports = ["."],
-           visibility = ["//visibility:public"],
-)

--- a/examples/python/MODULE.bazel
+++ b/examples/python/MODULE.bazel
@@ -5,10 +5,16 @@ bazel_dep(name = "aspect_rules_py", version = "1.8.4")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "rules_python", version = "1.8.1")
 bazel_dep(name = "rules_uv", version = "0.88.0")
+bazel_dep(name = "ext_mod")
 
 local_path_override(
     module_name = "aspect_rules_lint",
     path = "../..",
+)
+
+local_path_override(
+    module_name = "ext_mod",
+    path = "ext_mod",
 )
 
 python_version = "3.9"

--- a/examples/python/ext_mod/MODULE.bazel
+++ b/examples/python/ext_mod/MODULE.bazel
@@ -1,0 +1,4 @@
+module(name = "ext_mod")
+
+bazel_dep(name = "rules_python", version = "1.8.1")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/examples/python/ext_mod/src/BUILD
+++ b/examples/python/ext_mod/src/BUILD
@@ -1,0 +1,14 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_python//python:defs.bzl", "py_library")
+
+write_file(
+    name = "py_code_generator",
+    out = "generated.py",
+    content = ["import os"],
+)
+
+py_library(name = "generated",
+           srcs = [":generated.py"],
+           imports = ["."],
+           visibility = ["//visibility:public"],
+)

--- a/examples/python/test/BUILD
+++ b/examples/python/test/BUILD
@@ -113,6 +113,40 @@ pydoclint_test(
     expected_exit_code = 1,
 )
 
+
+py_library(name = "dep_root_generated",
+           srcs = ["dep_generated.py"],
+           deps = ["//:root_generated"])
+
+ty_test(
+    name = "ty_should_find_generated_dep_at_root",
+    srcs = [":dep_root_generated"]
+)
+
+
+py_library(name = "generated",
+           srcs = ["generated.py"],
+           imports = ["."])
+
+py_library(name = "dep_generated",
+           srcs = ["dep_generated.py"],
+           deps = [":generated"])
+
+ty_test(
+    name = "ty_should_find_generated_dep",
+    srcs = [":dep_generated"]
+)
+
+py_library(name = "dep_ext_generated",
+           srcs = ["dep_generated.py"],
+           deps = ["@ext_mod//src:generated"]
+)
+
+ty_test(
+    name = "ty_should_find_ext_generated_dep",
+    srcs = [":dep_ext_generated"]
+)
+
 ty_test(
     name = "ty_should_fail_unsupported_operator",
     srcs = ["//src:unsupported_operator"],

--- a/examples/python/test/BUILD
+++ b/examples/python/test/BUILD
@@ -114,16 +114,6 @@ pydoclint_test(
 )
 
 
-py_library(name = "dep_root_generated",
-           srcs = ["dep_generated.py"],
-           deps = ["//:root_generated"])
-
-ty_test(
-    name = "ty_should_find_generated_dep_at_root",
-    srcs = [":dep_root_generated"]
-)
-
-
 py_library(name = "generated",
            srcs = ["generated.py"],
            imports = ["."])

--- a/examples/python/test/dep_generated.py
+++ b/examples/python/test/dep_generated.py
@@ -1,0 +1,1 @@
+import generated

--- a/lint/ty.bzl
+++ b/lint/ty.bzl
@@ -141,21 +141,24 @@ def _resolve_import_path(import_path, workspace_name, bin_dir_path):
 
     Workspace-internal paths start with the workspace name (e.g. "_main/pkg/src")
     and live directly under the execroot — they must NOT be prefixed with "external/".
+    if they're generated, then it will be relative to bazel bin dir
     External paths (pip packages) live under "external/" in the execroot.
 
     Args:
         import_path: an entry from PyInfo.imports
         workspace_name: ctx.workspace_name (e.g. "_main")
-        bin_dir_path: ctx.bin_dir.path
+        bin_dir_path: ctx.bin_dir.path, used for generated file path
 
     Returns:
-        The corrected path string, or None if the path should be skipped.
+        The corrected path string list (some of them might not exist)
     """
     if import_path == workspace_name or import_path == ".":
-        return bin_dir_path
+        return [bin_dir_path]
     if import_path.startswith(workspace_name + "/"):
-        return import_path[len(workspace_name) + 1:]
-    return "external/" + import_path
+        rel = import_path[len(workspace_name) + 1:]
+        return [rel, bin_dir_path + "/" + rel]
+    external_rel = "external/" + import_path
+    return [external_rel, bin_dir_path + "/" + external_rel]
 
 # buildifier: disable=function-docstring
 def _ty_aspect_impl(target, ctx):
@@ -179,8 +182,8 @@ def _ty_aspect_impl(target, ctx):
                 transitive_sources.append(dep[PyInfo].transitive_pyi_files)
                 for import_path in dep[PyInfo].imports.to_list():
                     resolved = _resolve_import_path(import_path, ctx.workspace_name, ctx.bin_dir.path)
-                    if resolved:
-                        import_paths[resolved] = True
+                    for e in resolved:
+                        import_paths[e] = True
 
     # When srcs contain labels to other targets (e.g., genrules that produce .py files),
     # we need to collect their transitive sources for proper type resolution
@@ -191,8 +194,8 @@ def _ty_aspect_impl(target, ctx):
                 transitive_sources.append(src[PyInfo].transitive_pyi_files)
                 for import_path in src[PyInfo].imports.to_list():
                     resolved = _resolve_import_path(import_path, ctx.workspace_name, ctx.bin_dir.path)
-                    if resolved:
-                        import_paths[resolved] = True
+                    for e in resolved:
+                        import_paths[e] = True
 
     files_to_lint = filter_srcs(ctx.rule)
     outputs, info = output_files(_MNEMONIC, target, ctx)


### PR DESCRIPTION
<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

 if dep contains generated source file, it will be placed under ctx.bin_path, for example generated source file from external module will be placed under `./bazel-out/k8-fastbuild/bin/external/ext_mod+/src/generated.py` and in-workspace ones will be placed under `./bazel-out/k8-fastbuild/bin/test/generated.py`.  currently they're not added to extra search path, leads `Cannot resolve imported module` error 

this PR tries to improve this

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): yes, user may observe different lint errors due to generated source also being considered
- Suggested release notes appear below: yes
  generated source files also being considered during linting

### Test plan

- New test cases added