### PR TITLE
refactor(lint): accept args objects in run_patcher

### DIFF
--- a/lint/buildifier.bzl
+++ b/lint/buildifier.bzl
@@ -49,7 +49,10 @@ def buildifier_action(ctx, executable, srcs, stdout = None, exit_code = None, pa
     """
     if patch != None:
         wrapper = ctx.actions.declare_file(ctx.label.name + ".buildifier_wrapper.sh")
-        args_list = ["--warnings={}".format(ctx.attr._warnings)] + [s.path for s in srcs]
+        args = ctx.actions.args()
+        args.add("--warnings={}".format(ctx.attr._warnings))
+        args.add_all(srcs)
+
         ctx.actions.write(
             output = wrapper,
             content = """#!/bin/bash
@@ -63,7 +66,7 @@ def buildifier_action(ctx, executable, srcs, stdout = None, exit_code = None, pa
             ctx,
             ctx.executable,
             inputs = srcs,
-            args = args_list,
+            args = args,
             files_to_diff = [src.path for src in srcs],
             patch_out = patch,
             tools = [wrapper, executable],

--- a/lint/keep_sorted.bzl
+++ b/lint/keep_sorted.bzl
@@ -47,14 +47,19 @@ def keep_sorted_action(ctx, executable, srcs, stdout, exit_code = None, options 
         patch: output file for patch (optional). If provided, uses run_patcher instead of run_shell.
     """
     inputs = srcs
+
+    args = ctx.actions.args()
+    args.add_all(options)
+    args.add("--mode", "fix" if patch != None else "lint")
+    args.add_all(srcs)
+
     if patch != None:
         # Use run_patcher for fix mode
-        args_list = options + ["--mode=fix"] + [s.path for s in srcs]
         run_patcher(
             ctx,
             ctx.executable,
             inputs = inputs,
-            args = args_list,
+            args = args,
             files_to_diff = [s.path for s in srcs],
             patch_out = patch,
             tools = [executable],
@@ -67,10 +72,6 @@ def keep_sorted_action(ctx, executable, srcs, stdout, exit_code = None, options 
     else:
         # Use run_shell for lint mode
         outputs = [stdout]
-        args = ctx.actions.args()
-        args.add_all(options)
-        args.add("--mode=lint")
-        args.add_all(srcs)
 
         if exit_code:
             command = "{keep_sorted} $@ >{stdout}; echo $? > " + exit_code.path

--- a/lint/private/patcher.mjs
+++ b/lint/private/patcher.mjs
@@ -47,6 +47,9 @@ async function sync(src, dst, subdir, filesToDiff) {
 
 async function main(args, sandbox) {
   const config = JSON.parse(await fs.promises.readFile(args[0]));
+  const spawnArgs = args.length > 1
+    ? (await fs.promises.readFile(args[1], "utf8")).split(/\r?\n/)
+    : config.args;
 
   debug("sandbox", sandbox);
   debug("config", JSON.stringify(config, null, 2));
@@ -65,11 +68,11 @@ async function main(args, sandbox) {
   );
 
   debug(
-    `spawning linter: ${config.linter} ${config.args.join(
+    `spawning linter: ${config.linter} ${spawnArgs.join(
       " "
     )} (with env ${JSON.stringify(config.env || {})})`
   );
-  const ret = childProcess.spawnSync(config.linter, config.args, {
+  const ret = childProcess.spawnSync(config.linter, spawnArgs, {
     stdio: "inherit",
     cwd: sandbox,
     env: config.env || {},

--- a/lint/private/patcher_action.bzl
+++ b/lint/private/patcher_action.bzl
@@ -32,7 +32,7 @@ def run_patcher(
         ctx: Bazel Rule or Aspect evaluation context
         executable: struct with a _patcher field
         inputs: action inputs (list or depset)
-        args: list of arguments to pass to the linter
+        args: Args object or list of arguments to pass to the linter
         files_to_diff: list of file paths to diff
         patch_out: output file for the patch
         tools: tools for the action (first tool is used as the linter)
@@ -51,16 +51,23 @@ def run_patcher(
     if patch_cfg_name == None:
         patch_cfg_name = ctx.label.name
     patch_cfg = ctx.actions.declare_file("_{}.{}".format(patch_cfg_name, patch_cfg_suffix))
+    arguments = [patch_cfg.path]
 
     # Build patch config dictionary
     patch_cfg_dict = {
         "linter": tools[0].path,  # Derive linter path from the first tool
-        "args": args,
         "files_to_diff": files_to_diff,
         "output": patch_out.path,
     }
     if patch_cfg_env != None:
         patch_cfg_dict["env"] = patch_cfg_env
+
+    if type(args) == "Args":
+        args.use_param_file("%s", use_always=True)
+        args.set_param_file_format("multiline")
+        arguments.append(args)
+    else:
+        patch_cfg_dict["args"] = args
 
     ctx.actions.write(
         output = patch_cfg,
@@ -103,7 +110,7 @@ def run_patcher(
         "inputs": final_inputs,
         "outputs": outputs_list,
         "executable": executable._patcher,
-        "arguments": [patch_cfg.path],
+        "arguments": arguments,
         "env": final_env,
         "tools": tools,
     }

--- a/lint/qmllint.bzl
+++ b/lint/qmllint.bzl
@@ -48,9 +48,11 @@ def qmllint_action(ctx, executable, srcs, config, stdout, exit_code = None, patc
     """
     inputs = srcs + [config]
 
+    args = ctx.actions.args()
+    args.add_all(srcs)
+
     if patch != None:
         wrapper = ctx.actions.declare_file(ctx.label.name + ".qmllint_wrapper.sh")
-        files = [s.path for s in srcs]
         ctx.actions.write(
             output = wrapper,
             content = """#!/bin/bash
@@ -64,8 +66,8 @@ def qmllint_action(ctx, executable, srcs, config, stdout, exit_code = None, patc
             ctx,
             ctx.executable,
             inputs = inputs,
-            args = files,
-            files_to_diff = files,
+            args = args,
+            files_to_diff = [s.path for s in srcs],
             patch_out = patch,
             tools = [wrapper, executable],
             stdout = stdout,
@@ -75,8 +77,6 @@ def qmllint_action(ctx, executable, srcs, config, stdout, exit_code = None, patc
         )
     else:
         outputs = [stdout]
-        args = ctx.actions.args()
-        args.add_all(srcs)
 
         if exit_code:
             command = "{qmllint} $@ > {stdout} 2>&1; echo $? > " + exit_code.path

--- a/lint/rubocop.bzl
+++ b/lint/rubocop.bzl
@@ -140,18 +140,23 @@ def rubocop_action(
         patch: output file for patch (optional). If provided, uses run_patcher instead of run_shell.
     """
     inputs = srcs + config
+    
+    args = ctx.actions.args()
+    args.add("--force-exclusion")
+    if color:
+        args.add("--color")
+
     if patch != None:
         # Use run_patcher for fix mode
-        rubocop_args = (
-            ["--autocorrect-all", "--force-exclusion", "--cache", "false"] +
-            (["--color"] if color else []) +
-            [s.path for s in srcs]
-        )
+        args.add("--autocorrect-all")
+        args.add("--cache", "false")
+        args.add_all(srcs)
+
         run_patcher(
             ctx,
             ctx.executable,
             inputs = inputs,
-            args = rubocop_args,
+            args = args,
             files_to_diff = [s.path for s in srcs],
             patch_out = patch,
             tools = [executable],
@@ -163,12 +168,8 @@ def rubocop_action(
     else:
         # Use run_shell for lint mode
         outputs = [stdout]
-        args = ctx.actions.args()
         args.add("--format", "simple")
-        args.add("--force-exclusion")
         args.add("--cache-root", "/tmp")
-        if color:
-            args.add("--color")
         args.add_all(srcs)
 
         command = _build_rubocop_command(

--- a/lint/ruff.bzl
+++ b/lint/ruff.bzl
@@ -78,14 +78,22 @@ def ruff_action(ctx, executable, srcs, config, stdout, exit_code = None, env = {
         patch: output file for patch (optional). If provided, uses run_patcher instead of run_shell.
     """
     inputs = srcs + config
+
+    args = ctx.actions.args()
+    args.add("check")
+    args.add("--force-exclude")
+    args.add("--quiet")
+
     if patch != None:
         # Use run_patcher for fix mode
-        args_list = ["check", "--fix", "--force-exclude", "--quiet"] + [s.path for s in srcs]
+        args.add("--fix")
+        args.add_all(srcs)
+
         run_patcher(
             ctx,
             ctx.executable,
             inputs = inputs,
-            args = args_list,
+            args = args,
             files_to_diff = [s.path for s in srcs],
             patch_cfg_env = env,
             patch_out = patch,
@@ -99,10 +107,6 @@ def ruff_action(ctx, executable, srcs, config, stdout, exit_code = None, env = {
     else:
         # Use run_shell for lint mode
         outputs = [stdout]
-        args = ctx.actions.args()
-        args.add("check")
-        args.add("--force-exclude")
-        args.add("--quiet")
         args.add_all(srcs)
         if not env.get("FORCE_COLOR"):
             args.add("--output-format=concise")


### PR DESCRIPTION
This PR amends the implementation of `run_patcher` to accept an Args object created via `ctx.action.args()`. The motivation for this is that linting actions often have divergent implementations for the patch vs. check path where command-line argument construction cannot be shared. Now common arguments can be shared between the two and we get the other benefits of using Args objects (e.g. deferred evaluation of depsets to execution phase, etc.).

The change is to spill out the args object into a params file in `run_patcher` and load the command line arguments from a separate file rather than from the patcher config JSON object. Passing a list continues to work and the behavior should be unchanged. I've also updated a handful of linter aspects to pass Args objects instead.

### Changes are visible to end-users:

No, this is an internal API refactoring

### Test plan

- Covered by existing test cases