### PR TITLE
fix(sarif): Use forward slash for artifactLocation.uri

### DIFF
--- a/tools/sarif/sarif.go
+++ b/tools/sarif/sarif.go
@@ -266,12 +266,21 @@ func rubocopJsonToSarif(label, mnemonic, report string) (sarifJsonString string,
 	return sarifJsonString, nil
 }
 
+// Matches an absolute path once separators have been normalised to slashes:
+// either a POSIX path ("/foo") or a Windows drive-letter path ("C:/foo").
+// filepath.IsAbs cannot be used here because it only recognises the host's
+// convention, which would make the result depend on the platform running the linter.
+var absolutePathRe = regexp.MustCompile(`^(?:/|[a-zA-Z]:/)`)
+
 // We expect relative paths when processing lint output and therefore need to convert any absolute paths.
 // Assumptions we make when determining the relative paths:
 //   - The linter is running on the host, so the path will have an 'execroot' segment
 //   - We only lint source files, so there is no 'bazel-bin/<platform>/bin' segment
 func determineRelativePath(path string, label string) string {
-	if !strings.HasPrefix(path, "/") || !strings.HasPrefix(label, "//") {
+	// A SARIF artifactLocation.uri is a URI, so it always uses forward slashes.
+	path = strings.ReplaceAll(path, `\`, "/")
+
+	if !absolutePathRe.MatchString(path) || !strings.HasPrefix(label, "//") {
 		return path
 	}
 

--- a/tools/sarif/sarif_test.go
+++ b/tools/sarif/sarif_test.go
@@ -135,6 +135,19 @@ func TestSarif(t *testing.T) {
 		g.Expect(sarifJson.Runs[0].Results[0].Locations[0].PhysicalLocation.Region.GetRdfRange().Start.Line).To(Equal(int32(2)))
 	})
 
+	t.Run("determineRelativePath: converts Windows path separators to URI separators", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		// These run on every platform, so they exercise the conversion on Linux CI too.
+		g.Expect(determineRelativePath(`src\file.ts`, "//src:ts")).To(Equal("src/file.ts"))
+		g.Expect(determineRelativePath(`foo\bar\baz`, "//foo/bar:baz")).To(Equal("foo/bar/baz"))
+		g.Expect(determineRelativePath(`src\file.ts`, "")).To(Equal("src/file.ts"))
+
+		// A POSIX path is already a valid URI path and is returned untouched.
+		g.Expect(determineRelativePath("src/file.ts", "//src:ts")).To(Equal("src/file.ts"))
+		g.Expect(determineRelativePath("foo/bar/baz", "//foo/bar:baz")).To(Equal("foo/bar/baz"))
+	})
+
 	t.Run("determineRelativePath: returns relative paths untouched", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 
@@ -181,6 +194,12 @@ func TestSarif(t *testing.T) {
 		g.Expect(determineRelativePath("/mnt/ephemeral/output/bazel-examples/__main__/sandbox/linux-sandbox/769/execroot/_main/speller/lookup/lookup-test.cc", "//:lookup")).To(Equal("speller/lookup/lookup-test.cc"))
 		g.Expect(determineRelativePath("/mnt/ephemeral/output/bazel-examples/__main__/sandbox/linux-sandbox/780/execroot/_main/speller/data_driven_tests/lookup-datatest.cc", "//:data_driven_tests")).To(Equal("speller/data_driven_tests/lookup-datatest.cc"))
 		g.Expect(determineRelativePath("/private/var/tmp/_bazel_jesse/93d7e699c5e2019d94351d19b00be5a3/sandbox/darwin-sandbox/249/execroot/_main/speller/announce/announce.cc", "//:announce")).To(Equal("speller/announce/announce.cc"))
+
+		// Windows path, with a drive letter instead of a leading slash
+		g.Expect(determineRelativePath("c:/private/var/tmp/_bazel_jesse/93d7e699c5e2019d94351d19b00be5a3/sandbox/darwin-sandbox/249/execroot/_main/speller/announce/announce.cc", "//speller/announce:announce")).To(Equal("speller/announce/announce.cc"))
+		g.Expect(determineRelativePath(`c:\private\var\tmp\_bazel_jesse\93d7e699c5e2019d94351d19b00be5a3\sandbox\darwin-sandbox\249\execroot\_main\speller\announce\announce.cc`, "//speller/announce:announce")).To(Equal("speller/announce/announce.cc"))
+		g.Expect(determineRelativePath("C:/users/jesse/_bazel/abc123/execroot/_main/speller/announce/announce.cc", "//:announce")).To(Equal("speller/announce/announce.cc"))
+		g.Expect(determineRelativePath(`C:\users\jesse\_bazel\abc123\execroot\_main\speller\announce\announce.cc`, "//:announce")).To(Equal("speller/announce/announce.cc"))
 	})
 
 	t.Run("determineRelativePath: returns absolute paths on regex or label error", func(t *testing.T) {


### PR DESCRIPTION
SARIF's artifactLocation.uri is a URI and must always use a slash (/) separators. On windows file paths use backslash (\\) and will generate invalid uris. 

This PR changes the windows file path backslash to forward slash. It uses the `ToSlash()` method to convert backslash to forward slash, which only works on windows and is noop on linux. The tests cases use `FromSlash()` to convert unix path to windows path.

Stylelint already converts the [reported file path to unix paths](https://github.com/aspect-build/rules_lint/blob/cd20671330c5f85c703df5d4499011df37d55c3a/lint/js/stylelint.compactFormatter.mjs#L130) but other linters do not.

---

### Test plan

To test this use eslint on windows to generate sarif report. It will use invalid URI in artifactLocation.

```
    bazel test //test:eslint_machine_output_test.uri
```

Before: `"uri": "src\\file.ts"`
After:  `"uri": "src/file.ts`