### PR TITLE
docs: align supported tools and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,47 +124,50 @@ Linters which are not language-specific:
 
 - [keep-sorted]
 
-| Language               | Formatter                 | Linter(s)                                               |
-| ---------------------- | ------------------------- | ------------------------------------------------------- |
-| C / C++                | [clang-format]            | [clang-tidy] or [cppcheck]                              |
-| CUE                    | [cue fmt]                 |                                                         |
-| Cuda                   | [clang-format]            |                                                         |
-| CSS, Less, Sass        | [Prettier]                | [Stylelint]                                             |
-| F#                     | [Fantomas]                |                                                         |
-| Go                     | [gofmt] or [gofumpt]      |                                                         |
-| Go Module              | [modfmt]                  |                                                         |
-| Gherkin                | [prettier-plugin-gherkin] |                                                         |
-| GraphQL                | [Prettier]                |                                                         |
-| HCL (Hashicorp Config) | [terraform] fmt           |                                                         |
-| HTML                   | [Prettier]                |                                                         |
-| JSON                   | [Prettier]                |                                                         |
-| Java                   | [google-java-format]      | [pmd] , [Checkstyle], [Spotbugs]                        |
-| JavaScript             | [Prettier]                | [ESLint]                                                |
-| HTML templates         | [djlint]                  |                                                         |
-| Jsonnet                | [jsonnetfmt]              |                                                         |
-| Kotlin                 | [ktfmt]                   | [ktlint]                                                |
-| Markdown               | [Prettier]                | [Vale]                                                  |
-| Pkl                    | [pkl]                     |                                                         |
-| Protocol Buffer        | [buf]                     | [buf lint]                                              |
-| Python                 | [ruff]                    | [bandit], [flake8], [pydoclint], [pylint], [ruff], [ty] |
-| QML                    | [qmlformat]               | [qmllint]                                               |
-| Ruby                   |                           | [RuboCop], [Standard]                                   |
-| Rust                   | [rustfmt]                 | [clippy]                                                |
-| SQL                    | [prettier-plugin-sql]     |                                                         |
-| Scala                  | [scalafmt]                | [scalafix]                                              |
-| Shell                  | [shfmt]                   | [shellcheck]                                            |
-| Starlark               | [Buildifier]              | [Buildifier]                                            |
-| Swift                  | [SwiftFormat] (1)         |                                                         |
-| TOML                   | [taplo]                   | [taplo]                                                 |
-| TSX                    | [Prettier]                | [ESLint]                                                |
-| TypeScript             | [Prettier]                | [ESLint]                                                |
-| YAML                   | [yamlfmt]                 | [yamllint]                                              |
-| XML                    | [prettier/plugin-xml]     |                                                         |
+| Language           | Formatter                 | Linter(s)                                               |
+| ------------------ | ------------------------- | ------------------------------------------------------- |
+| C / C++            | [clang-format]            | [clang-tidy] or [cppcheck]                              |
+| C#                 | [CSharpier]               |                                                         |
+| CUE                | [cue fmt]                 |                                                         |
+| CUDA               | [clang-format]            |                                                         |
+| CSS, Less, SCSS    | [Prettier]                | [Stylelint]                                             |
+| F#                 | [Fantomas]                |                                                         |
+| Go                 | [gofmt] or [gofumpt]      |                                                         |
+| Go Module          | [modfmt]                  |                                                         |
+| Gherkin            | [prettier-plugin-gherkin] |                                                         |
+| GraphQL            | [Prettier]                |                                                         |
+| HTML               | [Prettier]                |                                                         |
+| HTML templates     | [djlint]                  |                                                         |
+| JSON, JSON5, JSONC | [Prettier]                |                                                         |
+| Java               | [google-java-format]      | [pmd], [Checkstyle], [SpotBugs]                         |
+| JavaScript         | [Prettier]                | [ESLint]                                                |
+| Jsonnet            | [jsonnetfmt]              |                                                         |
+| Kotlin             | [ktfmt]                   | [ktlint]                                                |
+| Markdown           | [Prettier]                | [Vale]                                                  |
+| Pkl                | [pkl]                     |                                                         |
+| Protocol Buffer    | [buf]                     | [buf lint]                                              |
+| Python             | [ruff]                    | [bandit], [flake8], [pydoclint], [pylint], [ruff], [ty] |
+| QML                | [qmlformat]               | [qmllint]                                               |
+| Ruby               |                           | [RuboCop], [StandardRB][standard]                       |
+| Rust               | [rustfmt]                 | [clippy]                                                |
+| SQL                | [prettier-plugin-sql]     |                                                         |
+| Scala              | [scalafmt]                | [scalafix]                                              |
+| Shell              | [shfmt]                   | [shellcheck]                                            |
+| Starlark           | [Buildifier]              | [Buildifier]                                            |
+| Swift              | [SwiftFormat] (1)         |                                                         |
+| Terraform          | [terraform] fmt           |                                                         |
+| TOML               | [taplo]                   | [taplo]                                                 |
+| TSX                | [Prettier]                | [ESLint]                                                |
+| TypeScript         | [Prettier]                | [ESLint]                                                |
+| Vue                | [Prettier]                |                                                         |
+| YAML               | [yamlfmt]                 | [yamllint]                                              |
+| XML                | [prettier/plugin-xml]     |                                                         |
 
 [prettier]: https://prettier.io
