### PR TITLE
fix: Create windows launcher for shells scripts

### DIFF
--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -153,7 +153,10 @@ bzl_library(
 bzl_library(
     name = "lint_test",
     srcs = ["lint_test.bzl"],  # keep
-    deps = ["@bazel_lib//lib:paths"],
+    deps = [
+        "@bazel_lib//lib:paths",
+        "@bazel_lib//lib:windows_utils",
+    ],
 )
 
 bzl_library(

--- a/lint/lint_test.bzl
+++ b/lint/lint_test.bzl
@@ -36,6 +36,7 @@ flake8_test(
 """
 
 load("@bazel_lib//lib:paths.bzl", "to_rlocation_path")
+load("@bazel_lib//lib:windows_utils.bzl", "create_windows_native_launcher_script")
 
 def _write_assert(ctx, files):
     "Create a parameter to substitute into the shell script"
@@ -72,8 +73,15 @@ def _test_impl(ctx):
         },
         is_executable = True,
     )
+
+    if ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo]):
+        launcher = create_windows_native_launcher_script(ctx, bin)
+        runfiles = runfiles.merge(ctx.runfiles(files = [bin]))
+    else:
+        launcher = bin
+
     return [DefaultInfo(
-        executable = bin,
+        executable = launcher,
         runfiles = runfiles,
     )]
 
@@ -89,6 +97,8 @@ def lint_test(aspect):
             """),
             "_bin": attr.label(default = ":lint_test.sh", allow_single_file = True, executable = True, cfg = "exec"),
             "_runfiles_lib": attr.label(default = "@bazel_tools//tools/bash/runfiles"),
+            "_windows_constraint": attr.label(default = "@platforms//os:windows"),
         },
+        toolchains = ["@bazel_tools//tools/sh:toolchain_type"],
         test = True,
     )


### PR DESCRIPTION
Windows can only execute files with extension `.exe`, `.bat`, or `.cmd` when using the windows api `CreateProcessW`, which bazel uses to run DefaultInfo provider executables. When executing a bash shell script it must be wrapped in a windows launcher. Using the launcher from `bazel-lib` to create a batch script, when on windows, that executes bash script from runfiles will fix this issue and keep supporting bash scripts for assertions.

---

### Test plan

To test this create any `lint_test()` aspect rule in windows. It currently fails when trying to run `lint_test.sh`.
```
CreateProcessW(...keep_sorted.lint_test.sh): %1 is not a valid Win32 application. (error: 193) 
```
Will eventually have this tested by CI pipeline once other changes are merged.
