### PR TITLE
fix(clang_tidy_wrapper): drop eval, run clang-tidy directly with "$@"

### DIFF
--- a/lint/clang_tidy_wrapper.bash
+++ b/lint/clang_tidy_wrapper.bash
@@ -33,13 +33,16 @@ else
     out_file=$(mktemp)
 fi
 # include stderr in output file; it contains some of the diagnostics
-command="$clang_tidy $@ $file > $out_file 2>&1"
+# NB: do NOT collapse "$@" into a single string and eval it — args containing
+# shell metacharacters such as `__attribute__((deprecated))` then get re-parsed
+# by the shell ("syntax error near unexpected token `('"). Run clang-tidy
+# directly with "$@" so each argument is preserved verbatim.
 if [[ -n $CLANG_TIDY__VERBOSE ]]; then
     echo "$@"
     echo "cwd: " `pwd`
-    echo $command
+    echo "$clang_tidy $@ > $out_file 2>&1"
 fi
-eval $command
+"$clang_tidy" "$@" > "$out_file" 2>&1
 exit_code=$?
 if [[ -z $CLANG_TIDY__STDOUT_STDERR_OUTPUT_FILE ]]; then
     cat $out_file

--- a/lint/clang_tidy_wrapper.bash
+++ b/lint/clang_tidy_wrapper.bash
@@ -35,13 +35,16 @@ fi
 # Capture raw output here; statistics get filtered into $out_file below.
 raw_out_file=$(mktemp)
 # include stderr in output file; it contains some of the diagnostics
-command="$clang_tidy $@ $file > $raw_out_file 2>&1"
+# NB: do NOT collapse "$@" into a single string and eval it — args containing
+# shell metacharacters such as `__attribute__((deprecated))` then get re-parsed
+# by the shell ("syntax error near unexpected token `('"). Run clang-tidy
+# directly with "$@" so each argument is preserved verbatim.
 if [[ -n $CLANG_TIDY__VERBOSE ]]; then
     echo "$@"
     echo "cwd: " `pwd`
-    echo $command
+    echo "$clang_tidy $@ > $raw_out_file 2>&1"
 fi
-eval $command
+"$clang_tidy" "$@" > "$raw_out_file" 2>&1
 exit_code=$?
 # Drop clang-tidy summary statistics (e.g. "N warnings generated.") that it
 # prints even on a clean, exit-0 run thus tripping in fail_on_violation mode.