+[csharpier]: https://csharpier.com/
 [google-java-format]: https://github.com/google/google-java-format
 [bandit]: https://bandit.readthedocs.io/en/latest/
-[Fantomas]: https://fsprojects.github.io/fantomas/
+[fantomas]: https://fsprojects.github.io/fantomas/
 [flake8]: https://flake8.pycqa.org/en/latest/index.html
 [pydoclint]: https://jsh9.github.io/pydoclint/
 [pmd]: https://docs.pmd-code.org/latest/index.html

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,30 +1,37 @@
 # Examples
 
-This directory contains language-specific examples demonstrating how to use `rules_lint` for both formatting and linting.
+This directory contains self-contained examples demonstrating how to use `rules_lint` for formatting, linting, or both.
 
-Each example is self-contained and shows:
+Each example includes a minimal working configuration for its supported tools. From an example directory, run `aspect format` for formatting or `aspect lint //...` for linting when the corresponding tool is configured.
 
-- How to set up formatting and linting for a specific language
-- Minimal working configuration
-- How to run formatters and linters with Bazel
+## Available Examples
 
-## Structure
+| Directory           | Formatter(s)                                                                  | Linter(s)                                   |
+| ------------------- | ----------------------------------------------------------------------------- | ------------------------------------------- |
+| `cpp/`              | clang-format for C, C++, and CUDA                                             | clang-tidy, Cppcheck                        |
+| `csharp/`           | CSharpier                                                                     |                                             |
+| `fsharp/`           | Fantomas                                                                      |                                             |
+| `go-module/`        | modfmt                                                                        |                                             |
+| `go/`               | gofumpt                                                                       |                                             |
+| `java/`             | google-java-format                                                            | PMD, Checkstyle, SpotBugs                   |
+| `keep-sorted/`      |                                                                               | keep-sorted                                 |
+| `kotlin/`           | ktfmt                                                                         | ktlint                                      |
+| `nodejs/`           | Prettier for JavaScript, TypeScript, Vue, CSS, Less, SCSS, HTML, and Markdown | ESLint, Stylelint, Vale                     |
+| `other_formatters/` | cue fmt, Prettier, jsonnetfmt, djlint                                         |                                             |
+| `pkl/`              | pkl format                                                                    |                                             |
+| `protobuf/`         | Buf                                                                           | Buf                                         |
+| `python/`           | Ruff                                                                          | Ruff, Bandit, Flake8, pydoclint, Pylint, ty |
+| `qml/`              | qmlformat                                                                     | qmllint                                     |
+| `ruby/`             |                                                                               | RuboCop, StandardRB                         |
+| `rust/`             | rustfmt                                                                       | Clippy                                      |
+| `scala/`            | Scalafmt                                                                      | Scalafix                                    |
+| `shell/`            | shfmt                                                                         | ShellCheck                                  |
+| `sql/`              | Prettier with its SQL plugin                                                  |                                             |
+| `starlark/`         |                                                                               | Buildifier                                  |
+| `swift/`            | SwiftFormat                                                                   |                                             |
+| `terraform/`        | terraform fmt                                                                 |                                             |
+| `toml/`             | Taplo                                                                         | Taplo                                       |
+| `xml/`              | Prettier with its XML plugin                                                  |                                             |
+| `yaml/`             | yamlfmt                                                                       | yamllint                                    |
 
