### PR TITLE
fix(shellcheck): add deps as source inputs

### DIFF
--- a/examples/shell/.shellcheckrc
+++ b/examples/shell/.shellcheckrc
@@ -4,6 +4,8 @@ enable=quote-safe-variables
 # Turn on warnings for unassigned uppercase variables
 enable=check-unassigned-uppercase
 
+# Permit following `source` statements into sh_library deps.
+external-sources=true
+
 # Allow [ ! -z foo ] instead of suggesting -n
 disable=SC2236
-

--- a/examples/shell/src/BUILD
+++ b/examples/shell/src/BUILD
@@ -8,9 +8,24 @@ sh_library(
     srcs = ["hello.sh"],
 )
 
+sh_library(
+    name = "sourced_dep",
+    srcs = ["sourced_dep.sh"],
+)
+
+sh_library(
+    name = "sourced_main",
+    srcs = ["sourced_main.sh"],
+    deps = [":sourced_dep"],
+)
+
 # Cause a test failure when files are not formatted.
 # This is useful when you have no other way to check formatting on CI; see documentation.
 format_test(
     name = "format_files_test",
-    srcs = ["hello.sh"],
+    srcs = [
+        "hello.sh",
+        "sourced_dep.sh",
+        "sourced_main.sh",
+    ],
 )

--- a/examples/shell/src/sourced_dep.sh
+++ b/examples/shell/src/sourced_dep.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sourced_message() {
+    [ -z $1 ] && echo "missing value"
+    printf 'hello %s\n' "$1"
+}

--- a/examples/shell/src/sourced_main.sh
+++ b/examples/shell/src/sourced_main.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source src/sourced_dep.sh
+
+message="$(sourced_message "${1:-world}")"
+printf '%s\n' "$message"

--- a/examples/shell/test/BUILD
+++ b/examples/shell/test/BUILD
@@ -1,5 +1,5 @@
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_lint//lint/private:machine_report_testing.bzl", "report_test")
+load("@aspect_rules_lint//lint/private:machine_report_testing.bzl", "report_results_count_test", "report_test")
 load("//test:machine_output.bzl", "machine_shellcheck_report")
 load("//tools/lint:linters.bzl", "shellcheck_test")
 
@@ -11,9 +11,30 @@ shellcheck_test(
     expected_exit_code = 1,
 )
 
+shellcheck_test(
+    name = "shellcheck_sourced_main",
+    srcs = ["//src:sourced_main"],
+)
+
+shellcheck_test(
+    name = "shellcheck_sourced_dep",
+    srcs = ["//src:sourced_dep"],
+    expected_exit_code = 1,
+)
+
 machine_shellcheck_report(
     name = "machine_shellcheck_report",
     src = "//src:hello",
+)
+
+machine_shellcheck_report(
+    name = "machine_sourced_main_report",
+    src = "//src:sourced_main",
+)
+
+machine_shellcheck_report(
+    name = "machine_sourced_dep_report",
+    src = "//src:sourced_dep",
 )
 
 report_test(
@@ -21,4 +42,17 @@ report_test(
     expected_tool = "ShellCheck",
     expected_uri = "src/hello.sh",
     report = "machine_shellcheck_report",
+)
+
+report_results_count_test(
+    name = "sourced_main_machine_output_empty_test",
+    expected_count = 0,
+    report = "machine_sourced_main_report",
+)
+
+report_test(
+    name = "sourced_dep_machine_output_test",
+    expected_tool = "ShellCheck",
+    expected_uri = "src/sourced_dep.sh",
+    report = "machine_sourced_dep_report",
 )

--- a/lint/private/machine_report_testing.bzl
+++ b/lint/private/machine_report_testing.bzl
@@ -30,6 +30,17 @@ def report_test(name, report, expected_tool, expected_uri):
         filter2 = "\"%s\"" % expected_uri,
     )
 
+def report_results_count_test(name, report, expected_count):
+    """Test the number of SARIF results in a machine-readable report."""
+
+    jq_test(
+        name = name,
+        file1 = report,
+        file2 = report,
+        filter1 = "(.runs[].results // []) | length",
+        filter2 = str(expected_count),
+    )
+
 def _machine_report(ctx):
     """Implementation for machine report rules that extract SARIF reports from linted targets."""
     files = ctx.attr.src[OutputGroupInfo].rules_lint_machine.to_list()

