### PR TITLE
feat(ktlint): emit SARIF machine output so findings surface in reports

### DIFF
--- a/examples/kotlin/test/BUILD
+++ b/examples/kotlin/test/BUILD
@@ -1,9 +1,24 @@
 "Demonstrates how to enforce zero-lint-tolerance policy with tests"
 
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_lint//lint/private:machine_report_testing.bzl", "report_test")
 load("//tools/lint:linters.bzl", "ktlint_test")
+load(":machine_output.bzl", "machine_ktlint_report")
 
 ktlint_test(
     name = "ktlint",
     srcs = ["//src:hello_kt"],
     expected_exit_code = 1,
+)
+
+machine_ktlint_report(
+    name = "machine_ktlint_report",
+    src = "//src:hello_kt",
+)
+
+report_test(
+    name = "ktlint_machine_output_test",
+    expected_tool = "KTLint",
+    expected_uri = "src/hello.kt",
+    report = "machine_ktlint_report",
 )

--- a/examples/kotlin/test/machine_output.bzl
+++ b/examples/kotlin/test/machine_output.bzl
@@ -1,0 +1,7 @@
+"Kotlin-specific machine report rules for testing."
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_lint//lint/private:machine_report_testing.bzl", "machine_report_rule")
+load("//tools/lint:linters.bzl", "ktlint")
+
+machine_ktlint_report = machine_report_rule(ktlint)

--- a/lint/ktlint.bzl
+++ b/lint/ktlint.bzl
@@ -52,7 +52,7 @@ If your custom ruleset is a third-party dependency and not a first-party depende
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@rules_java//java/common/rules:java_runtime.bzl", "JavaRuntimeInfo")
-load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "noop_lint_action", "output_files", "should_visit")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OPTIONAL_SARIF_PARSER_TOOLCHAIN", "OUTFILE_FORMAT", "filter_srcs", "noop_lint_action", "output_files", "parse_to_sarif_action", "should_visit")
 
 _MNEMONIC = "AspectRulesLintKTLint"
 
@@ -145,7 +145,13 @@ def _ktlint_aspect_impl(target, ctx):
 
     color_options = ["--color"] if ctx.attr._options[LintOptionsInfo].color else []
     ktlint_action(ctx, ctx.executable._ktlint, files_to_lint, ctx.file._editorconfig, outputs.human.out, ctx.file._baseline_file, ctx.attr._java_runtime, ruleset_jar, outputs.human.exit_code, color_options)
-    ktlint_action(ctx, ctx.executable._ktlint, files_to_lint, ctx.file._editorconfig, outputs.machine.out, ctx.file._baseline_file, ctx.attr._java_runtime, ruleset_jar, outputs.machine.exit_code)
+
+    # ktlint has no SARIF output mode, so parse its raw text report into SARIF
+    # in a separate action — this is what surfaces KTLint findings in the
+    # structured lint report (rather than only as passthrough stdout).
+    raw_machine_report = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "raw_machine_report"))
+    ktlint_action(ctx, ctx.executable._ktlint, files_to_lint, ctx.file._editorconfig, raw_machine_report, ctx.file._baseline_file, ctx.attr._java_runtime, ruleset_jar, outputs.machine.exit_code)
+    parse_to_sarif_action(ctx, _MNEMONIC, raw_machine_report, outputs.machine.out)
     return [info]
 
 def lint_ktlint_aspect(binary, editorconfig, baseline_file, ruleset_jar = None, rule_kinds = ["kt_jvm_library", "kt_jvm_binary", "kt_js_library"]):
@@ -205,5 +211,6 @@ def lint_ktlint_aspect(binary, editorconfig, baseline_file, ruleset_jar = None, 
         }, extra_attrs),
         toolchains = [
             "@bazel_tools//tools/jdk:toolchain_type",
+            OPTIONAL_SARIF_PARSER_TOOLCHAIN,
         ],
     )

--- a/tools/sarif/sarif.go
+++ b/tools/sarif/sarif.go
@@ -123,6 +123,9 @@ func ToSarifJsonString(label string, mnemonic string, report string) (sarifJsonS
 			`%IInfo: %f:%l:%c: %m`,
 			`%-G%.%#`,
 		}
+	case "AspectRulesLintKTLint":
+		// ktlint --relative text output: `path:line:col: message (rule)`.
+		fm = []string{`%f:%l:%c: %m`}
 	case "AspectRulesLintKeepSorted":
 		fm = []string{`%f:%l:%e:%m`}
 	case "AspectRulesLintTy":

