### PR TITLE
fix(patcher.mjs): filter out empty lines for the args file

### DIFF
--- a/lint/private/patcher.mjs
+++ b/lint/private/patcher.mjs
@@ -48,7 +48,7 @@ async function sync(src, dst, subdir, filesToDiff) {
 async function main(args, sandbox) {
   const config = JSON.parse(await fs.promises.readFile(args[0]));
   const spawnArgs = args.length > 1
-    ? (await fs.promises.readFile(args[1], "utf8")).split(/\r?\n/)
+    ? (await fs.promises.readFile(args[1], "utf8")).split(/\r?\n/).filter(Boolean)
     : config.args;
 
   debug("sandbox", sandbox);


### PR DESCRIPTION
We noticed through a combination of arguments that an empty line could sneak in the argument files passed through patcher.mjs

When using the `ruff` linter, this extra line is passed as an empty argument to the `ruff` command which is rejected and the linting fails.

This patch adds a filter call after the split to prevent empty strings from leaking to the command.

### Changes are visible to end-users: no

### Test plan

I have setup a reproduction repo here: https://github.com/gergondet-woven/rules_lint-patcher_mjs-issue-repro

In this repo, running `./lint.sh` will show there is a fixable linter error but running `./fix.sh` will manifest the bug

I am not sure how this can be reproduced within this repo or if it's worth it given the patch is not so involved.

