### PR TITLE
feat(lint): add Oxlint aspect

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,7 +129,7 @@ jobs:
           assert-path: /usr/lib/bats/bats-assert
           assert-version: "2.1.0"
       # TODO: Fix for Bazel 9
-      - if: matrix.folder == 'examples/java' || matrix.folder == 'examples/shell'  || matrix.folder == 'examples/kotlin' || matrix.folder == 'format'
+      - if: matrix.folder == 'examples/java' || matrix.folder == 'examples/shell'  || matrix.folder == 'examples/kotlin' || matrix.folder == 'examples/nodejs' || matrix.folder == 'format'
         run: echo "USE_BAZEL_VERSION=8.x" >> "$GITHUB_ENV"
 
       - name: "Integration test"

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Linters which are not language-specific:
 | HTML templates     | [djlint]                  |                                                         |
 | JSON, JSON5, JSONC | [Prettier]                |                                                         |
 | Java               | [google-java-format]      | [pmd], [Checkstyle], [SpotBugs]                         |
-| JavaScript         | [Prettier]                | [ESLint]                                                |
+| JavaScript         | [Prettier]                | [ESLint] or [Oxlint]                                    |
 | Jsonnet            | [jsonnetfmt]              |                                                         |
 | Kotlin             | [ktfmt]                   | [ktlint]                                                |
 | Markdown           | [Prettier]                | [Vale]                                                  |
@@ -157,8 +157,8 @@ Linters which are not language-specific:
 | Swift              | [SwiftFormat] (1)         |                                                         |
 | Terraform          | [terraform] fmt           |                                                         |
 | TOML               | [taplo]                   | [taplo]                                                 |
-| TSX                | [Prettier]                | [ESLint]                                                |
-| TypeScript         | [Prettier]                | [ESLint]                                                |
+| TSX                | [Prettier]                | [ESLint] or [Oxlint]                                    |
+| TypeScript         | [Prettier]                | [ESLint] or [Oxlint]                                    |
 | Vue                | [Prettier]                |                                                         |
 | YAML               | [yamlfmt]                 | [yamllint]                                              |
 | XML                | [prettier/plugin-xml]     |                                                         |
@@ -175,6 +175,7 @@ Linters which are not language-specific:
 [spotbugs]: https://spotbugs.github.io/
 [buf lint]: https://buf.build/docs/lint/overview
 [eslint]: https://eslint.org/
+[oxlint]: https://oxc.rs/docs/guide/usage/linter.html
 [swiftformat]: https://github.com/nicklockwood/SwiftFormat
 [terraform]: https://github.com/hashicorp/terraform
 [buf]: https://docs.buf.build/format/usage

--- a/examples/nodejs/.aspect/config.axl
+++ b/examples/nodejs/.aspect/config.axl
@@ -5,6 +5,7 @@ def config(ctx: ConfigContext):
     # natively (no Bazel `--config=lint`).
     ctx.tasks["lint"].args.aspects = [
         "//tools/lint:linters.bzl%eslint",
+        "//tools/lint:linters.bzl%oxlint",
         "//tools/lint:linters.bzl%stylelint",
         "//tools/lint:linters.bzl%vale",
     ]

--- a/examples/nodejs/.bazelrc
+++ b/examples/nodejs/.bazelrc
@@ -3,6 +3,7 @@ common --incompatible_enable_proto_toolchain_resolution
 common --@aspect_rules_ts//ts:skipLibCheck=always
 
 build:lint --aspects=//tools/lint:linters.bzl%eslint
+build:lint --aspects=//tools/lint:linters.bzl%oxlint
 build:lint --aspects=//tools/lint:linters.bzl%stylelint
 build:lint --aspects=//tools/lint:linters.bzl%vale
 

--- a/examples/nodejs/.oxlintrc.json
+++ b/examples/nodejs/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "rules": {
+    "oxc/no-const-enum": "error"
+  }
+}

