### PR TITLE
fix(ty): resolve imports from standard dependencies without imports attribute

### DIFF
--- a/examples/python/MODULE.bazel
+++ b/examples/python/MODULE.bazel
@@ -6,6 +6,8 @@ bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "rules_python", version = "1.8.1")
 bazel_dep(name = "rules_uv", version = "0.88.0")
 bazel_dep(name = "ext_mod")
+bazel_dep(name = "abseil-py", version = "2.1.0")
+
 
 local_path_override(
     module_name = "aspect_rules_lint",

--- a/examples/python/test/BUILD
+++ b/examples/python/test/BUILD
@@ -137,6 +137,18 @@ ty_test(
     srcs = [":dep_ext_generated"]
 )
 
+py_library(name = "dep_bcr",
+           srcs = ["dep_bcr.py"],
+           deps = ["@abseil-py//absl/testing:absltest"]
+)
+
+ty_test(
+    name = "ty_should_find_bcr_dep",
+    srcs = [":dep_bcr"]
+)
+
+
+
 ty_test(
     name = "ty_should_fail_unsupported_operator",
     srcs = ["//src:unsupported_operator"],

--- a/examples/python/test/dep_bcr.py
+++ b/examples/python/test/dep_bcr.py
@@ -1,0 +1,1 @@
+from absl.testing import absltest

--- a/lint/ty.bzl
+++ b/lint/ty.bzl
@@ -180,10 +180,15 @@ def _ty_aspect_impl(target, ctx):
             if PyInfo in dep:
                 transitive_sources.append(dep[PyInfo].transitive_sources)
                 transitive_sources.append(dep[PyInfo].transitive_pyi_files)
-                for import_path in dep[PyInfo].imports.to_list():
-                    resolved = _resolve_import_path(import_path, ctx.workspace_name, ctx.bin_dir.path)
-                    for e in resolved:
-                        import_paths[e] = True
+                imports = dep[PyInfo].imports.to_list()
+                if imports:
+                    for import_path in imports:
+                        resolved = _resolve_import_path(import_path, ctx.workspace_name, ctx.bin_dir.path)
+                        for e in resolved:
+                            import_paths[e] = True
+                elif dep.label.workspace_root:
+                    import_paths[dep.label.workspace_root] = True
+                    import_paths[ctx.bin_dir.path + "/" + dep.label.workspace_root] = True
 
     # When srcs contain labels to other targets (e.g., genrules that produce .py files),
     # we need to collect their transitive sources for proper type resolution
@@ -192,10 +197,15 @@ def _ty_aspect_impl(target, ctx):
             if PyInfo in src:
                 transitive_sources.append(src[PyInfo].transitive_sources)
                 transitive_sources.append(src[PyInfo].transitive_pyi_files)
-                for import_path in src[PyInfo].imports.to_list():
-                    resolved = _resolve_import_path(import_path, ctx.workspace_name, ctx.bin_dir.path)
-                    for e in resolved:
-                        import_paths[e] = True
+                imports = src[PyInfo].imports.to_list()
+                if imports:
+                    for import_path in imports:
+                        resolved = _resolve_import_path(import_path, ctx.workspace_name, ctx.bin_dir.path)
+                        for e in resolved:
+                            import_paths[e] = True
+                elif src.label.workspace_root:
+                    import_paths[src.label.workspace_root] = True
+                    import_paths[ctx.bin_dir.path + "/" + src.label.workspace_root] = True
 
     files_to_lint = filter_srcs(ctx.rule)
     outputs, info = output_files(_MNEMONIC, target, ctx)


### PR DESCRIPTION
### Problem

When using the `ty` aspect to lint Python targets that depend on standard external Bazel dependencies (like `abseil-py` or `rules_python` pip dependencies that don't set the `imports` attribute), `ty` fails with `unresolved-import` errors for those dependencies.

This happens because:
1. Standard Bazel dependencies package their code directly at their repository root (e.g., `absl` is a folder directly under the repository root) and do not set the `imports` attribute in their `py_library` rules, relying on Bazel's default behavior instead.
2. Consequently, `dep[PyInfo].imports` is empty.
3. The `ty` aspect implementation only populated `extra-search-path` using `dep[PyInfo].imports`. Since it was empty, the dependency's repository root (e.g., `external/abseil-py+`) was omitted from the linter's search paths.

### Solution

This PR introduces a fallback to `dep.label.workspace_root` (e.g., `external/abseil-py+`) when `dep[PyInfo].imports` is empty. 
This ensures the dependency's workspace root (and its `bazel-bin` counterpart for generated files) is correctly added to `ty`'s `--extra-search-path` arguments.

### Test Plan

Added a regression test in `examples/python`:
1. Added `abseil-py` to `examples/python/MODULE.bazel`.
2. Created `examples/python/test/dep_bcr.py` importing `absl.testing`.
3. Added `ty_should_find_bcr_dep` test target in `examples/python/test/BUILD`.

Before this fix, running this test fails with:
```
error[unresolved-import]: Cannot resolve imported module `absl.testing`
```

With this fix, the test passes successfully.
