### PR TITLE
feat(format): support formatting of go.mod and go.work files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Linters which are not language-specific:
 | CSS, Less, Sass        | [Prettier]                | [Stylelint]                                             |
 | F#                     | [Fantomas]                |                                                         |
 | Go                     | [gofmt] or [gofumpt]      |                                                         |
+| Go Module              | [modfmt]                  |                                                         |
 | Gherkin                | [prettier-plugin-gherkin] |                                                         |
 | GraphQL                | [Prettier]                |                                                         |
 | HCL (Hashicorp Config) | [terraform] fmt           |                                                         |
@@ -90,6 +91,7 @@ Linters which are not language-specific:
 [prettier/plugin-xml]: https://github.com/prettier/plugin-xml
 [gofmt]: https://pkg.go.dev/cmd/gofmt
 [gofumpt]: https://github.com/mvdan/gofumpt
+[modfmt]: https://github.com/joshdk/modfmt
 [jsonnetfmt]: https://github.com/google/go-jsonnet
 [scalafmt]: https://scalameta.org/scalafmt
 [rubocop]: https://docs.rubocop.org/

--- a/examples/go-module/MODULE.bazel
+++ b/examples/go-module/MODULE.bazel
@@ -1,0 +1,13 @@
+"Bazel dependencies for the go.mod / go.work formatting example"
+
+bazel_dep(name = "aspect_rules_lint")
+bazel_dep(name = "rules_multitool", version = "0.11.0")
+
+local_path_override(
+    module_name = "aspect_rules_lint",
+    path = "../..",
+)
+
+multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
+multitool.hub(lockfile = "//tools:modfmt.lock.json")
+use_repo(multitool, "multitool")

--- a/examples/go-module/go.mod
+++ b/examples/go-module/go.mod
@@ -1,0 +1,10 @@
+module example.com/go-module-formatter-demo
+
+go 1.23
+
+require (
+    github.com/spf13/cobra v1.8.0
+github.com/stretchr/testify v1.9.0
+)
+
+require github.com/spf13/pflag v1.0.5 // indirect

--- a/examples/go-module/tools/BUILD
+++ b/examples/go-module/tools/BUILD
@@ -1,0 +1,3 @@
+package(default_visibility = ["//:__subpackages__"])
+
+exports_files(["modfmt.lock.json"])

--- a/examples/go-module/tools/format/BUILD
+++ b/examples/go-module/tools/format/BUILD
@@ -1,0 +1,11 @@
+"""BUILD definition for the formatter binary"""
+
+load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
+
+package(default_visibility = ["//:__subpackages__"])
+
+format_multirun(
+    name = "format",
+    go_module = "@multitool//tools/modfmt",
+    visibility = ["//:__subpackages__"],
+)

--- a/examples/go-module/tools/modfmt.lock.json
+++ b/examples/go-module/tools/modfmt.lock.json
@@ -1,0 +1,38 @@
+{
+  "modfmt": {
+    "binaries": [
+      {
+        "kind": "archive",
+        "url": "https://github.com/joshdk/modfmt/releases/download/v0.4.0/modfmt-linux-arm64.tar.gz",
+        "file": "modfmt",
+        "sha256": "ba6a960b905e206bda2e79ceb355354884c5d83256f26623102b0882044b7964",
+        "os": "linux",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/joshdk/modfmt/releases/download/v0.4.0/modfmt-linux-amd64.tar.gz",
+        "file": "modfmt",
+        "sha256": "d9083a268ecd92bfb29c8e15d900d880ace825341e219e19f1e0cc372eef6223",
+        "os": "linux",
+        "cpu": "x86_64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/joshdk/modfmt/releases/download/v0.4.0/modfmt-darwin-arm64.tar.gz",
+        "file": "modfmt",
+        "sha256": "5f9b461b5ecd96cf129f465f01cf0e3bb170b1cff73f84901d89668d831820a2",
+        "os": "macos",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/joshdk/modfmt/releases/download/v0.4.0/modfmt-darwin-amd64.tar.gz",
+        "file": "modfmt",
+        "sha256": "2529427c5be83731bd89cf6b47ad620c14555bc76c61f24722eac9aaa47ed496",
+        "os": "macos",
+        "cpu": "x86_64"
+      }
+    ]
+  }
+}