--- a/tools/sarif/sarif_test.go
+++ b/tools/sarif/sarif_test.go
@@ -81,6 +81,22 @@ func TestSarif(t *testing.T) {
 		g.Expect(sarifJson.Runs[0].Results[1].Locations[0].PhysicalLocation.Region.GetRdfRange().Start.Line).To(Equal(int32(15)))
 	})
 
+	t.Run("processes ktlint output -> sarif correctly", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		sarifJsonString, _ := ToSarifJsonString("//src:hello_kt", "AspectRulesLintKTLint", ktlint_output)
+		sarifJson, _ := toSarifJson(sarifJsonString)
+
+		g.Expect(len(sarifJson.Runs)).To(Equal(1))
+		g.Expect(sarifJson.Runs[0].Tool.Driver.Name).To(Equal("KTLint"))
+		g.Expect(len(sarifJson.Runs[0].Results)).To(Equal(2))
+		g.Expect(sarifJson.Runs[0].Results[0].Message.Text).To(Equal("File name 'hello.kt' should conform PascalCase (standard:filename)"))
+		g.Expect(sarifJson.Runs[0].Results[1].Message.Text).To(Equal("Wildcard import (standard:no-wildcard-imports)"))
+		g.Expect(sarifJson.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI).To(Equal("src/hello.kt"))
+		g.Expect(sarifJson.Runs[0].Results[0].Locations[0].PhysicalLocation.Region.GetRdfRange().Start.Line).To(Equal(int32(1)))
+		g.Expect(sarifJson.Runs[0].Results[1].Locations[0].PhysicalLocation.Region.GetRdfRange().Start.Line).To(Equal(int32(2)))
+	})
+
 	t.Run("determineRelativePath: returns relative paths untouched", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 

--- a/tools/sarif/statics_test.go
+++ b/tools/sarif/statics_test.go
@@ -71,6 +71,9 @@ var pydoclint_output string
 //go:embed testdata/lint_result/cppcheck_output.txt
 var cppcheck_output string
 
+//go:embed testdata/lint_result/ktlint_output.txt
+var ktlint_output string
+
 type LintResult struct {
 	Label    string
 	Mnemonic string

--- a/tools/sarif/testdata/lint_result/ktlint_output.txt
+++ b/tools/sarif/testdata/lint_result/ktlint_output.txt
@@ -1,0 +1,2 @@
+src/hello.kt:1:1: File name 'hello.kt' should conform PascalCase (standard:filename)
+src/hello.kt:2:1: Wildcard import (standard:no-wildcard-imports)


### PR DESCRIPTION
The Aspect CLI reads each linter's **machine** output group expecting SARIF, and renders it as the structured lint findings report (the `⚠️ file:line · Linter — Rule` rows). Most linters print plain text, so their aspects run a `parse_to_sarif_action` step (driven by a per-linter errorformat in `tools/sarif`) to convert that text into SARIF for the machine output.

KTLint's aspect skipped that step: its plain-text output was written straight to the machine output group, unparsed. So the CLI got text where it expected SARIF, and KTLint violations only appeared as passthrough linter stdout — a failing run surfaced solely as `ERROR: Linter process(es) exited non-zero: KTLint`, with no structured findings.

This wires KTLint up like the other text-output linters (e.g. buildifier, pylint, ruff): run ktlint into a raw text report, then `parse_to_sarif_action` converts it to SARIF (registering the optional SARIF-parser toolchain on the aspect). Adds the `AspectRulesLintKTLint` errorformat case — `%f:%l:%c: %m`, matching ktlint's `--relative` `path:line:col: message (rule)` output.

> Note: `spotbugs.bzl` has the same missing-conversion gap and is **not** addressed here — its output needs its own errorformat mapping and there's no SpotBugs example to validate against. Left as a follow-up.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- KTLint findings now surface in the Aspect CLI's structured lint findings report (and SARIF-consuming surfaces), like other linters. Previously KTLint's machine output skipped SARIF conversion, so its violations only appeared as raw stdout.

### Test plan

- New test cases added
- `go test ./tools/sarif/...` passes, including a case asserting ktlint text output parses into SARIF (two findings, correct file/line/message, tool name `KTLint`).
- Added a `report_test` to the `examples/kotlin` test suite; `bazel test //test:all` (Bazel 8.x) passes, asserting the real ktlint machine report is SARIF with tool `KTLint` and URI `src/hello.kt`.
