### PR TITLE
fix(patcher): Preserve the diff binary filename and extension

### DIFF
--- a/lint/private/patcher_binary.bzl
+++ b/lint/private/patcher_binary.bzl
@@ -1,9 +1,24 @@
-"""Workaround https://github.com/bazelbuild/bazel/issues/14009 to support Bazel prior to 8.3 & 9
+"Patcher binary that includes diff tool"
 
-TODO(3.0): when we drop support for Bazel 7 and 8.2, we can simplify this.
-"""
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
-load("@bazel_features//:features.bzl", "bazel_features")
+
+_DIFF_TOOLCHAIN = "@diff.bzl//diff/toolchain:execution_type"
+
+def _diff_bin_impl(ctx):
+    diff_bin = ctx.toolchains[_DIFF_TOOLCHAIN].diffutilsinfo.diff_bin
+    # Use basename to maintain .exe file extension on windows to allow for execution
+    diff_copy = ctx.actions.declare_file(diff_bin.basename)
+    ctx.actions.symlink(output = diff_copy, target_file = diff_bin, is_executable = True)
+    return DefaultInfo(
+        files = depset([diff_copy]),
+        runfiles = ctx.runfiles(files = [diff_copy]),
+    )
+
+_diff_bin = rule(
+    doc = "Copies the diff binary out of the resolved toolchain, preserving its filename.",
+    implementation = _diff_bin_impl,
+    toolchains = [_DIFF_TOOLCHAIN],
+)
 
 def patcher_binary(name):
     """Create a js_binary that can be used to run the patcher.mjs script.
@@ -11,25 +26,14 @@ def patcher_binary(name):
     Args:
         name: The name of the patcher binary.
     """
-    diff_bin_copy = "_{}.diff_bin".format(name)
-    env = {}
-    data = []
-    if bazel_features.toolchains.genrule_accepts_toolchain_types:
-        native.genrule(
-            name = diff_bin_copy,
-            outs = ["diff_bin"],
-            cmd = "cp $(DIFF_BIN) $(location :diff_bin)",
-            executable = True,
-            toolchains = ["@diff.bzl//diff/toolchain:execution_type"],
-        )
-        data.append(diff_bin_copy)
-        env["DIFF_BIN"] = "$(rlocationpath {})".format(diff_bin_copy)
+    diff_bin = "_{}.diff_bin".format(name)
+    _diff_bin(name = diff_bin)
 
     js_binary(
         name = name,
-        data = data,
+        data = [diff_bin],
         entry_point = "patcher.mjs",
-        env = env,
+        env = {"DIFF_BIN": "$(rlocationpath {})".format(diff_bin)},
         log_level = select({
             "@aspect_rules_lint//lint:debug.enabled": "debug",
             "//conditions:default": "error",


### PR DESCRIPTION
Windows will only execute files that have certain extensions such as `.exe` or `.bat`. To make diff command usable in patcher.mjs script it must have an `.exe` file extension.

This PR creates a new rule `_diff_bin` that creates a symlink of the diff binary from toolchain `@diff.bzl//diff/toolchain:execution_type` to bazel-out runfiles directory. I tried changing the current `genrule()` implementation but was not able to use `select()` on outs attribute or use the make variable expansion in outs variable to create a diff.exe in bazel output.

---

### Test plan


Linting should be working in the nodejs example with this patch applied on main branch. Must use bazel version >= 8.6 but not version 9. Bazel version 9 is not supported with the version of rules_swc in nodejs example.

```powershell
bazel --windows_enable_symlinks build --config=lint --enable_runfiles --@aspect_rules_lint//lint:fix --output_groups=rules_lint_patch //src:ts_typings
```
Before:  throws an error
```
ERROR: .../src/BUILD:53:11: output 'src/ts_typings.AspectRulesLintESLint.patch' was not created
ERROR: Linting //src:ts_typings with ESLint failed: not all outputs were created or valid
```
After: it contains the fix for `const a: string = "a"`
