### PR TITLE
fix(format): forward tags to multirun individual commands

### DIFF
--- a/format/defs.bzl
+++ b/format/defs.bzl
@@ -116,6 +116,7 @@ def format_multirun(name, jobs = 4, print_command = False, disable_git_attribute
             command(
                 command = Label("@aspect_rules_lint//format/private:format"),
                 description = "Formatting {} with {}...".format(lang, toolname),
+                tags = common_attrs.get("tags", []),
                 **_format_attr_factory(target_name, lang, toolname, tool_label, mode, disable_git_attribute_checks, custom_args)
             )
         commands.append(target_name)


### PR DESCRIPTION
This PR forwards tags passed to format_multirun to the individual commands it creates.

Our main use-case here is to pass `manual` down to avoid pulling in the llvm_toolchain_llvm repo unless it's required for formatting/linting purposes.

### Changes are visible to end-users: no

### Test plan

- `bazel build //...` in a repo that has multirun_format with clang-format sourced through the `llvm_toolchain` module, with `tags = ["manual"]` passed to the `format_multirun` macro, the repo is still pulled prior to this patch, after this patch it's not;