--- a/lint/test/BUILD.bazel
+++ b/lint/test/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+sh_test(
+    name = "clang_tidy_wrapper_test",
+    srcs = ["clang_tidy_wrapper_test.sh"],
+    data = ["//lint:clang_tidy_wrapper"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/lint/test/clang_tidy_wrapper_test.sh
+++ b/lint/test/clang_tidy_wrapper_test.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+# Tests for lint/clang_tidy_wrapper.bash.
+#
+# Regression test: the wrapper used to build a single string and `eval` it,
+# which re-parsed arguments through the shell. Arguments containing shell
+# metacharacters such as `-DDEPRECATED=__attribute__((deprecated))` then
+# failed with "syntax error near unexpected token `('". The wrapper must
+# invoke clang-tidy directly with "$@" so every argument arrives verbatim.
+
+set -o nounset -o errexit -o pipefail
+
+wrapper="$(rlocation "_main/lint/clang_tidy_wrapper.bash")"
+if [[ ! -f "$wrapper" ]]; then
+    echo "FAIL: clang_tidy_wrapper.bash not found in runfiles" >&2
+    exit 1
+fi
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# A recording mock for clang-tidy: writes each argument it receives on its
+# own line, then exits with MOCK_EXIT_CODE (default 0).
+mock_clang_tidy="$tmp_dir/mock-clang-tidy"
+cat > "$mock_clang_tidy" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$MOCK_ARGS_FILE"
+echo "mock clang-tidy output"
+exit "${MOCK_EXIT_CODE:-0}"
+EOF
+chmod +x "$mock_clang_tidy"
+
+failures=0
+
+fail() {
+    echo "FAIL: $1" >&2
+    failures=$((failures + 1))
+}
+
+pass() {
+    echo "PASS: $1"
+}
+
+#-------------------------------------------------------------------
+# Test 1: arguments containing shell metacharacters are passed verbatim
+# and are not re-parsed by the shell.
+
+args=(
+    "-DDEPRECATED_ATTR=__attribute__((deprecated))"
+    "-DGREETING=\"hello world\""
+    "-DCMD=\$(echo pwned)"
+    "-DSEMI=a;b"
+    "-DGLOB=*"
+    "arg with spaces"
+    "--"
+    "-Ifoo/bar"
+    "source file.cpp"
+)
+
+export MOCK_ARGS_FILE="$tmp_dir/args1.txt"
+exit_code=0
+MOCK_EXIT_CODE=0 "$wrapper" "$mock_clang_tidy" "${args[@]}" > "$tmp_dir/stdout1.txt" 2>&1 || exit_code=$?
+
+if [[ $exit_code -ne 0 ]]; then
+    fail "wrapper exited with $exit_code for metacharacter args (eval regression?):
+$(cat "$tmp_dir/stdout1.txt")"
+else
+    pass "wrapper survives args with shell metacharacters"
+fi
+
+printf '%s\n' "${args[@]}" > "$tmp_dir/expected1.txt"
+if diff -u "$tmp_dir/expected1.txt" "$MOCK_ARGS_FILE"; then
+    pass "all arguments arrive at clang-tidy verbatim"
+else
+    fail "arguments were mangled before reaching clang-tidy"
+fi
+
+#-------------------------------------------------------------------
+# Test 2: non-zero exit codes from clang-tidy are propagated.
+
+export MOCK_ARGS_FILE="$tmp_dir/args2.txt"
+exit_code=0
+MOCK_EXIT_CODE=3 "$wrapper" "$mock_clang_tidy" "-DX=__attribute__((noreturn))" foo.cpp \
+    > "$tmp_dir/stdout2.txt" 2>&1 || exit_code=$?
+
+if [[ $exit_code -eq 3 ]]; then
+    pass "clang-tidy exit code is propagated"
+else
+    fail "expected exit code 3, got $exit_code"
+fi
+
+#-------------------------------------------------------------------
+# Test 3: with CLANG_TIDY__EXIT_CODE_OUTPUT_FILE set, the wrapper returns
+# success and records the real exit code in the file.
+
+export MOCK_ARGS_FILE="$tmp_dir/args3.txt"
+export CLANG_TIDY__EXIT_CODE_OUTPUT_FILE="$tmp_dir/exit_code.txt"
+export CLANG_TIDY__STDOUT_STDERR_OUTPUT_FILE="$tmp_dir/output.txt"
+exit_code=0
+MOCK_EXIT_CODE=2 "$wrapper" "$mock_clang_tidy" "-DY=__attribute__((unused))" bar.cpp \
+    > "$tmp_dir/stdout3.txt" 2>&1 || exit_code=$?
+unset CLANG_TIDY__EXIT_CODE_OUTPUT_FILE
+unset CLANG_TIDY__STDOUT_STDERR_OUTPUT_FILE
+
+if [[ $exit_code -eq 0 ]]; then
+    pass "wrapper returns success when exit code file is requested"
+else
+    fail "expected exit code 0 with CLANG_TIDY__EXIT_CODE_OUTPUT_FILE, got $exit_code"
+fi
+
+if [[ "$(cat "$tmp_dir/exit_code.txt")" == "2" ]]; then
+    pass "real exit code written to CLANG_TIDY__EXIT_CODE_OUTPUT_FILE"
+else
+    fail "expected '2' in exit code file, got '$(cat "$tmp_dir/exit_code.txt")'"
+fi
+
+if grep -q "mock clang-tidy output" "$tmp_dir/output.txt"; then
+    pass "clang-tidy output captured in CLANG_TIDY__STDOUT_STDERR_OUTPUT_FILE"
+else
+    fail "clang-tidy output missing from CLANG_TIDY__STDOUT_STDERR_OUTPUT_FILE"
+fi
+
+#-------------------------------------------------------------------
+
+if [[ $failures -ne 0 ]]; then
+    echo "$failures test(s) failed" >&2
+    exit 1
+fi
+echo "All clang_tidy_wrapper tests passed!"


### PR DESCRIPTION
  ## Summary

  `lint/clang_tidy_wrapper.bash` collapses positional args into a single string and `eval`s it:

  ```bash
  command="$clang_tidy $@ $file > $out_file 2>&1"
  eval $command
  ```

  Once `"$@"` is folded into one string and re-evaluated by the shell, any argument containing shell metacharacters is mis-parsed. In practice this trips on the C/C++
   macro definitions Bazel passes through, e.g.:

  ```
  -DGLOG_DEPRECATED=__attribute__((deprecated))
  -DGLOG_EXPORT=__attribute__((visibility("default")))
  ```

  The `((` is interpreted as bash arithmetic-evaluation syntax, so the wrapper aborts with:

  ```
  clang_tidy_wrapper: eval: line 42: syntax error near unexpected token `('
  ```

  `clang-tidy` then never runs.

  ## Why the lint-only path appears to work

  `clang_tidy_action` uses two execution paths:

  - **`run_shell` (lint mode)** — compiler args are materialized into a Bazel params file (`use_param_file("--config %s", use_always = True)`). The wrapper receives 
  `@params_file`, not the raw flags, so the offending macro definitions never reach the shell.
  - **`run_patcher` (`--fix` / `lint:fix=True` mode)** — compiler args are passed directly on the command line (`args = [..., "--"] + compiler_args`). The full
  `__attribute__((...))` strings hit `eval` and the wrapper crashes.

  End result: lint diagnostics work fine, but `--fix` silently produces an empty patch (`clang-tidy` never executes, so nothing modifies the sandbox source, so the
  diff is empty). The failure is invisible because `JS_BINARY__SILENT_ON_SUCCESS=1` swallows the wrapper's stderr unless the patcher itself exits non-zero, and the
  patcher reports the wrapper's exit code only via `JS_BINARY__EXIT_CODE_OUTPUT_FILE`.

  ## Fix

  Run `clang-tidy` directly with `"$@"` so each argument is preserved verbatim and no shell re-parsing occurs:

  ```bash
  "$clang_tidy" "$@" > "$out_file" 2>&1
  ```

  The `eval` was only there to interpret the `> $out_file 2>&1` redirection inside the assembled string; that's no longer necessary once we run the command directly.

  ## Repro

  A minimal `cc_library` whose `defines` (or transitive `defines`) include an `__attribute__((...))` form is sufficient. With `--@aspect_rules_lint//lint:fix=True
  diff is empty). The failure is invisible because `JS_BINARY__SILENT_ON_SUCCESS=1` swallows the wrapper's stderr unless the patcher itself exits non-zero, and the
  patcher reports the wrapper's exit code only via `JS_BINARY__EXIT_CODE_OUTPUT_FILE`.

  ## Fix

  Run `clang-tidy` directly with `"$@"` so each argument is preserved verbatim and no shell re-parsing occurs:

  ```bash
  "$clang_tidy" "$@" > "$out_file" 2>&1
  ```

  The `eval` was only there to interpret the `> $out_file 2>&1` redirection inside the assembled string; that's no longer necessary once we run the command directly.

  ## Repro

  A minimal `cc_library` whose `defines` (or transitive `defines`) include an `__attribute__((...))` form is sufficient. With `--@aspect_rules_lint//lint:fix=True
  --output_groups=rules_lint_patch`, the `.AspectRulesLintClangTidy.patch` output file will be 0 bytes before this change, and the actual unified diff after.

  ## Test Plan

  - [ ] Lint-only build (`--output_groups=rules_lint_human`) still produces diagnostics.
  - [ ] Fix build (`--output_groups=rules_lint_patch --@aspect_rules_lint//lint:fix=True`) on a target whose compile args contain `__attribute__((...))` produces a
  non-empty patch.
  - [ ] Existing `e2e/clang_tidy` tests pass.
  - [ ] `CLANG_TIDY__VERBOSE=1` still prints the equivalent command line.

---

### Changes are visible to end-users: no