--- a/examples/nodejs/BUILD
+++ b/examples/nodejs/BUILD
@@ -7,6 +7,7 @@ npm_link_all_packages(name = "node_modules")
 
 exports_files(
     [
+        ".oxlintrc.json",
         ".swcrc",
         ".vale.ini",
     ],

--- a/examples/nodejs/README.md
+++ b/examples/nodejs/README.md
@@ -11,6 +11,7 @@ This example demonstrates how to set up formatting and linting for Node.js ecosy
 ### Linters
 
 - **ESLint** - JavaScript and TypeScript linter
+- **Oxlint** - JavaScript and TypeScript linter
 - **Stylelint** - CSS linter
 - **Vale** - Markdown linter
 
@@ -32,6 +33,7 @@ The `src/` directory contains example files with intentional violations:
 
 - `hello.js` - Simple JavaScript file
 - `file.ts`, `file-dep.ts` - TypeScript files with ESLint violations
+- `oxlint-fixable.ts` - TypeScript with an auto-fixable Oxlint violation
 - `hello.tsx` - React TypeScript file
 - `hello.vue` - Vue component
 - `hello.css`, `clean.css` - CSS files (one with violations, one clean)
@@ -43,6 +45,7 @@ The `src/` directory contains example files with intentional violations:
 ## Configuration Files
 
 - `eslint.config.mjs` - ESLint configuration
+- `.oxlintrc.json` - Oxlint configuration
 - `stylelint.config.mjs` - Stylelint configuration
 - `.vale.ini` - Vale configuration for Markdown
 - `prettier.config.cjs` - Prettier configuration

--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -7,6 +7,7 @@
     "@eslint/js": "^9.16.0",
     "@types/node": "^18",
     "eslint": "^9.16.0",
+    "oxlint": "1.74.0",
     "prettier": "^2.8.7",
     "stylelint": "^16",
     "stylelint-config-standard": "^36.0.1",

--- a/examples/nodejs/pnpm-lock.yaml
+++ b/examples/nodejs/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       eslint:
         specifier: ^9.16.0
         version: 9.39.2
+      oxlint:
+        specifier: 1.74.0
+        version: 1.74.0
       prettier:
         specifier: ^2.8.7
         version: 2.8.8
@@ -242,6 +245,177 @@ packages:
         integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
       }
     engines: { node: ">= 8" }
