### PR TITLE
chore(scala): bump minimum version of aspect_rules_lint

### DIFF
--- a/lint/scala/MODULE.bazel
+++ b/lint/scala/MODULE.bazel
@@ -5,7 +5,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "aspect_rules_lint", version = "2.7.1")
+bazel_dep(name = "aspect_rules_lint", version = "2.7.2")
 bazel_dep(name = "rules_java", version = "7.0.6")
 bazel_dep(name = "rules_scala", version = "7.1.6")
 


### PR DESCRIPTION
Follow-up to #914. Updates the minimum version of `aspect_rules_lint` required for `aspect_rules_lint_scala`.

### Changes are visible to end-users:

No

### Test plan

- Covered by existing test cases