### PR TITLE
feat(cppcheck): build SARIF output

### DIFF
--- a/lint/cppcheck.bzl
+++ b/lint/cppcheck.bzl
@@ -37,7 +37,7 @@ def _filter_srcs(rule):
 def _prefixed(list, prefix):
     array = []
     for arg in list:
-        array.append("{} {}".format(prefix, arg))
+        array.append("{}{}".format(prefix, arg))
     return array
 
 def _get_compiler_args(compilation_context):

--- a/lint/cppcheck.bzl
+++ b/lint/cppcheck.bzl
@@ -3,7 +3,7 @@
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
-load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OPTIONAL_SARIF_PARSER_TOOLCHAIN", "OUTFILE_FORMAT", "noop_lint_action", "output_files", "parse_to_sarif_action")
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OPTIONAL_SARIF_PARSER_TOOLCHAIN", "OUTFILE_FORMAT", "noop_lint_action", "output_files", "parse_to_sarif_action", "should_visit")
 
 _MNEMONIC = "AspectRulesLintCppCheck"
 
@@ -101,6 +101,9 @@ def cppcheck_action(ctx, compilation_context, executable, srcs, stdout, exit_cod
     )
 
 def _cppcheck_aspect_impl(target, ctx):
+    if not should_visit(ctx.rule, ctx.attr._rule_kinds):
+        return []
+
     if not CcInfo in target:
         return []
 
@@ -138,7 +141,9 @@ def _cppcheck_aspect_impl(target, ctx):
     )
     return [info]
 
-def lint_cppcheck_aspect(binary, verbose = False, args = []):
+DEFAULT_RULE_KINDS = ["cc_binary", "cc_library"]
+
+def lint_cppcheck_aspect(binary, verbose = False, rule_kinds = DEFAULT_RULE_KINDS, args = []):
     """A factory function to create a linter aspect.
 
     Args:
@@ -166,6 +171,7 @@ def lint_cppcheck_aspect(binary, verbose = False, args = []):
             ```
 
         verbose: print debug messages including cppcheck command lines being invoked.
+        rule_kinds: which target kinds should be visited automatically
         args: additional options to pass to cppcheck.
     """
 
@@ -193,6 +199,9 @@ def lint_cppcheck_aspect(binary, verbose = False, args = []):
                 cfg = "exec",
             ),
             "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+            "_rule_kinds": attr.string_list(
+                default = rule_kinds,
+            ),
         },
         toolchains = [
             OPTIONAL_SARIF_PARSER_TOOLCHAIN,

--- a/lint/cppcheck.bzl
+++ b/lint/cppcheck.bzl
@@ -67,7 +67,9 @@ def cppcheck_action(ctx, compilation_context, executable, srcs, stdout, exit_cod
 
     outputs = [stdout]
     env = {}
-    env["CPPCHECK__STDOUT_STDERR_OUTPUT_FILE"] = stdout.path
+
+    if not do_xml:
+        env["CPPCHECK__STDOUT_STDERR_OUTPUT_FILE"] = stdout.path
 
     if exit_code:
         env["CPPCHECK__EXIT_CODE_OUTPUT_FILE"] = exit_code.path
@@ -84,7 +86,15 @@ def cppcheck_action(ctx, compilation_context, executable, srcs, stdout, exit_cod
     cppcheck_args.extend(_get_compiler_args(compilation_context))
 
     if do_xml:
+        env["CPPCHECK__OUTPUT_FILE"] = stdout.path
         cppcheck_args.append("--xml-version=3")
+    else:
+        # The SARIF parser is keyed to this exact layout, so it is not user-overridable.
+        # {severity} appears twice on purpose: errorformat consumes the leading copy to derive
+        # the SARIF level, the copy in the tag survives into the message text. With
+        # --report-type, cppcheck substitutes the coding-standard classification for {severity}
+        # and the guideline for {id}.
+        cppcheck_args.append("--template={file}:{line}:{column}: {severity}: {message} [{severity} {id}]")
 
     for f in srcs:
         cppcheck_args.append(f.short_path)
@@ -93,7 +103,7 @@ def cppcheck_action(ctx, compilation_context, executable, srcs, stdout, exit_cod
         inputs = _gather_inputs(compilation_context, srcs),
         outputs = outputs,
         tools = [executable._cppcheck_wrapper, executable._cppcheck, find_cpp_toolchain(ctx).all_files],
-        command = executable._cppcheck_wrapper.path + " $@",
+        command = executable._cppcheck_wrapper.path + ' "$@"',
         arguments = [executable._cppcheck.path] + cppcheck_args,
         env = env,
         mnemonic = _MNEMONIC,
@@ -101,10 +111,10 @@ def cppcheck_action(ctx, compilation_context, executable, srcs, stdout, exit_cod
     )
 
 def _cppcheck_aspect_impl(target, ctx):
-    if not should_visit(ctx.rule, ctx.attr._rule_kinds):
+    if not CcInfo in target:
         return []
 
-    if not CcInfo in target:
+    if not should_visit(ctx.rule, ctx.attr._rule_kinds):
         return []
 
     files_to_lint = _filter_srcs(ctx.rule)
@@ -123,14 +133,12 @@ def _cppcheck_aspect_impl(target, ctx):
 
     cppcheck_action(ctx, compilation_context, ctx.executable, files_to_lint, outputs.human.out, outputs.human.exit_code, args = ctx.attr._args)
 
-    # report:
-    raw_machine_report = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "raw_machine_report"))
-    cppcheck_action(ctx, compilation_context, ctx.executable, files_to_lint, raw_machine_report, outputs.machine.exit_code, args = ctx.attr._args)
-    parse_to_sarif_action(ctx, _MNEMONIC, raw_machine_report, outputs.machine.out)
+    parse_to_sarif_action(ctx, _MNEMONIC, outputs.human.out, outputs.machine.out)
 
+    # The XML report is a deliverable of its own; unlike the text output it is lossless, keeping
+    # the cppcheck id alongside the coding-standard guideline and classification.
     xml_output = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "xml"))
