### PR TITLE
feat: Add SARIF handling for cppcheck

### DIFF
--- a/examples/cpp/src/cpp/lib/BUILD
+++ b/examples/cpp/src/cpp/lib/BUILD
@@ -16,6 +16,6 @@ cc_library(
         "xhello-time.h",
     ],
     includes = ["."],
-    local_defines = ["LOCAL_DEFINE_IS_DEFINED=\"a_string\""],
+    local_defines = ["LOCAL_DEFINE_IS_DEFINED=\\\"a_string\\\""],
     visibility = ["//src/cpp/main:__pkg__"],
 )

--- a/tools/sarif/sarif.go
+++ b/tools/sarif/sarif.go
@@ -80,6 +80,16 @@ func ToSarifJsonString(label string, mnemonic string, report string) (sarifJsonS
 		}
 	case "AspectRulesLintVale":
 		fm = []string{`%f:%l:%c:%m`}
+	case "AspectRulesLintCppCheck":
+		fm = []string{
+			`%f:%l:%c: %trror: %m`,
+			`%f:%l:%c: %tarning: %m`,
+			`%f:%l:%c: %tyle: %m`,
+			`%f:%l:%c: %terformance: %m`,
+			`%f:%l:%c: %tortability: %m`,
+			`%f:%l:%c: %tnformation: %m`,
+			`%-G%.%#`,
+		}
 	case "AspectRulesLintClangTidy":
 		fm = []string{
 			`%f:%l:%c: %trror: %m`,

--- a/tools/sarif/sarif_test.go
+++ b/tools/sarif/sarif_test.go
@@ -65,6 +65,22 @@ func TestSarif(t *testing.T) {
 		g.Expect(sarifJson.Runs[0].Results[0].Locations[0].PhysicalLocation.Region.GetRdfRange().Start.Line).To(Equal(int32(4)))
 	})
 
+	t.Run("processes cppcheck output -> sarif correctly", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		sarifJsonString, _ := ToSarifJsonString("//src:hello_cc", "AspectRulesLintCppCheck", cppcheck_output)
+		sarifJson, _ := toSarifJson(sarifJsonString)
+
+		g.Expect(len(sarifJson.Runs)).To(Equal(1))
+		g.Expect(sarifJson.Runs[0].Tool.Driver.Name).To(Equal("CppCheck"))
+		g.Expect(len(sarifJson.Runs[0].Results)).To(Equal(2))
+		g.Expect(sarifJson.Runs[0].Results[0].Message.Text).To(Equal("Memory leak: ptr [memleak]"))
+		g.Expect(sarifJson.Runs[0].Results[1].Message.Text).To(Equal("Variable 'x' is assigned a value that is never used. [unreadVariable]"))
+		g.Expect(sarifJson.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI).To(Equal("src/hello.cc"))
+		g.Expect(sarifJson.Runs[0].Results[0].Locations[0].PhysicalLocation.Region.GetRdfRange().Start.Line).To(Equal(int32(10)))
+		g.Expect(sarifJson.Runs[0].Results[1].Locations[0].PhysicalLocation.Region.GetRdfRange().Start.Line).To(Equal(int32(15)))
+	})
+
 	t.Run("determineRelativePath: returns relative paths untouched", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 

--- a/tools/sarif/statics_test.go
+++ b/tools/sarif/statics_test.go
@@ -68,6 +68,9 @@ var qmllint_output string
 //go:embed testdata/lint_result/pydoclint_output.txt
 var pydoclint_output string
 
+//go:embed testdata/lint_result/cppcheck_output.txt
+var cppcheck_output string
+
 type LintResult struct {
 	Label    string
 	Mnemonic string

--- a/tools/sarif/testdata/lint_result/cppcheck_output.txt
+++ b/tools/sarif/testdata/lint_result/cppcheck_output.txt
@@ -1,0 +1,4 @@
+/some_absolute_path/sandbox/linux-sandbox/1/execroot/_main/src/hello.cc:10:5: error: Memory leak: ptr [memleak]
+    int *ptr = new int;
+    ^
+/some_absolute_path/sandbox/linux-sandbox/1/execroot/_main/src/hello.cc:15:3: warning: Variable 'x' is assigned a value that is never used. [unreadVariable]


### PR DESCRIPTION
- Add SARIF handling for cppcheck
- Fix `local_defines` in `examples/cpp/src/cpp/lib/BUILD`

Close #569

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below:
   Add SARIF handling for cppcheck

### Test plan

- New test cases added for cppcheck