### PR TITLE
fix(format.sh): prefer BUILD_WORKING_DIRECTORY for subdirectory scoping

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -13,11 +13,13 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: runfiles.bash initializer cannot find $f. An executable rule may have forgotten to expose it in the runfiles, or the binary may require RUNFILES_DIR to be set."; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v3 ---
 
-if [[ -n "$BUILD_WORKSPACE_DIRECTORY" ]]; then
-  # Needed for the rustfmt binary wrapper in rules_rust; see
-  # https://github.com/aspect-build/rules_lint/pull/327
-  unset BUILD_WORKING_DIRECTORY
-  cd $BUILD_WORKSPACE_DIRECTORY
+# Prefer BUILD_WORKING_DIRECTORY so git ls-files scopes to the invoking subtree
+# and all paths stay CWD-relative. The previous unset BUILD_WORKING_DIRECTORY
+# (#327) was wrong — see https://github.com/aspect-build/rules_lint/pull/882.
+if [[ -n "${BUILD_WORKING_DIRECTORY:-}" ]]; then
+  cd "$BUILD_WORKING_DIRECTORY"
+elif [[ -n "${BUILD_WORKSPACE_DIRECTORY:-}" ]]; then
+  cd "$BUILD_WORKSPACE_DIRECTORY"
 elif [[ -n "$TEST_WORKSPACE" ]]; then
   if [[ -n "$WORKSPACE" ]]; then
     WORKSPACE_PATH="$(dirname "$(realpath ${WORKSPACE})")"

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -4,6 +4,13 @@
 bats_load_library "bats-support"
 bats_load_library "bats-assert"
 
+setup() {
+    # Run bazel from the workspace root so BUILD_WORKING_DIRECTORY equals
+    # BUILD_WORKSPACE_DIRECTORY. format.sh cds to BUILD_WORKING_DIRECTORY, so
+    # running from a subdirectory would scope git ls-files to that subtree only.
+    cd "$(git rev-parse --show-toplevel)"
+}
+
 # No arguments: will use git ls-files
 @test "should run prettier on javascript using git ls-files" {
     run bazel run //format/test:format_JavaScript_with_prettier

--- a/format/test/ls-files_test.sh
+++ b/format/test/ls-files_test.sh
@@ -144,3 +144,18 @@ tree2/src.js'
 }
 
 git sparse-checkout disable
+
+# BUILD_WORKING_DIRECTORY scopes ls-files to a subdirectory
+mkdir -p sub
+touch sub/sub.js
+git add sub/sub.js
+git commit --message 'add subdirectory js file'
+(
+  BUILD_WORKSPACE_DIRECTORY="$(pwd)" BUILD_WORKING_DIRECTORY="$(pwd)/sub" \
+    source "$TEST_SRCDIR/_main/format/private/format.sh"
+  sub_js=$(ls-files JavaScript)
+  [[ "$sub_js" == "sub.js" ]] || {
+    echo >&2 -e "expected ls-files to return sub.js when scoped to sub/, was\n$sub_js"
+    exit 1
+  }
+)


### PR DESCRIPTION
## Why #327's fix was wrong and what this PR does instead

### The original bug

When `bazel run //:format` is invoked from a subdirectory (e.g. `b/`), Bazel sets:
- `BUILD_WORKSPACE_DIRECTORY` = repo root (`/repo`)
- `BUILD_WORKING_DIRECTORY` = invocation directory (`/repo/b`)

Before #327, `format.sh` did `cd $BUILD_WORKSPACE_DIRECTORY`, so `git ls-files` ran at the repo root and returned workspace-root-relative paths — including files like `a/lib.rs` that live outside `b/`. Those paths were then passed to `rustfmt`.

The problem is that `rustfmt` in rules_rust is wrapped by an `upstream_wrapper` binary that, when `BUILD_WORKING_DIRECTORY` is set, does `cd $BUILD_WORKING_DIRECTORY` before invoking the real `rustfmt`. So after `format.sh` cds to `/repo`, the wrapper cds to `/repo/b`, and then tries to open `a/lib.rs` relative to `/repo/b` — which doesn't exist. Hence exit code 123.

### Why #327's fix was wrong

#327 fixed the symptom by adding `unset BUILD_WORKING_DIRECTORY` before `cd $BUILD_WORKSPACE_DIRECTORY`. This stopped the rustfmt wrapper from cding to the subdirectory. But running a formatter from the cwd, which BUILD_WORKING_DIRECTORY is set to, is standard practice for formatters, which is why rustfmt in rules_rust was calling `cd BUILD_WORKING_DIRECTORY` in the first place.

### What this PR does instead

The real fix is to `cd "$BUILD_WORKING_DIRECTORY"` (when set) rather than `BUILD_WORKSPACE_DIRECTORY`. This makes everything consistent:

- **No-args path** (`git ls-files`): runs from `BUILD_WORKING_DIRECTORY`, so it naturally returns only files in the invoking subtree, already relative to CWD. No workspace-root-relative paths, no out-of-subtree files.
- **With-args path** (`find "$@"`): callers pass CWD-relative paths, which `find` resolves correctly from CWD.
- **rustfmt's wrapper**: cds to `BUILD_WORKING_DIRECTORY` — but we're already there, so it's a no-op.

When `BUILD_WORKING_DIRECTORY` is not set (test context, older Bazel, etc.) the fallback to `BUILD_WORKSPACE_DIRECTORY` is unchanged.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Suggested release notes:
- `format.sh` now cds to `BUILD_WORKING_DIRECTORY` when set, scoping `bazel run //:format` to the invoking directory and correctly fixing the rustfmt subdirectory bug from #327.

### Test plan

- Existing `ls-files_test.sh` passes — it sets `BUILD_WORKSPACE_DIRECTORY` without `BUILD_WORKING_DIRECTORY`, exercising the unchanged fallback path.
- Manual: `bazel run //:format` from a subdirectory containing Rust files — rustfmt no longer errors with "file does not exist" and only files in the subtree are formatted.
