### PR TITLE
feat: surface diagnostics on stderr when failing the action

### DIFF
--- a/lint/clang_tidy_wrapper.bash
+++ b/lint/clang_tidy_wrapper.bash
@@ -81,4 +81,15 @@ fi
 if [[ -n $CLANG_TIDY__VERBOSE ]]; then
     echo exit $exit_code
 fi
+# Surface the captured diagnostics on the action's stderr when we are about
+# to exit non-zero. Without this, fail_on_violation builds report
+# `Linting //x:y failed` with no body — the diagnostic text sits in the
+# .out file (CLANG_TIDY__STDOUT_STDERR_OUTPUT_FILE) and never reaches the
+# user. The fatal_error branch above already cats to stdout for
+# clang-diagnostic-error; this covers the warnings-as-errors case
+# (e.g. WarningsAsErrors: "*") where there is no clang-diagnostic-error
+# string in the output.
+if [ $exit_code -ne 0 ] && [ -n "$CLANG_TIDY__STDOUT_STDERR_OUTPUT_FILE" ] && [ -s "$out_file" ]; then
+    cat "$out_file" >&2
+fi
 exit $exit_code


### PR DESCRIPTION
  ## Summary

  When `--@aspect_rules_lint//lint:fail_on_violation=True` is enabled, a build that trips a clang-tidy check today reports:

  ```
  ERROR: ... Linting //x:y with clang-tidy failed: (Exit 1): clang_tidy_wrapper failed: ...
  ```

  …with no diagnostic body. The actual `clang-tidy` output is silently parked in `bazel-bin/.../<file>.AspectRulesLintClangTidy.out` and the developer has to know to go fish it out, which mostly defeats the point of `fail_on_violation` (loud failure in CI, immediate signal locally).

  ## Why it's silent today

  `clang_tidy.bzl` always sets `CLANG_TIDY__STDOUT_STDERR_OUTPUT_FILE` to the `.out` file path. The wrapper redirects `clang-tidy`'s combined stdout/stderr there:

  ```bash
  "$clang_tidy" "$@" > "$out_file" 2>&1
  ```

  …and the existing "cat to stdout" branch only fires when `CLANG_TIDY__STDOUT_STDERR_OUTPUT_FILE` is **unset** (i.e. direct CLI use), so diagnostics never reach the action's stderr.

  There is already a fast-path that does dump the file: when the captured output contains `clang-diagnostic-error` (a real clang frontend error). That doesn't help for warnings-as-errors configs (`WarningsAsErrors: "*"`), where every diagnostic is reported as `[google-readability-…]` / `[modernize-…]` / etc. — no `clang-diagnostic-error` substring, so the dump is skipped and the action exits non-zero in silence.

  ## Fix

  Just before the final `exit $exit_code`, dump the captured output to the action's stderr when we're about to fail and the output is in a file the user can't see:

  ```bash
  if [ $exit_code -ne 0 ] && [ -n "$CLANG_TIDY__STDOUT_STDERR_OUTPUT_FILE" ] && [ -s "$out_file" ]; then
      cat "$out_file" >&2
  fi
  exit $exit_code
  ```

  Bazel surfaces failed-action stderr in the build output, so `clang-tidy`'s diagnostics now appear inline in `bazel build` failures.

  The conditions are deliberately narrow:

  - `exit_code != 0` — only on the failing path; successful runs stay quiet.
  - `CLANG_TIDY__STDOUT_STDERR_OUTPUT_FILE` set — only when the output went to a file (i.e. invoked from rules_lint). Direct CLI users already get the output via the existing line-44 `cat`.
  - `[ -s "$out_file" ]` — skip if the file is empty (nothing to print).

  The existing `fatal_error` branch is untouched, so the `clang-diagnostic-error` path still cats to stdout as it does today.

  ## Behavior matrix

  | Mode | `CLANG_TIDY__STDOUT_STDERR_OUTPUT_FILE` | `CLANG_TIDY__EXIT_CODE_OUTPUT_FILE` | Wrapper exit | Before | After |
  |---|---|---|---|---|---|
  | Lint, no `fail_on_violation` | set | set | 0 | (exit code in file, output in `.out`, build OK) | unchanged |
  | Lint, `fail_on_violation` | set | unset | non-zero on violation | action fails, diagnostics hidden in `.out` | action fails, **diagnostics on stderr** |
  | Direct CLI (`./clang_tidy_wrapper.bash …`) | unset | unset | non-zero on violation | output already cat'd to stdout (line 44) | unchanged |
  | `clang-diagnostic-error` (any mode) | either | either | non-zero | `fatal_error` branch cats to stdout, exits | unchanged |

  ## Repro

  Any `cc_library` whose `.clang-tidy` config has `WarningsAsErrors: "*"` and a check that fires (e.g. `google-readability-braces-around-statements` on a braceless
  `if`):

  ```sh
  bazel build \
    --aspects=//path/to:linters.bzl%clang_tidy \
    --@aspect_rules_lint//lint:fail_on_violation=True \
    --output_groups=rules_lint_human \
    //pkg:target
  ```

  Before: `Linting //pkg:target with clang-tidy failed: (Exit 1)` and nothing else.
  After: the same `Linting … failed` line followed by the actual `file.cc:LINE:COL: error: <msg> [<check>]` lines.

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