--- a/lint/shellcheck.bzl
+++ b/lint/shellcheck.bzl
@@ -19,7 +19,7 @@ load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OPTIONAL_SARIF_PARSER
 
 _MNEMONIC = "AspectRulesLintShellCheck"
 
-def shellcheck_action(ctx, executable, srcs, config, stdout, exit_code = None, options = []):
+def shellcheck_action(ctx, executable, srcs, transitive_srcs, config, stdout, exit_code = None, options = []):
     """Run shellcheck as an action under Bazel.
 
     Based on https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md
@@ -28,6 +28,7 @@ def shellcheck_action(ctx, executable, srcs, config, stdout, exit_code = None, o
         ctx: Bazel Rule or Aspect evaluation context
         executable: label of the shellcheck program
         srcs: bash files to be linted
+        transitive_srcs: depset of sourced shell files required for source resolution
         config: label of the .shellcheckrc file
         stdout: output file containing stdout of shellcheck
         exit_code: output file containing shellcheck exit code.
@@ -35,7 +36,7 @@ def shellcheck_action(ctx, executable, srcs, config, stdout, exit_code = None, o
             See https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md#return-values
         options: additional command-line options, see https://github.com/koalaman/shellcheck/blob/master/shellcheck.hs#L95
     """
-    inputs = srcs + [config]
+    inputs = depset(srcs + [config], transitive = [transitive_srcs])
 
     # Wire command-line options, see
     # https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md#options
@@ -69,6 +70,15 @@ def _shellcheck_aspect_impl(target, ctx):
     if not should_visit(ctx.rule, ctx.attr._rule_kinds):
         return []
 
+    transitive_sources = []
+    if hasattr(ctx.rule.attr, "deps"):
+        # rules_shell exposes sh_library sources through target.files.
+        # Provide those files as action inputs so ShellCheck can resolve `source`
+        # statements without linting deps as separate command-line arguments.
+        for dep in ctx.rule.attr.deps:
+            transitive_sources.append(dep.files)
+    transitive_srcs = depset(transitive = transitive_sources)
+
     files_to_lint = filter_srcs(ctx.rule)
     if ctx.attr._options[LintOptionsInfo].fix:
         outputs, info = patch_and_output_files(_MNEMONIC, target, ctx)
@@ -86,11 +96,11 @@ def _shellcheck_aspect_impl(target, ctx):
     # So we must run an action to generate the report separately from an action that writes the human-readable report.
     if hasattr(outputs, "patch"):
         discard_exit_code = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "patch_exit_code"))
-        shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, outputs.patch, discard_exit_code, ["--format", "diff"])
+        shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, transitive_srcs, ctx.file._config_file, outputs.patch, discard_exit_code, ["--format", "diff"])
 
-    shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, outputs.human.out, outputs.human.exit_code, color_options + config_options)
+    shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, transitive_srcs, ctx.file._config_file, outputs.human.out, outputs.human.exit_code, color_options + config_options)
     raw_machine_report = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "raw_machine_report"))
-    shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, ctx.file._config_file, raw_machine_report, outputs.machine.exit_code, config_options)
+    shellcheck_action(ctx, ctx.executable._shellcheck, files_to_lint, transitive_srcs, ctx.file._config_file, raw_machine_report, outputs.machine.exit_code, config_options)
 
     # Shellcheck does not have a SARIF output format built-in.
     # We could use https://crates.io/crates/shellcheck-sarif but don't want to introduce a Rust dependency.


### PR DESCRIPTION
## Summary
- add `deps` files as ShellCheck action inputs so sourced `sh_library` files are available in the sandbox
- keep the ShellCheck command line limited to the target's direct `srcs`, so deps are extra source inputs rather than double-linted arguments
- add a shell example regression that proves a target can source a dep cleanly while the dep is still linted on its own target

## Testing
- `cd examples/shell && USE_BAZEL_VERSION=8.x bazel test //test:shellcheck_sourced_main //test:sourced_main_machine_output_empty_test`
- `cd examples/shell && USE_BAZEL_VERSION=8.x bazel test //test:shellcheck_sourced_dep //test:sourced_dep_machine_output_test //test:sourced_dep_machine_output_test.uri`
- `cd examples/shell && USE_BAZEL_VERSION=8.x bazel test //test:all`
- `cd examples/shell && USE_BAZEL_VERSION=8.x bazel build --config=lint --output_groups=rules_lint_human //...`
- `cd examples/shell && USE_BAZEL_VERSION=8.x bazel build --config=lint --output_groups=rules_lint_patch --@aspect_rules_lint//lint:fix //...`
