### PR TITLE
fix(patcher): Use path.sep when comparing paths on windows

### DIFF
--- a/lint/private/patcher.mjs
+++ b/lint/private/patcher.mjs
@@ -34,7 +34,9 @@ async function sync(src, dst, subdir, filesToDiff) {
       // while with `cp` the `deference` option must be set explicitly.
       await fs.promises.copyFile(srcF, dstF);
       await fs.promises.chmod(dstF, "600");
-    } else if (filesToDiff.find((d) => d.startsWith(f + "/")) !== undefined) {
+    } else if (
+      filesToDiff.find((d) => d.startsWith(f + path.sep)) !== undefined
+    ) {
       debug(`entering ${f}`);
       await sync(src, dst, f, filesToDiff);
     } else {


### PR DESCRIPTION
On windows patching will silently fail to sandbox the files it is fixing. When it sees a windows path like `src\foo.ts` it won't recognize that `src\` is a folder since it only checks for forward slash `/` and will not recurse into the directory. It will create a symlink to the actual `src\` directory from execroot and the linter applies its fixes to `src\foo.ts`, modifying the actual source file. When the file is diffed against sandbox symlink no changes are found and a fix is not generated.

---

### Test plan

It is not possible to run the examples in windows currently. There needs to be a few more patches to rules_lint and a patch to rules_multirun and possibly and upgrade to v2 of rules_python. This is a start with the goal of enabling the CI pipeline on windows.

