### PR TITLE
chore: publish aspect_rules_lint_scala on scala-v* tags

### DIFF
--- a/.bcr/README.md
+++ b/.bcr/README.md
@@ -14,6 +14,8 @@ live under this folder at the same relative path as the module in the repo:
 - `.bcr/` — the root `aspect_rules_lint` module, released from `v*` tags
 - `.bcr/lint/rust/` — the `aspect_rules_lint_rust` module (`lint/rust`),
   released from `rust-v*` tags
+- `.bcr/lint/scala/` — the `aspect_rules_lint_scala` module (`lint/scala`),
+  released from `scala-v*` tags
 
 Each release publishes exactly one module: the trigger workflow passes the
 module's root through the `module_roots` input of the publish-to-bcr reusable

--- a/.bcr/lint/scala/metadata.template.json
+++ b/.bcr/lint/scala/metadata.template.json
@@ -1,0 +1,23 @@
+{
+  "homepage": "https://github.com/aspect-build/rules_lint",
+  "maintainers": [
+    {
+      "email": "jesse@aspect.build",
+      "github": "JesseTatasciore",
+      "name": "Jesse Tatasciore"
+    },
+    {
+      "email": "jason@aspect.build",
+      "github": "jbedard",
+      "name": "Jason Bedard"
+    },
+    {
+      "email": "r@rafiksalama.com",
+      "github": "rafikk",
+      "name": "Rafik Salama"
+    }
+  ],
+  "repository": ["github:aspect-build/rules_lint"],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/lint/scala/presubmit.yml
+++ b/.bcr/lint/scala/presubmit.yml
@@ -1,0 +1,12 @@
+matrix:
+  platform:
+    - ubuntu2204
+    - macos
+  bazel: [8.x, 9.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@aspect_rules_lint_scala//:all"

--- a/.bcr/lint/scala/source.template.json
+++ b/.bcr/lint/scala/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "**leave this alone**",
+  "strip_prefix": "rules_lint-{TAG}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_lint-{TAG}.tar.gz"
+}

--- a/.github/workflows/release-scala.yml
+++ b/.github/workflows/release-scala.yml
@@ -1,0 +1,36 @@
+# Release + publish aspect_rules_lint_scala to the BCR, independently of the
+# root module (own scala-v* version line). Thin trigger over release-module.yaml;
+# to add another module (e.g. lint/scala), copy this file with a new tag
+# prefix / root / name (and add a release_prep.sh case + .bcr/<module>/ templates).
+name: Release Scala lint module
+
+on:
+  push:
+    tags:
+      - "scala-v*.*.*"
+  # In case of problems, let release engineers retry by manually dispatching
+  # the workflow from the GitHub UI
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  attestations: write
+  contents: write
+
+jobs:
+  release:
+    uses: ./.github/workflows/release-module.yaml
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      tag_prefix: "scala-v"
+      module_root: "lint/scala"
+      module_name: "aspect_rules_lint_scala"
+      # The root workspace's tests don't cover this nested module (it is its
+      # own Bazel workspace, tested by repo CI), so skip the test run.
+      bazel_test_command: "true"
+    secrets:
+      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -76,6 +76,8 @@ rust-v*)
 	SRC_MODULE_ROOT="lint/rust"
 	;;
 	# rules-rust-v*) SRC_MODULE_ROOT="lint/rules_rust" ;;
+scala-v*)
+	SRC_MODULE_ROOT="lint/scala"
 v*) ;; # Root module release, handled below.
 *)
 	echo "Unknown tag format: ${TAG}" >&2

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -20,7 +20,7 @@ setup() {
     assert_output --partial "+ prettier --write --log-level=warn examples/nodejs/src/(special_char)/[square]/hello.ts examples/nodejs/src/file-dep.ts examples/nodejs/src/file.ts"
     assert_output --partial "+ prettier --write --log-level=warn examples/nodejs/src/hello.tsx"
     assert_output --partial "+ prettier --write --log-level=warn examples/nodejs/src/hello.vue"
-    assert_output --partial "+ prettier --write --log-level=warn .bcr/lint/rust/metadata.template.json .bcr/lint/rust/source.template.json .bcr/metadata.template.json .bcr/source.template.json"
+    assert_output --partial "+ prettier --write --log-level=warn .bcr/lint/rust/metadata.template.json .bcr/lint/rust/source.template.json .bcr/lint/scala/metadata.template.json .bcr/lint/scala/source.template.json .bcr/metadata.template.json .bcr/source.template.json"
     assert_output --partial "+ prettier --write --log-level=warn examples/nodejs/.swcrc"
     assert_output --partial "+ prettier --write --log-level=warn examples/other_formatters/src/config.json5"
 }
@@ -206,7 +206,7 @@ setup() {
     run bazel run //format/test:format_YAML_with_yamlfmt
     assert_success
 
-    assert_output --partial "+ yamlfmt .bcr/lint/rust/presubmit.yml .bcr/presubmit.yml"
+    assert_output --partial "+ yamlfmt .bcr/lint/rust/presubmit.yml .bcr/lint/scala/presubmit.yml .bcr/presubmit.yml"
 }
 
 @test "should run rustfmt on Rust" {


### PR DESCRIPTION
Adds set up for publishing `aspect_rules_lint_scala` to BCR.

### Changes are visible to end-users:

no

### Test plan

- Manual testing
