### PR TITLE
fix(release): fail release if any sarif_parser platform integrity is missing

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -40,6 +40,30 @@ RELEASED_BINARY_INTEGRITY = $(
 )
 EOF
 
+# Fail the release if any sarif_parser platform the toolchain requires is missing
+# an integrity entry. Without this, a dropped or unbuilt release binary silently
+# produces an incomplete RELEASED_BINARY_INTEGRITY, and the gap only surfaces at
+# `bazel build` time in a consuming repo as
+# "key \"sarif_parser-<platform>\" not found in dictionary" (see #906).
+# The required platforms are the keys of SARIF_PARSER_PLATFORMS.
+missing=()
+for platform in $(grep -oE '^    "[a-z0-9_]+": struct\(' tools/toolchains/sarif_parser_toolchain.bzl | sed -E 's/^    "([^"]+)".*/\1/'); do
+  ext=""
+  [[ "$platform" == windows_* ]] && ext=".exe"
+  key="sarif_parser-${platform}${ext}"
+  if ! grep -q "\"${key}\"" ${PREFIX}/tools/integrity.bzl; then
+    missing+=("$key")
+  fi
+done
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "ERROR: release integrity is missing entries for: ${missing[*]}" >&2
+  echo "The go-binaries/ artifact did not contain a .sha256 for every required" >&2
+  echo "sarif_parser platform. Aborting to avoid publishing a broken release." >&2
+  echo "Generated tools/integrity.bzl was:" >&2
+  cat ${PREFIX}/tools/integrity.bzl >&2
+  exit 1
+fi
+
 # Append that generated file back into the archive
 tar --file $ARCHIVE_TMP --append ${PREFIX}/tools/integrity.bzl
 

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -28,6 +28,17 @@ tar --create --auto-compress \
 # Delete the placeholder file
 tar --file $ARCHIVE_TMP --delete ${PREFIX}/tools/integrity.bzl
 
+# download-artifact now extracts a single artifact flat into the workspace root
+# rather than into go-binaries/ (actions/download-artifact#455). Move the files
+# back where the glob below and `release_files: go-binaries/*` expect them.
+# This is the root cause that shipped 2.7.0 with an empty integrity dict.
+if compgen -G '*.sha256' >/dev/null; then
+  mkdir -p go-binaries
+  for f in *.sha256; do
+    mv "$f" "${f%.sha256}" go-binaries/
+  done
+fi
+
 mkdir -p ${PREFIX}/tools
 cat >${PREFIX}/tools/integrity.bzl <<EOF
 "Generated during release by release_prep.sh"

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -28,10 +28,11 @@ tar --create --auto-compress \
 # Delete the placeholder file
 tar --file $ARCHIVE_TMP --delete ${PREFIX}/tools/integrity.bzl
 
-# download-artifact now extracts a single artifact flat into the workspace root
-# rather than into go-binaries/ (actions/download-artifact#455). Move the files
-# back where the glob below and `release_files: go-binaries/*` expect them.
-# This is the root cause that shipped 2.7.0 with an empty integrity dict.
+# A single uploaded artifact is extracted flat into the workspace root, not into
+# go-binaries/ (actions/download-artifact#455). Move the files into go-binaries/
+# so the integrity glob below and `release_files: go-binaries/*` find them; if
+# they are left in the root the glob matches nothing and the integrity dict is
+# published empty.
 if compgen -G '*.sha256' >/dev/null; then
   mkdir -p go-binaries
   for f in *.sha256; do
@@ -52,10 +53,10 @@ RELEASED_BINARY_INTEGRITY = $(
 EOF
 
 # Fail the release if any sarif_parser platform the toolchain requires is missing
-# an integrity entry. Without this, a dropped or unbuilt release binary silently
-# produces an incomplete RELEASED_BINARY_INTEGRITY, and the gap only surfaces at
-# `bazel build` time in a consuming repo as
-# "key \"sarif_parser-<platform>\" not found in dictionary" (see #906).
+# an integrity entry. A dropped or unbuilt release binary otherwise yields an
+# incomplete RELEASED_BINARY_INTEGRITY that publishes without error; the gap only
+# surfaces later in a consuming repo at `bazel build` time as
+# "key \"sarif_parser-<platform>\" not found in dictionary".
 # The required platforms are the keys of SARIF_PARSER_PLATFORMS.
 missing=()
 for platform in $(grep -oE '^    "[a-z0-9_]+": struct\(' tools/toolchains/sarif_parser_toolchain.bzl | sed -E 's/^    "([^"]+)".*/\1/'); do


### PR DESCRIPTION
## Summary

2.7.0 shipped with an incomplete `tools/integrity.bzl` (missing `sarif_parser-linux_amd64`), which broke `aspect lint`/`aspect format` on Linux for consumers:

```
no such package '@@aspect_rules_lint++toolchains+sarif_parser_linux_amd64//':
key "sarif_parser-linux_amd64" not found in dictionary
```

### Same root cause as rules_py #1110

Yes — this is the **same issue** @jbedard fixed in aspect-build/rules_py@9633720ec85fe97d2a3300b346b6101a6cdb64d8 (#1110). GHA `download-artifact` now extracts a single artifact **flat** into the workspace root rather than into `<name>/` (actions/download-artifact#455). rules_lint uses the same `release_ruleset.yaml@v7.6.0` reusable workflow and reads `go-binaries/*.sha256`, so after the change that glob matched nothing → empty `RELEASED_BINARY_INTEGRITY` → the broken release.

## What changed

1. **Root-cause fix (ports rules_py #1110):** relocate the flat-extracted `*.sha256` (and their binaries) back into `go-binaries/` before the integrity glob runs, so `release_prep.sh` and `release_files: go-binaries/*` find them again.

2. **Guardrail (new):** after generating `tools/integrity.bzl`, fail the release if any platform declared in `SARIF_PARSER_PLATFORMS` is missing its integrity key. This catches *any* future cause of a partial dict at publish time instead of shipping it broken.

## Are these changes visible to end-users?

No — release tooling. (It prevents a class of broken release that is very visible.)

## Test plan

- Verified the validation against fixtures: an incomplete dict (the broken 2.7.0 shape) fails listing every missing platform; a complete dict (all 7 `SARIF_PARSER_PLATFORMS`) passes.
- Confirmed rules_lint uses the same `release_ruleset.yaml@v7.6.0` as rules_py, so it has the same flat-extract behavior #1110 addressed.
- `shellcheck` clean (no new error-level findings).

> [!NOTE]
> A 2.7.1 patch release with the corrected integrity dict is still needed to unbreak existing 2.7.0 consumers; this PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
