### PR TITLE
feat(format): use Prettier for YAML formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Linters which are not language-specific:
 | TOML                   | [taplo]                   |                                                         |
 | TSX                    | [Prettier]                | [ESLint]                                                |
 | TypeScript             | [Prettier]                | [ESLint]                                                |
-| YAML                   | [yamlfmt]                 | [yamllint]                                              |
+| YAML                   | [Prettier]                | [yamllint]                                              |
 | XML                    | [prettier/plugin-xml]     |                                                         |
 
 [prettier]: https://prettier.io
@@ -204,7 +204,6 @@ Linters which are not language-specific:
 [cue fmt]: https://cuelang.org/docs/reference/command/cue-help-fmt/
 [cppcheck]: https://www.cppcheck.com/
 [vale]: https://vale.sh/
-[yamlfmt]: https://github.com/google/yamlfmt
 [yamllint]: https://yamllint.readthedocs.io/en/stable/
 [rustfmt]: https://rust-lang.github.io/rustfmt
 [stylelint]: https://stylelint.io

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,7 @@ Each example is self-contained and shows:
 - `ruby/` - Ruby formatting with RuboCop; linting with RuboCop or StandardRB
 - `kotlin/` - Kotlin formatting with ktfmt; linting with Ktlint
 - `css/` - CSS formatting with Prettier; linting with Stylelint
-- `yaml/` - YAML formatting with yamlfmt; linting with Yamllint
+- `yaml/` - YAML formatting with Prettier; linting with Yamllint
 - `markdown/` - Markdown formatting with Prettier; linting with Vale
 - `proto/` - Protocol Buffer formatting and linting with Buf
 - `starlark/` - Starlark formatting with Buildifier; linting with Buildifier

--- a/examples/yaml/BUILD
+++ b/examples/yaml/BUILD
@@ -1,6 +1,9 @@
+load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 
 package(default_visibility = ["//visibility:public"])
+
+npm_link_all_packages(name = "node_modules")
 
 compile_pip_requirements(
     name = "requirements",

--- a/examples/yaml/MODULE.bazel
+++ b/examples/yaml/MODULE.bazel
@@ -1,12 +1,20 @@
 "Bazel dependencies for YAML formatting and linting example"
 
 bazel_dep(name = "aspect_rules_lint")
+bazel_dep(name = "aspect_rules_js", version = "2.0.0")
 bazel_dep(name = "rules_python", version = "0.26.0")
 
 local_path_override(
     module_name = "aspect_rules_lint",
     path = "../..",
 )
+
+npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
+npm.npm_translate_lock(
+    name = "npm",
+    pnpm_lock = "//:pnpm-lock.yaml",
+)
+use_repo(npm, "npm")
 
 python_version = "3.9"
 

--- a/examples/yaml/README.md
+++ b/examples/yaml/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to set up formatting and linting for YAML files us
 
 ### Formatters
 
-- **yamlfmt** - YAML formatter
+- **Prettier** - YAML formatter
 
 ### Linters
 

--- a/examples/yaml/package.json
+++ b/examples/yaml/package.json
@@ -1,0 +1,9 @@
+{
+  "devDependencies": {
+    "prettier": "^3.6.2"
+  },
+  "packageManager": "pnpm@10.5.2",
+  "pnpm": {
+    "onlyBuiltDependencies": []
+  }
+}

--- a/examples/yaml/pnpm-lock.yaml
+++ b/examples/yaml/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: "9.0"
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    devDependencies:
+      prettier:
+        specifier: ^3.6.2
+        version: 3.9.6
+
+packages:
+  prettier@3.9.6:
+    resolution:
+      {
+        integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==,
+      }
+    engines: { node: ">=14" }
+    hasBin: true
+
+snapshots:
+  prettier@3.9.6: {}

--- a/examples/yaml/tools/format/BUILD
+++ b/examples/yaml/tools/format/BUILD
@@ -1,9 +1,15 @@
 load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
+load("@npm//:prettier/package_json.bzl", prettier = "bin")
 
 package(default_visibility = ["//:__subpackages__"])
+
+prettier.prettier_binary(
+    name = "prettier",
+    env = {"BAZEL_BINDIR": "."},
+)
 
 format_multirun(
     name = "format",
     visibility = ["//:__subpackages__"],
-    yaml = "@aspect_rules_lint//format:yamlfmt",
+    yaml = ":prettier",
 )

--- a/format/multitool.lock.json
+++ b/format/multitool.lock.json
@@ -209,49 +209,5 @@
         "cpu": "x86_64"
       }
     ]