-- `python/` - Python formatting with Ruff; linting with Ruff, Bandit, Flake8, Pydoclint, Pylint, or Ty
-- `nodejs/` - TypeScript/JavaScript formatting with Prettier; linting with ESLint
-- `java/` - Java formatting with Google Java Format; linting with PMD, Checkstyle, or SpotBugs
-- `rust/` - Rust formatting with rustfmt; linting with Clippy
-- `cpp/` - C/C++ formatting with clang-format; linting with Clang-Tidy or Cppcheck
-- `shell/` - Shell script formatting with shfmt; linting with ShellCheck
-- `ruby/` - Ruby formatting with RuboCop; linting with RuboCop or StandardRB
-- `kotlin/` - Kotlin formatting with ktfmt; linting with Ktlint
-- `css/` - CSS formatting with Prettier; linting with Stylelint
-- `yaml/` - YAML formatting with yamlfmt; linting with Yamllint
-- `markdown/` - Markdown formatting with Prettier; linting with Vale
-- `proto/` - Protocol Buffer formatting and linting with Buf
-- `starlark/` - Starlark formatting with Buildifier; linting with Buildifier
-- `qml/` - QML formatting with qmlformat; linting with qmllint
-
-## Multi-language Example
-
-For examples of a monorepo with multiple languages, see the `example/` directory at the repository root.
+The `other_formatters/` example covers CUE, Gherkin, GraphQL, HTML Jinja templates, JSON5, and Jsonnet without creating a separate workspace for each format.

--- a/examples/cpp/README.md
+++ b/examples/cpp/README.md
@@ -16,10 +16,10 @@ This example demonstrates how to set up formatting and linting for C++ code usin
 ## Setup
 
 1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
+2. Configure the Aspect CLI lint task in `.aspect/config.axl`
 3. Configure Formatters and Linters
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 - See `tools/lint/linters.bzl` for how to set up each linter aspect
 
 4. Perform formatting and linting using `aspect format` and `aspect lint`

--- a/examples/csharp/README.md
+++ b/examples/csharp/README.md
@@ -12,12 +12,12 @@ Note: No C# linter is currently available in rules_lint.
 
 ## Setup
 
-1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
-3. Configure Formatters
+1. Configure `MODULE.bazel` with the required dependencies and .NET toolchain
+2. Configure the Paket dependencies in `paket.dependencies` and `3rdparty/nuget/`
+3. Configure the formatter
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
-- See `3rdparty/nuget/` for paket dependency setup
+- See `tools/format/BUILD` for how to set up the formatter
+- See `3rdparty/nuget/` for Paket dependency setup
 
 4. Perform formatting using `aspect format`
 

--- a/examples/fsharp/README.md
+++ b/examples/fsharp/README.md
@@ -12,15 +12,13 @@ Note: No F# linter is currently available in rules_lint.
 
 ## Setup
 
-1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
-3. Configure .NET Toolchain
-4. Configure Paket Dependencies (see `3rdparty/nuget/` for setup)
-5. Configure Formatters
+1. Configure `MODULE.bazel` with the required dependencies and .NET toolchain
+2. Configure the Paket dependencies in `paket.dependencies` and `3rdparty/nuget/`
+3. Configure the formatter
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 
-6. Perform formatting using `aspect format`
+4. Perform formatting using `aspect format`
 
 ## Example Code
 

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -12,13 +12,12 @@ Note: You can also use standard `gofmt` instead of `gofumpt` if you prefer.
 
 ## Setup
 
-1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
-3. Configure Formatters
+1. Configure `MODULE.bazel` with the required dependencies
+2. Configure the formatter
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 
-4. Perform formatting using `aspect format`
+3. Perform formatting using `aspect format`
 
 ## Example Code
 

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -17,10 +17,10 @@ This example demonstrates how to set up formatting and linting for Java code usi
 ## Setup
 
 1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
+2. Configure the Aspect CLI lint task in `.aspect/config.axl`
 3. Configure Formatters and Linters
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 - See `tools/lint/linters.bzl` for how to set up each linter aspect
 
 4. Perform formatting and linting using `aspect format` and `aspect lint`

