### PR TITLE
fix(keep-sorted): honor 'no-lint' tag

### DIFF
--- a/lint/keep_sorted.bzl
+++ b/lint/keep_sorted.bzl
@@ -28,7 +28,7 @@ following the documentation at https://github.com/google/keep-sorted#usage.
 """
 
 load("@jq.bzl//jq:jq.bzl", "jq_lib")
-load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OPTIONAL_SARIF_PARSER_TOOLCHAIN", "OUTFILE_FORMAT", "filter_srcs", "noop_lint_action", "output_files", "parse_to_sarif_action", "patch_and_output_files")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OPTIONAL_SARIF_PARSER_TOOLCHAIN", "OUTFILE_FORMAT", "filter_srcs", "noop_lint_action", "output_files", "parse_to_sarif_action", "patch_and_output_files", "should_visit")
 load("//lint/private:patcher_action.bzl", "patcher_attrs", "run_patcher")
 
 _MNEMONIC = "AspectRulesLintKeepSorted"
@@ -90,6 +90,9 @@ def keep_sorted_action(ctx, executable, srcs, stdout, exit_code = None, options 
         )
 
 def _keep_sorted_aspect_impl(target, ctx):
+    if not should_visit(ctx.rule, ["*"]):
+        return []
+
     if ctx.attr._options[LintOptionsInfo].fix:
         outputs, info = patch_and_output_files(_MNEMONIC, target, ctx)
     else:

--- a/lint/private/lint_aspect.bzl
+++ b/lint/private/lint_aspect.bzl
@@ -35,7 +35,7 @@ def should_visit(rule, allow_kinds, allow_filegroup_tags = []):
 
     Args:
         rule: a [rules_attributes](https://bazel.build/rules/lib/builtins/rule_attributes.html) object
-        allow_kinds (list of string): return true if the rule's kind is in the list
+        allow_kinds (list of string): return true if the rule's kind is in the list, a value of ["*"] returns true for all rule kinds
         allow_filegroup_tags (list of string): return true if the rule is a filegroup and has a tag in this list
 
     Returns:
@@ -44,7 +44,7 @@ def should_visit(rule, allow_kinds, allow_filegroup_tags = []):
     if "no-lint" in rule.attr.tags:
         return False
 
-    if rule.kind in allow_kinds:
+    if rule.kind in allow_kinds or allow_kinds == ["*"]:
         return True
     if rule.kind == "filegroup":
         for allow_tag in allow_filegroup_tags:


### PR DESCRIPTION
This PR updates `lint_keep_sorted_aspect` to honor the `no-lint` tag on targets.

Since the keep-sorted aspect runs over all rule kinds, it did not include a `should_visit` check in its implementation, which causes it to ignore `no-lint` tags on the target.

I've updated `should_visit` to interpret `["*"]` to mean "allow all rule kinds"

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no, it's a bug fix
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Manual testing; please provide instructions so we can reproduce: Tested against our internal repository. Let me know if you'd like me to add a test case for this.
