### PR TITLE
fix(format): quote path args so find doesn't word-split

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -286,7 +286,7 @@ function run-format {
   local args="$1" && shift
   local TIMEFORMAT="Formatted ${lang} in %lR"
 
-  local files=$(ls-files "$lang" $@)
+  local files=$(ls-files "$lang" "$@")
   if [ -n "$files" ] && [ -n "$bin" ]; then
     case "$lang" in
       'Protocol Buffer')

--- a/format/test/ls-files_test.sh
+++ b/format/test/ls-files_test.sh
@@ -92,6 +92,23 @@ go=$(ls-files Go src.go)
     exit 1
 }
 
+# when a path argument contains spaces (e.g. a Go template directory like
+# 'foo/{{ .X }}/bar.tf'), the path must reach `find` as a single argument
+# instead of being word-split into 'foo/{{', '.X', '}}/bar.tf'.
+mkdir -p 'templated/{{ .X }}'
+touch 'templated/{{ .X }}/file.tf'
+git add .
+git commit --all --message 'add templated tf path'
+tf=$(ls-files Terraform 'templated/{{ .X }}/file.tf' 2>/tmp/ls-files-stderr)
+[[ "$tf" == 'templated/{{ .X }}/file.tf' ]] || {
+    echo >&2 -e "expected ls-files to return the templated tf path, was\n$tf"
+    exit 1
+}
+[[ ! -s /tmp/ls-files-stderr ]] || {
+    echo >&2 -e "expected no stderr from ls-files, was\n$(cat /tmp/ls-files-stderr)"
+    exit 1
+}
+
 # sparse-checkout should be supported
 mkdir tree1 tree2
 touch tree1/src.js tree2/src.js


### PR DESCRIPTION
When run-format invoked ls-files with $@ unquoted, file path arguments containing whitespace (e.g. "/some/path with spaces/file.tf") were word-split by the shell before reaching find. find then complained:

    find: '/some/path': No such file or directory
    find: 'with': No such file or directory
    find: 'spaces/file.tf': No such file or directory

Quote the expansion. Add a regression test for the args branch of ls-files exercising a path with whitespace.

---

### Changes are visible to end-users: no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