+
+  "@oxlint/binding-android-arm-eabi@1.74.0":
+    resolution:
+      {
+        integrity: sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [android]
+
+  "@oxlint/binding-android-arm64@1.74.0":
+    resolution:
+      {
+        integrity: sha512-xjKdoMB+H+RCOByv/7l7nfIGW9mlOisqYdcyC75UqYuQecLpReAeEYUf2CNeDEI3KtmUgxpRw/+c63y4AeF/Bw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [android]
+
+  "@oxlint/binding-darwin-arm64@1.74.0":
+    resolution:
+      {
+        integrity: sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@oxlint/binding-darwin-x64@1.74.0":
+    resolution:
+      {
+        integrity: sha512-ggKc/tn5SJ1u2yG2izC6VKODfYKV8MQ2AicJlNzOjuyrC29udvOef6/JzK2r32xqCnBDLFouR1VCkjzEI0/N9Q==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [darwin]
+
+  "@oxlint/binding-freebsd-x64@1.74.0":
+    resolution:
+      {
+        integrity: sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@oxlint/binding-linux-arm-gnueabihf@1.74.0":
+    resolution:
+      {
+        integrity: sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxlint/binding-linux-arm-musleabihf@1.74.0":
+    resolution:
+      {
+        integrity: sha512-//PKyQb/tQXcHArx2f7z+oVI/eMS2Jpv+edNuAtOrgIhWdGcpHxogveAxzmF2rpH1AIHp4Hq04RF/rgJdiICnQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxlint/binding-linux-arm64-gnu@1.74.0":
+    resolution:
+      {
+        integrity: sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+
+  "@oxlint/binding-linux-arm64-musl@1.74.0":
+    resolution:
+      {
+        integrity: sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+
+  "@oxlint/binding-linux-ppc64-gnu@1.74.0":
+    resolution:
+      {
+        integrity: sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@oxlint/binding-linux-riscv64-gnu@1.74.0":
+    resolution:
+      {
+        integrity: sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [riscv64]
+    os: [linux]
+
+  "@oxlint/binding-linux-riscv64-musl@1.74.0":
+    resolution:
+      {
+        integrity: sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [riscv64]
+    os: [linux]
+
+  "@oxlint/binding-linux-s390x-gnu@1.74.0":
+    resolution:
+      {
+        integrity: sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [s390x]
+    os: [linux]
+
+  "@oxlint/binding-linux-x64-gnu@1.74.0":
+    resolution:
+      {
+        integrity: sha512-+aIvJyrdeD7LwCQ2WYLMUWNmnbeDRSPb40aBYtPjD9+PTqUwgJnk+HK5yLfSMeqXrMrDhE9uTmtt2y50tvjhHw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+
+  "@oxlint/binding-linux-x64-musl@1.74.0":
+    resolution:
+      {
+        integrity: sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+
+  "@oxlint/binding-openharmony-arm64@1.74.0":
+    resolution:
+      {
+        integrity: sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@oxlint/binding-win32-arm64-msvc@1.74.0":
+    resolution:
+      {
+        integrity: sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  "@oxlint/binding-win32-ia32-msvc@1.74.0":
+    resolution:
+      {
+        integrity: sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ia32]
+    os: [win32]
+
+  "@oxlint/binding-win32-x64-msvc@1.74.0":
+    resolution:
+      {
+        integrity: sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [win32]
 
   "@types/estree@1.0.8":
     resolution:
@@ -1099,6 +1273,22 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
+  oxlint@1.74.0:
+    resolution:
+      {
+        integrity: sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: ">=0.24.0"
+      vite-plus: "*"
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-limit@3.1.0:
     resolution:
       {
@@ -1615,6 +1805,63 @@ snapshots:
       "@nodelib/fs.scandir": 2.1.5
       fastq: 1.19.1
 
+  "@oxlint/binding-android-arm-eabi@1.74.0":
+    optional: true
+
+  "@oxlint/binding-android-arm64@1.74.0":
+    optional: true
+
+  "@oxlint/binding-darwin-arm64@1.74.0":
+    optional: true
+
+  "@oxlint/binding-darwin-x64@1.74.0":
+    optional: true
+
+  "@oxlint/binding-freebsd-x64@1.74.0":
+    optional: true
+
+  "@oxlint/binding-linux-arm-gnueabihf@1.74.0":
+    optional: true
+
+  "@oxlint/binding-linux-arm-musleabihf@1.74.0":
+    optional: true
+
+  "@oxlint/binding-linux-arm64-gnu@1.74.0":
+    optional: true
+
+  "@oxlint/binding-linux-arm64-musl@1.74.0":
+    optional: true
+
+  "@oxlint/binding-linux-ppc64-gnu@1.74.0":
+    optional: true
+
+  "@oxlint/binding-linux-riscv64-gnu@1.74.0":
+    optional: true
+
+  "@oxlint/binding-linux-riscv64-musl@1.74.0":
+    optional: true
+
+  "@oxlint/binding-linux-s390x-gnu@1.74.0":
+    optional: true
+
+  "@oxlint/binding-linux-x64-gnu@1.74.0":
+    optional: true
+
+  "@oxlint/binding-linux-x64-musl@1.74.0":
+    optional: true
+
+  "@oxlint/binding-openharmony-arm64@1.74.0":
+    optional: true
+
+  "@oxlint/binding-win32-arm64-msvc@1.74.0":
+    optional: true
+
+  "@oxlint/binding-win32-ia32-msvc@1.74.0":
+    optional: true
+
+  "@oxlint/binding-win32-x64-msvc@1.74.0":
+    optional: true
+
   "@types/estree@1.0.8": {}
 
   "@types/json-schema@7.0.15": {}
@@ -2108,6 +2355,28 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  oxlint@1.74.0:
+    optionalDependencies:
+      "@oxlint/binding-android-arm-eabi": 1.74.0
+      "@oxlint/binding-android-arm64": 1.74.0
+      "@oxlint/binding-darwin-arm64": 1.74.0
+      "@oxlint/binding-darwin-x64": 1.74.0
+      "@oxlint/binding-freebsd-x64": 1.74.0
+      "@oxlint/binding-linux-arm-gnueabihf": 1.74.0
+      "@oxlint/binding-linux-arm-musleabihf": 1.74.0
+      "@oxlint/binding-linux-arm64-gnu": 1.74.0
+      "@oxlint/binding-linux-arm64-musl": 1.74.0
+      "@oxlint/binding-linux-ppc64-gnu": 1.74.0
+      "@oxlint/binding-linux-riscv64-gnu": 1.74.0
+      "@oxlint/binding-linux-riscv64-musl": 1.74.0
+      "@oxlint/binding-linux-s390x-gnu": 1.74.0
+      "@oxlint/binding-linux-x64-gnu": 1.74.0
+      "@oxlint/binding-linux-x64-musl": 1.74.0
+      "@oxlint/binding-openharmony-arm64": 1.74.0
+      "@oxlint/binding-win32-arm64-msvc": 1.74.0
+      "@oxlint/binding-win32-ia32-msvc": 1.74.0
+      "@oxlint/binding-win32-x64-msvc": 1.74.0
 
   p-limit@3.1.0:
     dependencies:

--- a/examples/nodejs/src/BUILD
+++ b/examples/nodejs/src/BUILD
@@ -2,7 +2,7 @@ load("@aspect_rules_lint//format:defs.bzl", "format_test")
 load("@aspect_rules_swc//swc:defs.bzl", "swc")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
 load("@bazel_skylib//lib:partial.bzl", "partial")
-load("//tools/lint:linters.bzl", "eslint_test")
+load("//tools/lint:linters.bzl", "eslint_test", "oxlint_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -27,6 +27,18 @@ filegroup(
     name = "less",
     srcs = ["hello.less"],
     tags = ["lint-with-stylelint"],
+)
+
+filegroup(
+    name = "oxlint_fixable",
+    srcs = ["oxlint-fixable.ts"],
+    tags = ["lint-with-oxlint"],
+)
+
+oxlint_test(
+    name = "oxlint_fixable_test",
+    srcs = [":oxlint_fixable"],
+    expected_exit_code = 1,
 )
 
 filegroup(

--- a/examples/nodejs/src/oxlint-fixable.ts
+++ b/examples/nodejs/src/oxlint-fixable.ts
@@ -1,0 +1,6 @@
+const enum Direction {
+  Left,
+  Right,
+}
+
+console.log(Direction.Left);

--- a/examples/nodejs/test/BUILD
+++ b/examples/nodejs/test/BUILD
@@ -1,7 +1,7 @@
 # buildifier: disable=bzl-visibility
 load("@aspect_rules_lint//lint/private:machine_report_testing.bzl", "report_test")
-load("//test:machine_output.bzl", "machine_eslint_report", "machine_stylelint_report")
-load("//tools/lint:linters.bzl", "eslint_test", "stylelint_test")
+load("//test:machine_output.bzl", "machine_eslint_report", "machine_oxlint_report", "machine_stylelint_report")
+load("//tools/lint:linters.bzl", "eslint_test", "oxlint_test", "stylelint_test")
 
 eslint_test(
     name = "eslint_empty_report",
@@ -23,6 +23,24 @@ report_test(
     expected_tool = "ESLint",
     expected_uri = "src/file.ts",
     report = "machine_eslint_report",
+)
+
+oxlint_test(
+    name = "oxlint_fixable",
+    srcs = ["//src:oxlint_fixable"],
+    expected_exit_code = 1,
+)
+
+machine_oxlint_report(
+    name = "machine_oxlint_report",
+    src = "//src:oxlint_fixable",
+)
+
+report_test(
+    name = "oxlint_machine_output_test",
+    expected_tool = "oxlint",
+    expected_uri = "src/oxlint-fixable.ts",
+    report = "machine_oxlint_report",
 )
 
 machine_stylelint_report(

--- a/examples/nodejs/test/machine_output.bzl
+++ b/examples/nodejs/test/machine_output.bzl
@@ -2,7 +2,8 @@
 
 # buildifier: disable=bzl-visibility
 load("@aspect_rules_lint//lint/private:machine_report_testing.bzl", "machine_report_rule")
-load("//tools/lint:linters.bzl", "eslint", "stylelint")
+load("//tools/lint:linters.bzl", "eslint", "oxlint", "stylelint")
 
 machine_eslint_report = machine_report_rule(eslint)
+machine_oxlint_report = machine_report_rule(oxlint)
 machine_stylelint_report = machine_report_rule(stylelint)

--- a/examples/nodejs/test/oxlint_lint_test.bats
+++ b/examples/nodejs/test/oxlint_lint_test.bats
@@ -1,0 +1,21 @@
+bats_load_library "bats-support"
+bats_load_library "bats-assert"
+
+@test "Oxlint reports original violations while offering a patch" {
+    run bazel build \
+        --config=lint \
+        --output_groups=rules_lint_human,rules_lint_patch \
+        --@aspect_rules_lint//lint:fix \
+        //src:oxlint_fixable
+    assert_success
+
+    run cat bazel-bin/src/oxlint_fixable.AspectRulesLintOxlint.out.exit_code
+    assert_output "1"
+
+    run cat bazel-bin/src/oxlint_fixable.AspectRulesLintOxlint.out
+    assert_output --partial "Unexpected const enum"
+
+    run cat bazel-bin/src/oxlint_fixable.AspectRulesLintOxlint.patch
+    assert_output --partial -- "-const enum Direction"
+    assert_output --partial -- "+enum Direction"
+}

--- a/examples/nodejs/tools/lint/BUILD
+++ b/examples/nodejs/tools/lint/BUILD
@@ -8,11 +8,14 @@ load("@aspect_rules_lint//lint:vale_library.bzl", "VALE_STYLES")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")
+load("@npm//:oxlint/package_json.bzl", oxlint_bin = "bin")
 load("@npm//:stylelint/package_json.bzl", stylelint_bin = "bin")
 
 package(default_visibility = ["//:__subpackages__"])
 
 eslint_bin.eslint_binary(name = "eslint")
+
+oxlint_bin.oxlint_binary(name = "oxlint")
 
 stylelint_bin.stylelint_binary(name = "stylelint")
 

--- a/examples/nodejs/tools/lint/linters.bzl
+++ b/examples/nodejs/tools/lint/linters.bzl
@@ -2,6 +2,7 @@
 
 load("@aspect_rules_lint//lint:eslint.bzl", "lint_eslint_aspect")
 load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
+load("@aspect_rules_lint//lint:oxlint.bzl", "lint_oxlint_aspect")
 load("@aspect_rules_lint//lint:stylelint.bzl", "lint_stylelint_aspect")
 load("@aspect_rules_lint//lint:vale.bzl", "lint_vale_aspect")
 
@@ -16,6 +17,13 @@ eslint = lint_eslint_aspect(
 )
 
 eslint_test = lint_test(aspect = eslint)
+
+oxlint = lint_oxlint_aspect(
+    binary = Label("//tools/lint:oxlint"),
+    config = Label("//:.oxlintrc.json"),
+)
+
+oxlint_test = lint_test(aspect = oxlint)
 
 stylelint = lint_stylelint_aspect(
     binary = Label("//tools/lint:stylelint"),

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -142,6 +142,15 @@ bzl_library(
 )
 
 bzl_library(
+    name = "oxlint",
+    srcs = ["oxlint.bzl"],
+    deps = [
+        "//lint/private:lint_aspect",
+        "//lint/private:patcher_action",
+    ],
+)
+
+bzl_library(
     name = "buildifier",
     srcs = ["buildifier.bzl"],
     deps = [

--- a/lint/oxlint.bzl
+++ b/lint/oxlint.bzl
@@ -1,0 +1,187 @@
+"""Configures [Oxlint](https://oxc.rs/docs/guide/usage/linter.html) to run as a Bazel aspect.
+
+First, add `oxlint` to your npm dependencies and declare its binary, typically in
+`tools/lint/BUILD.bazel`:
+
+```starlark
+load("@npm//:oxlint/package_json.bzl", oxlint_bin = "bin")
+
+oxlint_bin.oxlint_binary(name = "oxlint")
+```
+
+Then declare the linter aspect, typically in `tools/lint/linters.bzl`:
+
+```starlark
+load("@aspect_rules_lint//lint:oxlint.bzl", "lint_oxlint_aspect")
+
+oxlint = lint_oxlint_aspect(
+    binary = Label("//tools/lint:oxlint"),
+    config = Label("//:.oxlintrc.json"),
+)
+```
+"""
+
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OUTFILE_FORMAT", "filter_srcs", "noop_lint_action", "output_files", "patch_and_output_files", "should_visit")
+load("//lint/private:patcher_action.bzl", "patcher_attrs", "run_patcher")
+
+_MNEMONIC = "AspectRulesLintOxlint"
+
+def oxlint_action(ctx, executable, srcs, config, stdout, exit_code = None, args = [], format = None, patch = None):
+    """Run Oxlint as a Bazel action.
+
+    Args:
+        ctx: Bazel rule or aspect evaluation context
+        executable: the Oxlint executable
+        srcs: JavaScript or TypeScript files to lint
+        config: Oxlint JSON or JSONC configuration file
+        stdout: output file for diagnostics
+        exit_code: optional output file for the exit code; without it, violations fail the action
+        args: additional Oxlint command-line arguments
+        format: optional Oxlint output format
+        patch: optional output patch; when present, run Oxlint with `--fix`
+    """
+    action_args = ctx.actions.args()
+    action_args.add_all(args)
+    action_args.add_all(["--config", config.path])
+    if format:
+        action_args.add_all(["--format", format])
+    if patch:
+        action_args.add("--fix")
+    action_args.add_all(srcs)
+
+    inputs = srcs + [config]
+    if patch:
+        run_patcher(
+            ctx,
+            ctx.executable,
+            inputs = inputs,
+            args = action_args,
+            files_to_diff = [src.path for src in srcs],
+            patch_out = patch,
+            patch_cfg_env = {"BAZEL_BINDIR": "."},
+            tools = [executable],
+            exit_code = exit_code,
+            mnemonic = _MNEMONIC,
+            progress_message = "Fixing %{label} with Oxlint",
+        )
+        return
+
+    outputs = [stdout]
+    if exit_code:
+        command = "{oxlint} $@ >{stdout} 2>&1; echo $? >{exit_code}"
+        outputs.append(exit_code)
+    else:
+        command = "{oxlint} $@ >{stdout} 2>&1"
+
+    ctx.actions.run_shell(
+        inputs = inputs,
+        outputs = outputs,
+        arguments = [action_args],
+        command = command.format(
+            oxlint = executable.path,
+            stdout = stdout.path,
+            exit_code = exit_code.path if exit_code else "",
+        ),
+        env = {"BAZEL_BINDIR": "."},
+        tools = [executable],
+        mnemonic = _MNEMONIC,
+        progress_message = "Linting %{label} with Oxlint",
+    )
+
+# buildifier: disable=function-docstring
+def _oxlint_aspect_impl(target, ctx):
+    if not should_visit(ctx.rule, ctx.attr._rule_kinds, ctx.attr._filegroup_tags):
+        return []
+
+    files_to_lint = filter_srcs(ctx.rule)
+    if ctx.attr._options[LintOptionsInfo].fix:
+        outputs, info = patch_and_output_files(_MNEMONIC, target, ctx)
+    else:
+        outputs, info = output_files(_MNEMONIC, target, ctx)
+
+    if len(files_to_lint) == 0:
+        noop_lint_action(ctx, outputs)
+        return [info]
+
+    # Always report the original violations. Fixes are produced by a separate action so
+    # `aspect lint` still exits non-zero when it offers an unapplied patch.
+    oxlint_action(
+        ctx,
+        ctx.executable._oxlint,
+        files_to_lint,
+        ctx.file._config_file,
+        outputs.human.out,
+        outputs.human.exit_code,
+        args = ctx.attr._args,
+    )
+
+    if ctx.attr._options[LintOptionsInfo].fix:
+        patch_exit_code = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "patch.exit_code"))
+        oxlint_action(
+            ctx,
+            ctx.executable._oxlint,
+            files_to_lint,
+            ctx.file._config_file,
+            None,
+            patch_exit_code,
+            args = ctx.attr._args,
+            patch = outputs.patch,
+        )
+
+    # Oxlint emits SARIF natively, so no rules_lint parser action is needed.
+    oxlint_action(
+        ctx,
+        ctx.executable._oxlint,
+        files_to_lint,
+        ctx.file._config_file,
+        outputs.machine.out,
+        outputs.machine.exit_code,
+        args = ctx.attr._args,
+        format = "sarif",
+    )
+
+    return [info]
+
+def lint_oxlint_aspect(
+        binary,
+        config,
+        rule_kinds = ["js_library", "ts_project", "ts_project_rule"],
+        filegroup_tags = ["lint-with-oxlint"],
+        args = []):
+    """Create an Oxlint aspect.
+
+    Args:
+        binary: an Oxlint executable
+        config: an Oxlint JSON or JSONC configuration file
+        rule_kinds: target kinds visited automatically
+        filegroup_tags: tags that opt filegroups into Oxlint
+        args: additional Oxlint command-line arguments
+    """
+    return aspect(
+        implementation = _oxlint_aspect_impl,
+        attrs = patcher_attrs | {
+            "_options": attr.label(
+                default = "//lint:options",
+                providers = [LintOptionsInfo],
+            ),
+            "_oxlint": attr.label(
+                default = binary,
+                allow_files = True,
+                executable = True,
+                cfg = "exec",
+            ),
+            "_config_file": attr.label(
+                default = config,
+                allow_single_file = True,
+            ),
+            "_rule_kinds": attr.string_list(
+                default = rule_kinds,
+            ),
+            "_filegroup_tags": attr.string_list(
+                default = filegroup_tags,
+            ),
+            "_args": attr.string_list(
+                default = args,
+            ),
+        },
+    )

--- a/lint/oxlint.bzl
+++ b/lint/oxlint.bzl
@@ -9,6 +9,10 @@ load("@npm//:oxlint/package_json.bzl", oxlint_bin = "bin")
 oxlint_bin.oxlint_binary(name = "oxlint")
 ```
 
+The npm distribution is required when your configuration loads
+[JavaScript plugins](https://oxc.rs/docs/guide/usage/linter/js-plugins), including
+custom plugins you write, because they require a JavaScript runtime.
+
 Then declare the linter aspect, typically in `tools/lint/linters.bzl`:
 
 ```starlark


### PR DESCRIPTION
Closes #445.

Adds a public `lint_oxlint_aspect` for JavaScript and TypeScript targets.

The implementation follows the existing linter architecture:

- runs an unchanged human report action so original violations retain their exit code
- runs a separate `--fix` patch action
- emits Oxlint's native SARIF for machine reports
- supports configurable rule kinds, filegroup opt-in tags, and extra CLI arguments
- documents and exercises npm-based setup in the Node.js example

No application-specific aggregate rule, path override, suppression baseline, custom formatter, tsgolint layout, or iterative patcher is included.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Added Oxlint support with autofix patches and native SARIF reports.

### Test plan

- `USE_BAZEL_VERSION=8.x bazel test //...` from the repository root
- focused Node.js tests for lint exit codes and SARIF output
- regression coverage proving a fixable-only violation keeps report exit code 1 while producing a patch
- Buildifier and Prettier checks

The pre-existing full `examples/nodejs` test suite still has an unrelated missing `//src:prettier` input; the focused Oxlint targets pass.