### PR TITLE
fix: update broken registry.bazel.build/docs URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ We recommend using a Git pre-commit hook to format changed files, and [Aspect Wo
 
 See [Formatting](./docs/formatting.md) for more ways to use the formatter.
 
-Also see [API Documentation](https://registry.bazel.build/modules/aspect_rules_lint/latest/docs#format-defs-bzl)
+Also see [API Documentation](https://registry.bazel.build/modules/aspect_rules_lint/latest/docs/format/defs.bzl)
 
 Demo:
 ![pre-commit format](./docs/format-demo.svg)

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ We recommend using a Git pre-commit hook to format changed files, and [Aspect Wo
 
 See [Formatting](./docs/formatting.md) for more ways to use the formatter.
 
-Also see [API Documentation](https://registry.bazel.build/docs/aspect_rules_lint#format-defs-bzl)
+Also see [API Documentation](https://registry.bazel.build/modules/aspect_rules_lint/latest/docs#format-defs-bzl)
 
 Demo:
 ![pre-commit format](./docs/format-demo.svg)
@@ -259,7 +259,7 @@ Suggested fixes from the linter tools are presented interactively.
 
 See [Linting](./docs/linting.md) for more ways to use the linter.
 
-Also see [API Documentation](https://registry.bazel.build/docs/aspect_rules_lint)
+Also see [API Documentation](https://registry.bazel.build/modules/aspect_rules_lint/latest/docs)
 
 Demo:
 ![bazel lint demo](./docs/lint-fix-demo.svg)

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -13,7 +13,7 @@ load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
 format_multirun(name = "format")
 ```
 
-For more details, see the `format_multirun` [API documentation](https://registry.bazel.build/modules/aspect_rules_lint/latest/docs#format-defs-bzl) and
+For more details, see the `format_multirun` [API documentation](https://registry.bazel.build/modules/aspect_rules_lint/latest/docs/format/defs.bzl) and
 the `example/tools/format/BUILD.bazel` file.
 
 Finally, make it easy for developers to run on their changed files:

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -13,7 +13,7 @@ load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
 format_multirun(name = "format")
 ```
 
-For more details, see the `format_multirun` [API documentation](https://registry.bazel.build/docs/aspect_rules_lint#format-defs-bzl) and
+For more details, see the `format_multirun` [API documentation](https://registry.bazel.build/modules/aspect_rules_lint/latest/docs#format-defs-bzl) and
 the `example/tools/format/BUILD.bazel` file.
 
 Finally, make it easy for developers to run on their changed files:

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -93,7 +93,7 @@ You may wish to use the `--keep_going` flag to continue linting even after the f
 
 ### 5. Failures during `bazel test`
 
-Call the [lint_test](https://registry.bazel.build/docs/aspect_rules_lint#lint-lint_test-bzl)
+Call the [lint_test](https://registry.bazel.build/modules/aspect_rules_lint/latest/docs#lint-lint_test-bzl)
 factory function in your `linters.bzl` file, then use the resulting rule in your BUILD files or in a wrapper macro.
 
 See the `example/test/BUILD.bazel` file in this repo for some examples.

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -93,7 +93,7 @@ You may wish to use the `--keep_going` flag to continue linting even after the f
 
 ### 5. Failures during `bazel test`
 
-Call the [lint_test](https://registry.bazel.build/modules/aspect_rules_lint/latest/docs#lint-lint_test-bzl)
+Call the [lint_test](https://registry.bazel.build/modules/aspect_rules_lint/latest/docs/lint/lint_test.bzl)
 factory function in your `linters.bzl` file, then use the resulting rule in your BUILD files or in a wrapper macro.
 
 See the `example/test/BUILD.bazel` file in this repo for some examples.


### PR DESCRIPTION
## Summary

The `registry.bazel.build/docs/<name>` URL pattern returns 404 and is no longer valid.

The correct URL format is now `registry.bazel.build/modules/<name>/latest/docs`.

This was identified across multiple Bazel rule repositories — see https://github.com/hermeticbuild/rules_rs/pull/235 for the original fix.

## Changes

- Replaced broken `/docs/aspect_rules_lint` URLs with `/modules/aspect_rules_lint/latest/docs`
- Replaced anchor-based fragment URLs with explicit file paths:
  - `#format-defs-bzl` → `/format/defs.bzl`
  - `#lint-lint_test-bzl` → `/lint/lint_test.bzl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)