### PR TITLE
fix(cppcheck): Add missing `load` statement

### DIFF
--- a/lint/cppcheck.bzl
+++ b/lint/cppcheck.bzl
@@ -2,7 +2,7 @@
 """
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
-load("@rules_cc//cc:defs.bzl", "CcInfo")
+load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OPTIONAL_SARIF_PARSER_TOOLCHAIN", "OUTFILE_FORMAT", "noop_lint_action", "output_files", "parse_to_sarif_action")
 
 _MNEMONIC = "AspectRulesLintCppCheck"


### PR DESCRIPTION
Add missing `load` statement in `cppcheck` (needed for Bazel 9).