### PR TITLE
fix(ty): preserve arguments in long materialized shell commands

### DIFF
--- a/examples/python/src/BUILD
+++ b/examples/python/src/BUILD
@@ -41,6 +41,26 @@ py_library(
     deps = ["//src/python_lib:py_dependency"],
 )
 
+# Forces Bazel to materialize the ty action's shell command. The transitive
+# source has a known type error but is not imported by the clean target below.
+py_library(
+    name = "many_imports_with_unrelated_error",
+    srcs = ["unsupported_operator.py"],
+    imports = [
+        "long_import_path_{}/subdirectory/that_makes_the_generated_shell_command_long".format(i)
+        for i in range(250)
+    ],
+)
+
+py_library(
+    name = "uses_dependency_correctly_materialized",
+    srcs = ["uses_dependency_correctly.py"],
+    deps = [
+        ":many_imports_with_unrelated_error",
+        "//src/python_lib:py_dependency",
+    ],
+)
+
 py_library(
     name = "uses_generated_dependency_correctly",
     srcs = ["uses_generated_dependency_correctly.py"],

--- a/examples/python/test/BUILD
+++ b/examples/python/test/BUILD
@@ -237,6 +237,13 @@ ty_test(
     srcs = ["//src:uses_dependency_correctly"],
 )
 
+# Reproduces argument loss when Bazel materializes a long `run_shell` command.
+# The clean source must not inherit the unrelated error from its transitive dep.
+ty_test(
+    name = "ty_should_scope_materialized_command",
+    srcs = ["//src:uses_dependency_correctly_materialized"],
+)
+
 ty_test(
     name = "ty_should_resolve_generated_dep",
     srcs = ["//src:uses_generated_dependency_correctly"],

--- a/lint/ty.bzl
+++ b/lint/ty.bzl
@@ -81,18 +81,24 @@ def ty_action(ctx, executable, srcs, transitive_srcs, config, stdout, exit_code 
         else:
             code_search_paths.append(p)
 
-    # Build a script that adds --extra-search-path only for directories that exist
-    # Some pip package directories may not exist, so we check first
-    # Pass --extra-search-path via a @param file, as there might be many of them
-    extra_search_path_script = """PARAM_FILE="$(mktemp)"
-"""
+    # Pass the candidate search paths in a Bazel-managed parameter file so the
+    # shell command stays constant-size. Some candidates may not exist, so the
+    # command filters them into the parameter file consumed by ty.
+    search_path_args = ctx.actions.args()
+    search_path_args.add_all(stub_search_paths + code_search_paths)
+    search_path_args.set_param_file_format("multiline")
+    search_path_args.use_param_file("%s", use_always = True)
 
-    for path in stub_search_paths + code_search_paths:
-        extra_search_path_script += """if [ -d "{path}" ]; then
-  echo "--extra-search-path" >> "$PARAM_FILE"
-  echo "{path}" >> "$PARAM_FILE"
-fi
-""".format(path = path)
+    extra_search_path_script = """readonly SEARCH_PATHS_FILE="$1"
+shift
+
+readonly PARAM_FILE="$(mktemp)"
+while IFS= read -r path; do
+  if [ -d "$path" ]; then
+    printf '%s\n' "--extra-search-path" "$path" >> "$PARAM_FILE"
+  fi
+done < "$SEARCH_PATHS_FILE"
+"""
 
     color_flag = "--color always" if color else "--color never"
     command = """
@@ -132,7 +138,7 @@ fi
             extra_search_path_script = extra_search_path_script,
             color_flag = color_flag,
         ),
-        arguments = [action_args],
+        arguments = [search_path_args, action_args],
         mnemonic = _MNEMONIC,
         env = env,
         progress_message = "Linting %{label} with ty",


### PR DESCRIPTION
Closes #970.

For transparency: I both discovered and fixed this with help from an LLM agent.

`lint_ty_aspect` passes target sources and configuration through `$@`. That works while Bazel keeps the generated shell command inline.

Once enough import paths make the command long, Bazel materializes it as a child script. The arguments remain on the outer shell invocation, so the child script sees an empty `$@`. `ty` then checks every Python input available to the action rather than the requested target.

This PR:
- adds a regression that forces command materialization and demonstrates a clean target inheriting an unrelated transitive diagnostic.
- shell-quotes and embeds the short source/config argument list in the generated command.
- keeps the potentially long import search path in its existing parameter file.

The same fix applies to `aspect lint`, since Aspect CLI runs these Bazel aspect actions and processes their output afterward.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fixed `lint_ty_aspect` losing target sources and configuration when Bazel materializes a long shell command. Large targets no longer lint unrelated transitive Python sources.

### Test plan

- Covered by existing test cases
- New test cases added
- Manual testing:

  ```console
  cd examples/python

  # Repository default: Bazel 7.6.0
  bazel test //test:ty_should_scope_materialized_command

  # Bazel 9.2.0
  USE_BAZEL_VERSION=9.2.0 \
    bazel test //test:ty_should_scope_materialized_command
  ```

The new regression fails on the first commit and passes with the fix. All `10` ty-specific tests also pass.