### PR TITLE
refactor: only call clang tidy once

### DIFF
--- a/lint/clang_tidy.bzl
+++ b/lint/clang_tidy.bzl
@@ -37,13 +37,13 @@ clang_tidy = lint_clang_tidy_aspect(
 ```
 """
 
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules/directory:providers.bzl", "DirectoryInfo")
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OPTIONAL_SARIF_PARSER_TOOLCHAIN", "OUTFILE_FORMAT", "noop_lint_action", "output_files", "parse_to_sarif_action", "patch_and_output_files", "should_visit")
 load("//lint/private:patcher_action.bzl", "patcher_attrs", "run_patcher")
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
 _MNEMONIC = "AspectRulesLintClangTidy"
 _DISABLED_FEATURES = [
@@ -412,8 +412,8 @@ def _clang_tidy_aspect_impl(target, ctx):
 
         # TODO(alex): if we run with --fix, this will report the issues that were fixed. Does a machine reader want to know about them?
         raw_machine_report = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name + "_rules_lint/" + file.short_path, mnemonic = _MNEMONIC, suffix = "raw_machine_report"))
-	copy_file(name = "raw_machine_report_copy", out = raw_machine_report, src = output.human.out)
-	copy_file(name = "machine_exit_copde_copy", out = output.machine.exit_code, src = output.human.exit_code)
+        copy_file(name = "raw_machine_report_copy", out = raw_machine_report, src = output.human.out)
+        copy_file(name = "machine_exit_copde_copy", out = output.machine.exit_code, src = output.human.exit_code)
         parse_to_sarif_action(ctx, _MNEMONIC, raw_machine_report, output.machine.out)
     return [info]
 

--- a/lint/clang_tidy.bzl
+++ b/lint/clang_tidy.bzl
@@ -43,6 +43,7 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
 load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OPTIONAL_SARIF_PARSER_TOOLCHAIN", "OUTFILE_FORMAT", "noop_lint_action", "output_files", "parse_to_sarif_action", "patch_and_output_files", "should_visit")
 load("//lint/private:patcher_action.bzl", "patcher_attrs", "run_patcher")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
 _MNEMONIC = "AspectRulesLintClangTidy"
 _DISABLED_FEATURES = [
@@ -411,7 +412,8 @@ def _clang_tidy_aspect_impl(target, ctx):
 
         # TODO(alex): if we run with --fix, this will report the issues that were fixed. Does a machine reader want to know about them?
         raw_machine_report = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name + "_rules_lint/" + file.short_path, mnemonic = _MNEMONIC, suffix = "raw_machine_report"))
-        clang_tidy_action(ctx, compilation_context, ctx.executable, [file], raw_machine_report, output.machine.exit_code)
+	copy_file(name = "raw_machine_report_copy", out = raw_machine_report, src = output.human.out)
+	copy_file(name = "machine_exit_copde_copy", out = output.machine.exit_code, src = output.human.exit_code)
         parse_to_sarif_action(ctx, _MNEMONIC, raw_machine_report, output.machine.out)
     return [info]
 


### PR DESCRIPTION
While trying to improve performance of a `clang-tidy` job in my project using `rules_lint`, I noticed that `clang_tidy_action` was called twice, once to produce human-readable output and once to produce machine output. This looks like, in the worst case, it could end up with `clang-tidy` being called twice per target. Perhaps it is the case that the cache will almost always save us, but it's not 100% guaranteed and it makes the code a bit harder to follow.

This change instead just calls `copy_file` to copy the human output to the machine output, which it can then alter to its hearts content without risking a second call out to `clang-tidy`.

---

### Changes are visible to end-users: No

### Test plan

- Covered by existing test cases

This is a semantic noop, so existing test cases should cover it.