--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -123,6 +123,7 @@ function ls-files {
       'CSS') patterns=('*.css') ;;
       'F#') patterns=('*.fs') ;;
       'Go') patterns=('*.go') ;;
+      'Go Module') patterns=('go.mod' 'go.work') ;;
       'GraphQL') patterns=('*.graphql' '*.gql' '*.graphqls') ;;
       'HTML') patterns=('*.html' '*.hta' '*.htm' '*.html.hl' '*.inc' '*.xht' '*.xhtml') ;;
       'JSON') patterns=('.all-contributorsrc' '.arcconfig' '.auto-changelog' '.c8rc' '.htmlhintrc' '.imgbotconfig' '.nycrc' '.tern-config' '.tern-project' '.watchmanconfig' 'Pipfile.lock' 'composer.lock' 'deno.lock' 'flake.lock' 'mcmod.info' '*.json' '*.4DForm' '*.4DProject' '*.avsc' '*.geojson' '*.gltf' '*.har' '*.ice' '*.JSON-tmLanguage' '*.jsonl' '*.mcmeta' '*.tfstate' '*.tfstate.backup' '*.topojson' '*.webapp' '*.webmanifest' '*.yy' '*.yyp') ;;

--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -36,6 +36,7 @@ TOOLS = {
     "F#": "fantomas",
     "C#": "csharpier",
     "Pkl": "pkl",
+    "Go Module": "modfmt",
 }
 
 # Provided to make install more convenient
@@ -73,6 +74,7 @@ CHECK_FLAGS = {
     "fantomas": "--check",
     "csharpier": "check",
     "pkl": "format --silent",
+    "modfmt": "-c",
 }
 
 # Flags to pass each tool when running in default mode
@@ -106,6 +108,7 @@ FIX_FLAGS = {
     "fantomas": "",
     "csharpier": "format",
     "pkl": "format --write",
+    "modfmt": "-w",
 }
 
 def to_attribute_name(lang):

--- a/format/test/BUILD.bazel
+++ b/format/test/BUILD.bazel
@@ -46,6 +46,7 @@ format_multirun(
     fsharp = ":mock_fantomas.sh",
     gherkin = ":mock_prettier.sh",
     go = ":mock_gofmt.sh",
+    go_module = ":mock_modfmt.sh",
     graphql = ":mock_prettier.sh",
     html = ":mock_prettier.sh",
     html_jinja = ":mock_djlint.sh",

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -236,3 +236,10 @@ bats_load_library "bats-assert"
 
     assert_output --partial "pkl format --write examples/pkl/src/cats.pkl"
 }
+
+@test "should run modfmt on Go Module" {
+    run bazel run //format/test:format_Go_Module_with_modfmt
+    assert_success
+
+    assert_output --partial "+ modfmt -w examples/go-module/go.mod"
+}


### PR DESCRIPTION
Adds formatting support for `go.mod` and `go.work` files using [`modfmt`](https://github.com/joshdk/modfmt).

Wiring mirrors aspect-build/rules_lint#795 (Pkl): the language is registered in the central `TOOLS` / `CHECK_FLAGS` / `FIX_FLAGS` tables, file patterns are added to `format.sh`, and a small `examples/go-module/` example shows how to wire up the binary (via `rules_multitool`). No default tool is bundled — users bring their own, same as Pkl, Kotlin, Java, etc.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change: no
- Suggested release notes appear below: yes

RELEASE NOTES: Supports formatting of `go.mod` and `go.work` files via `modfmt`.

### Test plan

- New test cases added — `format/test/format_test.bats` covers `Go Module` via the mock binary.
- Manual:

  ```
  $ cd examples/go-module
  $ bazel run //tools/format
  $ git diff go.mod
  ```
