### PR TITLE
chore: upgrade keep-sorted to v0.8.0

### DIFF
--- a/lint/keep-sorted/go.mod
+++ b/lint/keep-sorted/go.mod
@@ -2,14 +2,14 @@ module github.com/aspect-build/rules_lint/lint/keep-sorted
 
 go 1.23.5
 
-require github.com/google/keep-sorted v0.6.0
+require github.com/google/keep-sorted v0.8.0
 
 require (
 	github.com/Workiva/go-datastructures v1.0.53 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/rs/zerolog v1.31.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/lint/keep-sorted/go.sum
+++ b/lint/keep-sorted/go.sum
@@ -6,8 +6,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/keep-sorted v0.6.0 h1:mrDMFnTUxsLatnYBBIJA/1j/Z3ZXTub/pCzbKvA2Ga8=
-github.com/google/keep-sorted v0.6.0/go.mod h1:JYy9vljs7P8b3QdPOQkywA+4u36FUHwsNITZIpJyPkE=
+github.com/google/keep-sorted v0.8.0 h1:v6BqaVm7GeR3hGh3hKOBh3AKdvhhzoAxc0LHWM+h+rs=
+github.com/google/keep-sorted v0.8.0/go.mod h1:rq0M4inbcsaXUa7PXPHyB28K+X1K/GHbahex2/DlylY=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -21,8 +21,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.31.0 h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=
 github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=


### PR DESCRIPTION
## Summary

Upgrade `github.com/google/keep-sorted` from v0.6.0 to v0.8.0 in `lint/keep-sorted/`.

This brings in improvements from two minor releases:
- **v0.7.0**: Adds `group_start_regex` support and other enhancements
- **v0.8.0**: Additional features and fixes

Also bumps transitive dependency `github.com/spf13/pflag` from v1.0.5 to v1.0.10.

## Changes

- Updated `lint/keep-sorted/go.mod` to require `keep-sorted v0.8.0`
- Regenerated `lint/keep-sorted/go.sum`

## Test plan

- [x] CI passes with the updated dependency
- [x] Verify keep-sorted linter still works correctly with the new version