### PR TITLE
fix(stylelint): expose patch-mode exit code

### DIFF
--- a/lint/stylelint.bzl
+++ b/lint/stylelint.bzl
@@ -171,8 +171,9 @@ def _stylelint_aspect_impl(target, ctx):
         args = color_options + ctx.attr._args,
         target = target,
     )
+    patch_exit_code = None
     if ctx.attr._options[LintOptionsInfo].fix:
-        _exit_code = ctx.actions.declare_file(OUTFILE_FORMAT.format(
+        patch_exit_code = ctx.actions.declare_file(OUTFILE_FORMAT.format(
             label = target.label.name,
             mnemonic = _MNEMONIC,
             suffix = "patch.exit_code",
@@ -182,7 +183,7 @@ def _stylelint_aspect_impl(target, ctx):
             ctx.executable,
             files_to_lint,
             None,
-            _exit_code,
+            patch_exit_code,
             args = color_options + ctx.attr._args,
             patch = outputs.patch,
             target = target,
@@ -195,6 +196,13 @@ def _stylelint_aspect_impl(target, ctx):
 
     # We could probably use https://www.npmjs.com/package/stylelint-sarif-formatter instead.
     parse_to_sarif_action(ctx, _MNEMONIC, raw_machine_report, outputs.machine.out)
+
+    if patch_exit_code:
+        info = OutputGroupInfo(
+            rules_lint_human = info.rules_lint_human,
+            rules_lint_machine = info.rules_lint_machine,
+            rules_lint_patch = depset([patch_exit_code], transitive = [info.rules_lint_patch]),
+        )
 
     return [info]
 


### PR DESCRIPTION
## Summary

- expose Stylelint's fixer exit code alongside the generated patch
- preserve the separate non-fix human report, so fixed violations remain visible
- align patch-mode outputs with other linter exit-code artifacts

## Root cause

Stylelint intentionally uses separate report and fix actions because `stylelint --fix` omits violations it repaired. The fixer wrote `*.patch.exit_code`, but that artifact was not included in any output group, so downstream patch-mode consumers could not observe it.

## Test plan

- `bazel --output_base=/tmp/rules_lint_bazel_stylelint test //lint/...`
- Bazel 8.4.2: `bazel build --aspects=//tools/lint:linters.bzl%stylelint --output_groups=rules_lint_human,rules_lint_patch --@aspect_rules_lint//lint:fix //src:css`
- verified focused output contains both `css.AspectRulesLintStylelint.patch` and `css.AspectRulesLintStylelint.patch.exit_code`

The broad Node example test run passed four tests, including `stylelint_no_violations`, before a host resource kill in an unrelated protobuf descriptor action.