### PR TITLE
fix: Load `CcInfo` and `cc_common`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,6 +33,7 @@ bazel_dep(name = "rules_multirun", version = "0.9.0")
 bazel_dep(name = "rules_multitool", version = "0.11.0")
 bazel_dep(name = "rules_shell", version = "0.5.0")
 bazel_dep(name = "rules_java", version = "7.0.6")
+bazel_dep(name = "rules_cc", version = "0.2.0")
 
 # Needed in the root because we use the run_clippy action in our aspect impl
 bazel_dep(name = "rules_rust", version = "0.67.0")

--- a/lint/clang_tidy.bzl
+++ b/lint/clang_tidy.bzl
@@ -40,6 +40,7 @@ clang_tidy = lint_clang_tidy_aspect(
 load("@bazel_skylib//rules/directory:providers.bzl", "DirectoryInfo")
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OPTIONAL_SARIF_PARSER_TOOLCHAIN", "OUTFILE_FORMAT", "noop_lint_action", "output_files", "parse_to_sarif_action", "patch_and_output_files", "should_visit")
 load("//lint/private:patcher_action.bzl", "patcher_attrs", "run_patcher")
 
@@ -455,6 +456,7 @@ def lint_clang_tidy_aspect(
             passes these as -isystem. Change this to False to pass these as -I, which allows clang-tidy to regard
             them as regular header files.
         verbose: print debug messages including clang-tidy command lines being invoked.
+        rule_kinds: which target kinds should be visited automatically
     """
 
     if type(global_config) == "string":

--- a/lint/cppcheck.bzl
+++ b/lint/cppcheck.bzl
@@ -2,6 +2,7 @@
 """
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc:defs.bzl", "CcInfo")
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OPTIONAL_SARIF_PARSER_TOOLCHAIN", "OUTFILE_FORMAT", "noop_lint_action", "output_files", "parse_to_sarif_action")
 
 _MNEMONIC = "AspectRulesLintCppCheck"


### PR DESCRIPTION
Load `CcInfo` and `cc_common` for Bazel 9 compatibility, fixes https://github.com/aspect-build/rules_lint/issues/835