-  },
-  "yamlfmt": {
-    "binaries": [
-      {
-        "kind": "archive",
-        "url": "https://github.com/google/yamlfmt/releases/download/v0.21.0/yamlfmt_0.21.0_Linux_arm64.tar.gz",
-        "file": "yamlfmt",
-        "sha256": "5b2689c963b177271330c5ce8ca7396751107e5a826be46f03d2cb9b6f0c7784",
-        "os": "linux",
-        "cpu": "arm64"
-      },
-      {
-        "kind": "archive",
-        "url": "https://github.com/google/yamlfmt/releases/download/v0.21.0/yamlfmt_0.21.0_Linux_x86_64.tar.gz",
-        "file": "yamlfmt",
-        "sha256": "1f300d9257b232bb3b541d7fb1b0e6b3c121bcbab381c86cd38cb8722be8a566",
-        "os": "linux",
-        "cpu": "x86_64"
-      },
-      {
-        "kind": "archive",
-        "url": "https://github.com/google/yamlfmt/releases/download/v0.21.0/yamlfmt_0.21.0_Darwin_arm64.tar.gz",
-        "file": "yamlfmt",
-        "sha256": "4b417ecb94339d57e4c122ecc948c1a00fe328b5853266de9806e652a92858fa",
-        "os": "macos",
-        "cpu": "arm64"
-      },
-      {
-        "kind": "archive",
-        "url": "https://github.com/google/yamlfmt/releases/download/v0.21.0/yamlfmt_0.21.0_Darwin_x86_64.tar.gz",
-        "file": "yamlfmt",
-        "sha256": "060e943bcb8583c456810eb1ff4721b4f46c4a0c1a4432449d5dc3bbfe29a22b",
-        "os": "macos",
-        "cpu": "x86_64"
-      },
-      {
-        "kind": "archive",
-        "url": "https://github.com/google/yamlfmt/releases/download/v0.21.0/yamlfmt_0.21.0_Windows_x86_64.tar.gz",
-        "file": "yamlfmt.exe",
-        "sha256": "07f80ce5d741eb4b0a9380ac78a19c7cb5bd44e2a9a47a5a04839e3ba54dd463",
-        "os": "windows",
-        "cpu": "x86_64"
-      }
-    ]
   }
 }

--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -29,7 +29,7 @@ TOOLS = {
     "C": "clang-format",
     "C++": "clang-format",
     "Cuda": "clang-format",
-    "YAML": "yamlfmt",
+    "YAML": "prettier",
     "Rust": "rustfmt",
     "XML": "prettier",
     "Gherkin": "prettier",
@@ -46,7 +46,6 @@ BUILTIN_TOOL_LABELS = {
     "Go": "@multitool//tools/gofumpt",
     "Shell": "@multitool//tools/shfmt",
     "Terraform": "@multitool//tools/terraform",
-    "YAML": "@multitool//tools/yamlfmt",
     "Python": "@multitool//tools/ruff",
 }
 
@@ -69,7 +68,6 @@ CHECK_FLAGS = {
     "jsonnetfmt": "--test",
     "scalafmt": "--test --respect-project-filters",
     "clang-format": "--style=file --fallback-style=none --dry-run -Werror",
-    "yamlfmt": "-lint",
     "rustfmt": "--check",
     "fantomas": "--check",
     "csharpier": "check",
@@ -103,7 +101,6 @@ FIX_FLAGS = {
     # https://github.com/scalameta/scalafmt/pull/2020
     "scalafmt": "--respect-project-filters",
     "clang-format": "-style=file --fallback-style=none -i",
-    "yamlfmt": "",
     "rustfmt": "",
     "fantomas": "",
     "csharpier": "format",

--- a/format/test/BUILD.bazel
+++ b/format/test/BUILD.bazel
@@ -69,7 +69,7 @@ format_multirun(
     terraform = ":mock_terraform-fmt.sh",
     toml = ":mock_taplo.sh",
     xml = ":mock_prettier.sh",
-    yaml = ":mock_yamlfmt.sh",
+    yaml = ":mock_prettier.sh",
 )
 
 format_multirun(

--- a/format/test/format_test.bats
+++ b/format/test/format_test.bats
@@ -202,11 +202,12 @@ setup() {
     assert_output --partial "+ buf format --write --disable-symlinks --path examples/protobuf/src/unused.proto"
 }
 
-@test "should run yamlfmt on YAML" {
-    run bazel run //format/test:format_YAML_with_yamlfmt
+@test "should run prettier on YAML" {
+    run bazel run //format/test:format_YAML_with_prettier
     assert_success
 
-    assert_output --partial "+ yamlfmt .bcr/lint/rust/presubmit.yml .bcr/lint/scala/presubmit.yml .bcr/presubmit.yml"
+    assert_output --partial "+ prettier --write --log-level=warn .bcr/lint/rust/presubmit.yml .bcr/lint/scala/presubmit.yml .bcr/presubmit.yml"
+    assert_output --partial "examples/yaml/src/config.yaml"
 }
 
 @test "should run rustfmt on Rust" {


### PR DESCRIPTION
AI-written, human-reviewed.

Replace yamlfmt with Prettier as the YAML formatter and update the example, tests, and documentation.

This is a breaking change. Users must replace yamlfmt-specific binaries, arguments, and generated targets with their Prettier equivalents.

Fixes #864.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

YAML formatting now uses Prettier instead of yamlfmt.

### Test plan

- Covered by existing test cases
- Manual testing: ran the YAML formatter example and formatting checks