-    xml_exit_code = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name, mnemonic = _MNEMONIC, suffix = "xml_exit_code"))
-    cppcheck_action(ctx, compilation_context, ctx.executable, files_to_lint, xml_output, xml_exit_code, do_xml = True, args = ctx.attr._args)
+    cppcheck_action(ctx, compilation_context, ctx.executable, files_to_lint, xml_output, outputs.machine.exit_code, do_xml = True, args = ctx.attr._args)
 
     # Create new OutputGroupInfo with xml_output added to machine outputs
     info = OutputGroupInfo(

--- a/lint/cppcheck_wrapper.bash
+++ b/lint/cppcheck_wrapper.bash
@@ -5,6 +5,8 @@
 # Controls:
 # - CPPCHECK__VERBOSE: If set, be verbose
 # - CPPCHECK__STDOUT_STDERR_OUTPUT_FILE: If set, write stdout and stderr to this file
+# - CPPCHECK__OUTPUT_FILE: If set, pass --output-file with this path to cppcheck; created
+# up-front since cppcheck writes nothing when it fails before checking starts
 # - CPPCHECK__EXIT_CODE_OUTPUT_FILE: If set, write the highest exit code 
 # to this file and return success
 
@@ -27,23 +29,34 @@ if [[ -n $CPPCHECK__EXIT_CODE_OUTPUT_FILE ]]; then
     fi
 fi
 
+output_file_arg=""
+if [[ -n $CPPCHECK__OUTPUT_FILE ]]; then
+    : > "$CPPCHECK__OUTPUT_FILE"
+    output_file_arg="--output-file=$CPPCHECK__OUTPUT_FILE"
+fi
+
 if [[ -n $CPPCHECK__STDOUT_STDERR_OUTPUT_FILE ]]; then
     out_file=$CPPCHECK__STDOUT_STDERR_OUTPUT_FILE
 else
     out_file=$(mktemp)
 fi
-# include stderr in output file; it contains some of the diagnostics
-command="$cppcheck $@ $file > $out_file 2>&1"
-if [[ -n $CPPCHECK__VERBOSE ]]; then
-    echo "$@"
-    echo "cwd: " `pwd`
-    echo $command
+cmd=("$cppcheck")
+if [[ -n $output_file_arg ]]; then
+    cmd+=("$output_file_arg")
 fi
-eval $command
+cmd+=("$@")
+
+if [[ -n $CPPCHECK__VERBOSE ]]; then
+    echo "cwd: " `pwd`
+    printf '%q ' "${cmd[@]}"
+    echo "> $out_file 2>&1"
+fi
+# include stderr in output file; it contains some of the diagnostics
+"${cmd[@]}" > "$out_file" 2>&1
 exit_code=$?
 if [ $exit_code -eq 1 ] && [ -s $out_file ]; then
     echo "Error: " $exit_code
-    echo "Something went wrong when running cppcheck. Maybe license file missing?"
+    echo "cppcheck failed, see its output below."
 fi
 cat $out_file
 

--- a/tools/sarif/sarif.go
+++ b/tools/sarif/sarif.go
@@ -82,13 +82,26 @@ func ToSarifJsonString(label string, mnemonic string, report string) (sarifJsonS
 	case "AspectRulesLintVale":
 		fm = []string{`%f:%l:%c:%m`}
 	case "AspectRulesLintCppCheck":
+		// Keyed to the --template the cppcheck aspect pins. Order matters: errorformat takes
+		// the first matching pattern, so the ignore patterns have to precede what they would
+		// otherwise fall into.
 		fm = []string{
-			`%f:%l:%c: %trror: %m`,
-			`%f:%l:%c: %tarning: %m`,
-			`%f:%l:%c: %tyle: %m`,
-			`%f:%l:%c: %terformance: %m`,
-			`%f:%l:%c: %tortability: %m`,
-			`%f:%l:%c: %tnformation: %m`,
+			// run metadata carries no location, e.g. `nofile:0:0: information: Active checkers: ...`
+			`%-Gnofile:%.%#`,
+			`%E%f:%l:%c: error: %m`,
+			// --report-type prints the coding-standard classification in place of the severity
+			`%E%f:%l:%c: Mandatory: %m`,
+			`%E%f:%l:%c: Required: %m`,
+			`%W%f:%l:%c: warning: %m`,
+			`%W%f:%l:%c: Advisory: %m`,
+			`%I%f:%l:%c: style: %m`,
+			`%I%f:%l:%c: performance: %m`,
+			`%I%f:%l:%c: portability: %m`,
+			`%I%f:%l:%c: information: %m`,
+			`%I%f:%l:%c: debug: %m`,
+			// a classification this list does not enumerate still yields a finding. Its leading
+			// token stays in the message, since errorformat cannot both match and discard it.
+			`%I%f:%l:%c: %m`,
 			`%-G%.%#`,
 		}
 	case "AspectRulesLintClangTidy":

--- a/tools/sarif/sarif_test.go
+++ b/tools/sarif/sarif_test.go
@@ -83,20 +83,58 @@ func TestSarif(t *testing.T) {
 		g.Expect(sarifJson.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI).To(Equal("src/missing_doc_arg.py"))
 		g.Expect(sarifJson.Runs[0].Results[0].Locations[0].PhysicalLocation.Region.GetRdfRange().Start.Line).To(Equal(int32(4)))
 	})
-	t.Run("processes cppcheck output -> sarif correctly", func(t *testing.T) {
+	t.Run("processes cppcheck text output -> sarif correctly", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 
-		sarifJsonString, _ := ToSarifJsonString("//src:hello_cc", "AspectRulesLintCppCheck", cppcheck_output)
-		sarifJson, _ := toSarifJson(sarifJsonString)
+		sarifJsonString, err := ToSarifJsonString("//src:hello_cc", "AspectRulesLintCppCheck", cppcheck_output)
+		g.Expect(err).ToNot(HaveOccurred())
 
+		sarifJson, err := toSarifJson(sarifJsonString)
+		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(sarifJson.Runs)).To(Equal(1))
-		g.Expect(sarifJson.Runs[0].Tool.Driver.Name).To(Equal("CppCheck"))
-		g.Expect(len(sarifJson.Runs[0].Results)).To(Equal(2))
-		g.Expect(sarifJson.Runs[0].Results[0].Message.Text).To(Equal("Memory leak: ptr [memleak]"))
-		g.Expect(sarifJson.Runs[0].Results[1].Message.Text).To(Equal("Variable 'x' is assigned a value that is never used. [unreadVariable]"))
-		g.Expect(sarifJson.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI).To(Equal("src/hello.cc"))
-		g.Expect(sarifJson.Runs[0].Results[0].Locations[0].PhysicalLocation.Region.GetRdfRange().Start.Line).To(Equal(int32(10)))
-		g.Expect(sarifJson.Runs[0].Results[1].Locations[0].PhysicalLocation.Region.GetRdfRange().Start.Line).To(Equal(int32(15)))
+
+		run := sarifJson.Runs[0]
+		g.Expect(run.Tool.Driver.Name).To(Equal("CppCheck"))
+
+		// the progress lines and the location-less checkersReport entry contribute no results
+		g.Expect(len(run.Results)).To(Equal(6))
+		for _, result := range run.Results {
+			g.Expect(result.Message.Text).ToNot(ContainSubstring("checkersReport"))
+			g.Expect(result.Message.Text).ToNot(ContainSubstring("Checking "))
+		}
+
+		// --report-type makes cppcheck print the classification in place of the severity and the
+		// guideline in place of the id, so a Required violation outranks its style severity
+		guideline := run.Results[0]
+		g.Expect(guideline.Level).To(Equal("error"))
+		// the tag rides along in the message rather than being set as ruleId: reviewdog writes a
+		// ruleId as a bare `<id>`, which GitHub's markdown sanitizer strips when it parses as an
+		// HTML tag name
+		g.Expect(guideline.Message.Text).To(Equal("A public base class should declare a protected non-virtual destructor. [Required 15.0.1]"))
+		g.Expect(guideline.Locations[0].PhysicalLocation.ArtifactLocation.URI).To(Equal("src/base.h"))
+		g.Expect(guideline.Locations[0].PhysicalLocation.Region.GetRdfRange().Start.Line).To(Equal(int32(38)))
+		g.Expect(guideline.Locations[0].PhysicalLocation.Region.GetRdfRange().Start.Column).To(Equal(int32(19)))
+
+		// a finding cppcheck did not map to a guideline keeps its severity and id
+		uninit := run.Results[1]
+		g.Expect(uninit.Level).To(Equal("warning"))
+		g.Expect(uninit.Message.Text).To(HaveSuffix(" [warning uninitMemberVar]"))
+		// sandbox-absolute paths are made workspace-relative, as for the other text-scraped linters
+		g.Expect(uninit.Locations[0].PhysicalLocation.ArtifactLocation.URI).To(Equal("src/widget.h"))
+
+		g.Expect(run.Results[2].Level).To(Equal("error"))
+
+		// a guideline with no classification keeps the plain severity, which stays a note. The
+		// severity is consumed off the front of the line, so it shows up only in the tag.
+		g.Expect(run.Results[3].Level).To(Equal("note"))
+		g.Expect(run.Results[3].Message.Text).To(Equal("Consider using std::find_if algorithm instead of a raw loop. [performance 6.9.2]"))
+
+		g.Expect(run.Results[4].Level).To(Equal("warning"))
+		g.Expect(run.Results[4].Message.Text).To(HaveSuffix(" [Advisory 15.1.4]"))
+
+		// an unenumerated classification is still reported, at note level, keeping its leading token
+		g.Expect(run.Results[5].Level).To(Equal("note"))
+		g.Expect(run.Results[5].Message.Text).To(Equal("L1: Do not use a bare pointer here. [L1 certDemo-MEM50]"))
 	})
 
 	t.Run("processes ktlint output -> sarif correctly", func(t *testing.T) {

--- a/tools/sarif/testdata/lint_result/cppcheck_output.txt
+++ b/tools/sarif/testdata/lint_result/cppcheck_output.txt
@@ -1,4 +1,9 @@
-/some_absolute_path/sandbox/linux-sandbox/1/execroot/_main/src/hello.cc:10:5: error: Memory leak: ptr [memleak]
-    int *ptr = new int;
-    ^
-/some_absolute_path/sandbox/linux-sandbox/1/execroot/_main/src/hello.cc:15:3: warning: Variable 'x' is assigned a value that is never used. [unreadVariable]
+Checking src/hello.cc ...
+src/base.h:38:19: Required: A public base class should declare a protected non-virtual destructor. [Required 15.0.1]
+Checking src/goodbye.cc ...
+/some_absolute_path/sandbox/linux-sandbox/1/execroot/_main/src/widget.h:232:22: warning: Member variable 'Widget::handler' is not initialized in the constructor. [warning uninitMemberVar]
+src/goodbye.cc:15:5: error: Memory leak: ptr [error memleak]
+src/goodbye.cc:177:49: performance: Consider using std::find_if algorithm instead of a raw loop. [performance 6.9.2]
+src/gadget.h:41:7: Advisory: Member variable 'Gadget::count' is not initialized in the constructor. [Advisory 15.1.4]
+nofile:0:0: information: Active checkers: 158/849 (use --checkers-report=<filename> to see details) [information checkersReport]
+src/gadget.h:58:3: L1: Do not use a bare pointer here. [L1 certDemo-MEM50]


### PR DESCRIPTION
The cppcheck aspect ran `cppcheck` three times: human, a separate text run parsed into SARIF, and xml. The text run did not produce usable SARIF.

This change runs `cppcheck` twice (human and xml):
- The human run pins `--template={file}:{line}:{column}: {severity}: {message} [{severity} {id}]` so the layout the SARIF parser expects is guaranteed. Its output is directly used as input for the SARIF parser, which has been updated to this format.
- xml output stays and is unchanged

Additional fixes to make the export work:
- `_prefixed` emitted `-I dir` instead of `-Idir`, so include paths were passed as two `argv` entries
- The xml run writes via `--output-file` instead of a stdout redirect, and the file is created up-front because cppcheck writes nothing when it fails before checking starts.
- The aspect now honors `should_visit`, with a new `rule_kinds` parameter on `lint_cppcheck_aspect` defaulting to `["cc_binary", "cc_library"]`.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

The `cppcheck` aspect now emits valid SARIF and runs one fewer action per target. 
`lint_cppcheck_aspect` accepts `rule_kinds` (default `["cc_binary", "cc_library"]`) to limit which target kinds are visited.

### Test plan

- Test cases for the SARIF exporter
- Manual tests in `examples/cpp` and our internal code base