### PR TITLE
fix(ty): output arrow alignment

### DIFF
--- a/tools/sarif/sarif.go
+++ b/tools/sarif/sarif.go
@@ -118,7 +118,7 @@ func ToSarifJsonString(label string, mnemonic string, report string) (sarifJsonS
 	case "AspectRulesLintTy":
 		fm = []string{
 			`%Eerror%m`,
-			`%C\\ \\ -->\\ %f:%l:%c`,
+			`%C\\ %#-->\\ %f:%l:%c`,
 			`%-G%.%#`,
 		}
 	default:


### PR DESCRIPTION
the arrow is aligned with line number, not at a fixed column



---

### Changes are visible to end-users: yes

user may observe ty sarif json is no longer empty and now contains additional information.

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes
user may observe ty sarif json is no longer empty and now contains additional information.

### Test plan

- Manual testing; please provide instructions so we can reproduce:

create a python file with lint error at different lines ( 1-9 or 10-99), second line arrow output alignment will change 