### PR TITLE
fix(ty): unconditionally include main workspace bin directory in import search paths

### DIFF
--- a/examples/python/test/BUILD
+++ b/examples/python/test/BUILD
@@ -29,6 +29,12 @@ write_file(
     content = ["import os"],
 )
 
+write_file(
+    name = "py_code_generator_no_imports",
+    out = "main_generated_no_imports.py",
+    content = ["import os"],
+)
+
 py_library(
     name = "generated_py",
     srcs = ["generated.py"],
@@ -128,6 +134,22 @@ py_library(
 ty_test(
     name = "ty_should_find_generated_dep",
     srcs = [":dep_generated"],
+)
+
+py_library(
+    name = "generated_no_imports",
+    srcs = ["main_generated_no_imports.py"],
+)
+
+py_library(
+    name = "dep_main_generated_no_imports",
+    srcs = ["dep_main_generated_no_imports.py"],
+    deps = [":generated_no_imports"],
+)
+
+ty_test(
+    name = "ty_should_find_main_generated_no_imports_dep",
+    srcs = [":dep_main_generated_no_imports"],
 )
 
 py_library(

--- a/examples/python/test/dep_main_generated_no_imports.py
+++ b/examples/python/test/dep_main_generated_no_imports.py
@@ -1,0 +1,1 @@
+import test.main_generated_no_imports

--- a/lint/ty.bzl
+++ b/lint/ty.bzl
@@ -172,7 +172,9 @@ def _ty_aspect_impl(target, ctx):
     # _resolve_import_path maps each entry to the correct execroot-relative path:
     #   - pip packages get an "external/" prefix
     #   - workspace-internal paths get the workspace name stripped
-    import_paths = {}
+    import_paths = {
+        ctx.bin_dir.path: True,
+    }
 
     # Collect from deps attribute using PyInfo
     if hasattr(ctx.rule.attr, "deps"):


### PR DESCRIPTION
This PR unconditionally adds `ctx.bin_dir.path` to `import_paths` for `ty` aspect. 

### Why?

 Currently, lint/ty.bzl only populates import search paths from dep[PyInfo].imports or via dep.label.workspace_root (for external workspaces).

For standard generated targets in the main workspace (like a standard `py_proto_library` or `py_grpc_library` generated from `.proto` sources):
1. They do not specify an explicit imports attribute in their `PyInfo` provider.
2. `workspace_root` evaluates to "" (empty string).

This doesn't let ty to resolve generated files' import paths that don't have an `imports` attr.

 ```
   error[unresolved-import]: Import 'foo.bar.proto_name_py2' could not be resolved
```

---

### Changes are visible to end-users: No

### Test plan

- New test cases added

