### PR TITLE
fix(format): guard against getconf not reporting ARG_MAX

### DIFF
--- a/format/private/format.sh
+++ b/format/private/format.sh
@@ -64,7 +64,12 @@ function process_args_in_batches() {
     # Uses up to ARG_MAX - 2k, or 128k, whichever is smaller, characters per
     # command. This was derived from following the defaults from xargs
     # https://www.gnu.org/software/findutils/manual/html_node/find_html/Limiting-Command-Size.html
-    max_batch_size=$(getconf ARG_MAX)-2048
+    # MSYS and Cygwin report ARG_MAX as "undefined", so fall back to the 8191
+    # character command line limit of cmd.exe, which formatters shipped as a
+    # `.bat` launcher have to be invoked through.
+    arg_max=$(getconf ARG_MAX)
+    [[ "$arg_max" =~ ^[0-9]+$ ]] || arg_max=8191
+    max_batch_size=$((arg_max - 2048))
     max_batch_size=$((max_batch_size < 128000 ? max_batch_size : 128000))
     
     # Check if there's only one argument and it starts with '@'


### PR DESCRIPTION
MSYS2 and git bash print "undefined" for `getconf ARG_MAX`. This causes an arithmetic expansion to be evaluated `undefined-2048` as -2048 and the formatter to pass no files to format command, which makes all files get formatted or checked.

This PR changes format.sh to validate that ARG_MAX is a number and otherwise fall back to the low command line limit of `cmd.exe` 8191 chars.


---


### Test plan

The format.sh bash script can be tested directly in msys2 or git bash to see that passed in files are ignored and all files are formatted.

To run formatting on windows rules_multirun needs a patch to create `.bat` files or else multirun fails to run bash scripts. Once that change is merged into rules_multirun it should be possible to test formatting with this change.