--- a/examples/keep-sorted/README.md
+++ b/examples/keep-sorted/README.md
@@ -13,7 +13,7 @@ Keep-sorted is a tool that ensures code blocks marked with `// keep-sorted start
 ## Setup
 
 1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
+2. Configure the Aspect CLI lint task in `.aspect/config.axl`
 3. Configure Go SDK
 4. Fetch keep-sorted Dependency (requires `--experimental_isolated_extension_usages` in `.bazelrc`)
 5. Configure Linters

--- a/examples/kotlin/README.md
+++ b/examples/kotlin/README.md
@@ -15,12 +15,12 @@ This example demonstrates how to set up formatting and linting for Kotlin code u
 ## Setup
 
 1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
+2. Configure the Aspect CLI lint task in `.aspect/config.axl`
 3. Configure Format Tools (add ktfmt)
 4. Configure Lint Tools (add ktlint)
 5. Configure Formatters and Linters
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 - See `tools/lint/linters.bzl` for how to set up each linter aspect
 
 6. Perform formatting and linting using `aspect format` and `aspect lint`

--- a/examples/nodejs/README.md
+++ b/examples/nodejs/README.md
@@ -17,11 +17,11 @@ This example demonstrates how to set up formatting and linting for Node.js ecosy
 ## Setup
 
 1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
+2. Configure the Aspect CLI lint task in `.aspect/config.axl`
 3. Set up npm dependencies (run `pnpm install` to generate `pnpm-lock.yaml`)
 4. Configure Formatters and Linters
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 - See `tools/lint/linters.bzl` for how to set up each linter aspect
 
 5. Perform formatting and linting using `aspect format` and `aspect lint`

--- a/examples/other_formatters/README.md
+++ b/examples/other_formatters/README.md
@@ -15,13 +15,12 @@ This example demonstrates formatting for various specialized languages and file 
 
 ## Setup
 
-1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
-3. Configure Formatters
+1. Configure `MODULE.bazel` with the required dependencies
+2. Configure the formatters
 
-- See `tools/format/BUILD.bazel` for how to set up each formatter
+- See `tools/format/BUILD` for how to set up each formatter
 
-4. Perform formatting using `aspect format`
+3. Perform formatting using `aspect format`
 
 ## Example Code
 

--- a/examples/protobuf/README.md
+++ b/examples/protobuf/README.md
@@ -15,11 +15,11 @@ This example demonstrates how to set up formatting and linting for Protocol Buff
 ## Setup
 
 1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
+2. Configure the Aspect CLI lint task in `.aspect/config.axl`
 3. Configure Buf Toolchain
 4. Configure Formatters and Linters
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 - See `tools/lint/linters.bzl` for how to set up the linter aspect
 
 4. Create `buf.yaml` configuration file

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -19,10 +19,10 @@ This example demonstrates how to set up formatting and linting for Python code u
 ## Setup
 
 1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
+2. Configure the Aspect CLI lint task in `.aspect/config.axl`
 3. Configure Formatters and Linters
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 - See `tools/lint/linters.bzl` for how to set up each linter aspect
 
 4. Perform formatting and linting using `aspect format` and `aspect lint`

--- a/examples/qml/README.md
+++ b/examples/qml/README.md
@@ -18,7 +18,7 @@ The `qml` tag is used for both formatting and linting in this example.
 ## Setup
 
 1. Configure `MODULE.bazel` with `rules_python` and `rules_lint`
-2. Create the `MODULE.aspect` file to register CLI tasks
+2. Configure the Aspect CLI lint task in `.aspect/config.axl`
 3. Install PySide tool wrappers with `pip.parse`
 4. Configure formatters and linters
 

--- a/examples/ruby/README.md
+++ b/examples/ruby/README.md
@@ -14,7 +14,7 @@ Note: No Ruby formatter is currently available in rules_lint.
 ## Setup
 
 1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
+2. Configure the Aspect CLI lint task in `.aspect/config.axl`
 3. Configure Linters
 
 - See `tools/lint/linters.bzl` for how to set up each linter aspect

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -15,11 +15,11 @@ This example demonstrates how to set up formatting and linting for Rust code usi
 ## Setup
 
 1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
+2. Configure the Aspect CLI lint task in `.aspect/config.axl`
 3. Configure Rust Toolchain
 4. Configure Formatters and Linters
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 - See `tools/lint/linters.bzl` for how to set up the linter aspect
 
 4. Create `.clippy.toml` configuration file (can be empty for defaults)

--- a/examples/scala/README.md
+++ b/examples/scala/README.md
@@ -15,11 +15,11 @@ This example demonstrates how to set up formatting and linting for Scala code us
 ## Setup
 
 1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
+2. Configure the Aspect CLI lint task in `.aspect/config.axl`
 3. Configure Maven Dependencies (add scalafmt + scalafix to maven.install artifacts)
 4. Configure Formatters and Linters
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 - See `tools/lint/linters.bzl` for how to set up the linter
 - See `.scalafmt.conf` for scalafmt configuration
 - See `.scalafix.conf` for scalafix rules

--- a/examples/shell/README.md
+++ b/examples/shell/README.md
@@ -15,10 +15,10 @@ This example demonstrates how to set up formatting and linting for shell scripts
 ## Setup
 
 1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
+2. Configure the Aspect CLI lint task in `.aspect/config.axl`
 3. Configure Formatters and Linters
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 - See `tools/lint/linters.bzl` for how to set up the linter aspect
 
 3. Create `.shellcheckrc` configuration file

--- a/examples/sql/README.md
+++ b/examples/sql/README.md
@@ -12,14 +12,13 @@ Note: No SQL linter is currently available in rules_lint.
 
 ## Setup
 
-1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
-3. Set up npm dependencies (run `pnpm install` to generate `pnpm-lock.yaml`)
-4. Configure Formatters
+1. Configure `MODULE.bazel` with the required dependencies
+2. Set up npm dependencies by running `pnpm install` to generate `pnpm-lock.yaml`
+3. Configure the formatter
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 
-5. Perform formatting using `aspect format`
+4. Perform formatting using `aspect format`
 
 ## Example Code
 

--- a/examples/starlark/README.md
+++ b/examples/starlark/README.md
@@ -11,7 +11,7 @@ This example demonstrates how to lint Starlark files with `rules_lint` using Bui
 ## Setup
 
 1. Configure `MODULE.bazel` with the required dependencies
-2. Create the `MODULE.aspect` file to register CLI tasks
+2. Configure the Aspect CLI lint task in `.aspect/config.axl`
 3. Configure the Buildifier linter in `tools/lint/linters.bzl`
 4. Run linting with `aspect lint`
 

--- a/examples/swift/README.md
+++ b/examples/swift/README.md
@@ -12,14 +12,12 @@ Note: No Swift linter is currently available in rules_lint.
 
 ## Setup
 
-1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
-3. Configure Format Tools (add swiftformat)
-4. Configure Formatters
+1. Configure `MODULE.bazel` with the required dependencies
+2. Add SwiftFormat and configure the formatter
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 
-5. Perform formatting using `aspect format`
+3. Perform formatting using `aspect format`
 
 ## Example Code
 

--- a/examples/toml/README.md
+++ b/examples/toml/README.md
@@ -19,7 +19,7 @@ This example demonstrates how to set up formatting and linting for TOML files us
 3. Configure Taplo (shared by formatting and linting)
 4. Configure Formatters and Linters
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 - See `tools/lint/linters.bzl` for how to set up the linter aspect
 
 5. Perform formatting and linting using `aspect format` and `aspect lint`

--- a/examples/xml/README.md
+++ b/examples/xml/README.md
@@ -12,14 +12,13 @@ Note: No XML linter is currently available in rules_lint.
 
 ## Setup
 
-1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
-3. Set up npm dependencies (run `pnpm install` to generate `pnpm-lock.yaml`)
-4. Configure Formatters
+1. Configure `MODULE.bazel` with the required dependencies
+2. Set up npm dependencies by running `pnpm install` to generate `pnpm-lock.yaml`
+3. Configure the formatter
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 
-5. Perform formatting using `aspect format`
+4. Perform formatting using `aspect format`
 
 ## Example Code
 

--- a/examples/yaml/README.md
+++ b/examples/yaml/README.md
@@ -15,11 +15,11 @@ This example demonstrates how to set up formatting and linting for YAML files us
 ## Setup
 
 1. Configure MODULE.bazel with required dependencies
-2. Create the MODULE.aspect file to register CLI tasks
+2. Configure the Aspect CLI lint task in `.aspect/config.axl`
 3. Configure Python Dependencies (set up pip for yamllint)
 4. Configure Formatters and Linters
 
-- See `tools/format/BUILD.bazel` for how to set up the formatter
+- See `tools/format/BUILD` for how to set up the formatter
 - See `tools/lint/linters.bzl` for how to set up the linter aspect
 
 5. Perform formatting and linting using `aspect format` and `aspect lint`


### PR DESCRIPTION
AI written, human reviewed.

Refresh the documentation so the supported-tools tables and example instructions match the integrations currently checked into the repository. This adds missing formatter and language entries, rebuilds the examples index, corrects tool names, and replaces stale configuration and BUILD file paths.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Prettier formatting checks passed
- Typos checks passed
- `git diff --check` passed